### PR TITLE
add secrets config to compass app gradle

### DIFF
--- a/microapps/CompassApp/app/build.gradle.kts
+++ b/microapps/CompassApp/app/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
 }
 
+secrets {
+    defaultPropertiesFileName = "secrets.defaults.properties"
+}
+
 android {
     namespace = "com.arcgismaps.toolkit.compassapp"
     compileSdk = libs.versions.compileSdk.get().toInt()


### PR DESCRIPTION
jenkins build is failing due to lack of default secrets in the compass app.