### PR TITLE
revert TextField label placement

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -140,7 +140,6 @@ internal class PlaceholderTransformation(private val placeholder: String) : Visu
     }
 
     override fun filter(text: AnnotatedString): TransformedText {
-        // add a blank space if place holder is empty so that the label always stays above
-        return TransformedText(AnnotatedString(placeholder.ifEmpty { " " }), mapping)
+        return TransformedText(AnnotatedString(placeholder), mapping)
     }
 }


### PR DESCRIPTION
### Summary

- Reverts the hack and show the label in the field when there is no hint, similar to M3 [guidelines](https://m3.material.io/components/text-fields/overview)