### PR TITLE
Save multi-line text in forms

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -9,18 +9,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Clear
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -36,27 +35,24 @@ import com.arcgismaps.toolkit.featureforms.utils.ClearFocus
 @Composable
 internal fun FormTextField(
     state: FormTextFieldState,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val text by state.value
     val hasError by state.hasError
     val isFocused by state.isFocused
     val supportingText by state.supportingText
     val contentLength by state.contentLength
-    var shouldClearFocus by remember { mutableStateOf(false) }
+    var clearFocus by remember { mutableStateOf(false) }
 
     // if the keyboard is gone clear focus from the field as a side-effect
-    ClearFocus(shouldClearFocus) {
-        shouldClearFocus = false
-    }
+    ClearFocus(clearFocus) { clearFocus = false }
 
     Column(modifier = modifier
         .fillMaxSize()
         .onFocusChanged { state.onFocusChanged(it.hasFocus) }
         .pointerInput(Unit) {
-            // any tap on a blank space outside the text field will also dismiss the keyboard
-            // and clear focus
-            detectTapGestures { shouldClearFocus = true }
+            // any tap on a blank space will also dismiss the keyboard and clear focus
+            detectTapGestures { clearFocus = true }
         }
         .padding(start = 15.dp, end = 15.dp, top = 10.dp, bottom = 10.dp)
     ) {
@@ -70,12 +66,15 @@ internal fun FormTextField(
                 Text(text = state.label)
             },
             trailingIcon = {
-                if (text.isNotEmpty()) {
-                    IconButton(
-                        onClick = {
-                            state.onValueChanged("")
-                        }
-                    ) {
+                if (isFocused && !state.singleLine && text.isNotEmpty()) {
+                    IconButton(onClick = { clearFocus = true }) {
+                        Icon(
+                            imageVector = Icons.Rounded.CheckCircle,
+                            contentDescription = "Done"
+                        )
+                    }
+                } else if (text.isNotEmpty()) {
+                    IconButton(onClick = { state.onValueChanged("") }) {
                         Icon(
                             imageVector = Icons.Rounded.Clear,
                             contentDescription = "Clear Text"
@@ -99,7 +98,7 @@ internal fun FormTextField(
                 PlaceholderTransformation(state.placeholder)
             else VisualTransformation.None,
             keyboardActions = KeyboardActions(
-                onDone = { shouldClearFocus = true }
+                onDone = { clearFocus = true }
             ),
             keyboardOptions = KeyboardOptions.Default.copy(
                 imeAction = if (state.singleLine) ImeAction.Done else ImeAction.None


### PR DESCRIPTION
### Summary of changes

- Provides a check icon when a multi-line text comes into focus and the field is not empty. 
- This check icon replaces the default cross icon for the field which is used to clear the field.
- Once the focus is gone, the cross icon replaces the check icon