### PR TITLE
Authentication refactor oauthusersigninactivity

### DIFF
--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthUserSignInActivity.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthUserSignInActivity.kt
@@ -108,7 +108,8 @@ public class OAuthUserSignInActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        // if we enter onNewIntent, that means another
+        // if we enter onNewIntent, that means that we have redirected from the custom tab (or an
+        // intermediary activity) with the response uri.
         handleRedirectIntent(intent)
     }
 


### PR DESCRIPTION
Refactors `OAuthUserSignInActivity` to allow for users to "intercept" the redirect coming from the Custom Chrome Tab.

This PR also simplifies `OAuthUserSignInActivity` so that it doesn't have any state. This simplifies the use case above because it means that users don't have to add anything special to the intent they use to launch this activity, it should just work. Practically this means that we launch the CCT only if a specific intent extra is present, which is set in the contract. Otherwise we assume that the activity was launched for the purposes of redirecting to complete the sign in.