### PR TITLE
DateTimePicker landscape layout

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/ItemDataSource.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/ItemDataSource.kt
@@ -55,6 +55,7 @@ interface ItemApi {
  */
 fun getListOfMaps(): List<String> {
     return listOf(
+        "https://runtimecoretest.maps.arcgis.com/home/item.html?id=ec09090060664cbda8d814e017337837",
         "https://runtimecoretest.maps.arcgis.com/home/item.html?id=df0f27f83eee41b0afe4b6216f80b541",
         "https://runtimecoretest.maps.arcgis.com/home/item.html?id=454422bdf7e24fb0ba4ffe0a22f6bf37",
         "https://runtimecoretest.maps.arcgis.com/home/item.html?id=c606b1f345044d71881f99d00583f8f7",

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -18,19 +18,16 @@
 
 package com.arcgismaps.toolkit.featureforms.components.datetime.picker
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -57,11 +54,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.layout
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -70,7 +64,6 @@ import androidx.compose.ui.window.DialogProperties
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.datetime.toZonedDateTime
 import java.time.Instant
-import kotlin.math.roundToInt
 
 /**
  * Defines the style of [DateTimePicker].
@@ -204,13 +197,19 @@ private fun (ColumnScope).PickerContent(
             onIconTap = onPickerToggle
         )
     }
-    if (picker == DateTimePickerInput.Time) {
-        title(if (style == DateTimePickerStyle.Time) null else Icons.Rounded.CalendarMonth)
-        Spacer(modifier = Modifier.height(10.dp))
-        TimePicker(state = timePickerState, modifier = Modifier.weight(1f, fill = false))
-    } else {
-        LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
-            item {
+    // make the picker content scrollable if the screen height sizing is more restrictive
+    // like in landscape mode
+    LazyColumn(
+        modifier = Modifier.weight(1f, false),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        item {
+            if (picker == DateTimePickerInput.Time) {
+                title(if (style == DateTimePickerStyle.Time) null else Icons.Rounded.CalendarMonth)
+                Spacer(modifier = Modifier.height(10.dp))
+                TimePicker(state = timePickerState, modifier = Modifier.padding(10.dp))
+            } else {
                 DatePicker(
                     state = datePickerState,
                     dateValidator = { timeStamp ->
@@ -233,7 +232,7 @@ private fun PickerTitle(
 ) {
     Row(
         Modifier
-            .padding(bottom = 15.dp)
+            .padding(start = 25.dp, end = 15.dp, bottom = 10.dp)
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically
@@ -266,6 +265,7 @@ private fun PickerFooter(
     Row(
         Modifier
             .wrapContentHeight()
+            .padding(start = 10.dp, end = 10.dp)
             .fillMaxWidth()
     ) {
         if (state.activePickerInput.value == DateTimePickerInput.Date) {
@@ -301,10 +301,6 @@ private fun DateTimePickerDialog(
     properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
     content: @Composable ColumnScope.() -> Unit
 ) {
-    val configuration = LocalConfiguration.current
-    val containerWidth = (configuration.screenWidthDp * 0.8).roundToInt().dp
-    val containerHeight = (configuration.screenHeightDp * 0.8).roundToInt().dp
-    Log.e("TAG", "DateTimePickerDialog: $containerWidth x $containerHeight")
     AlertDialog(
         onDismissRequest = onDismissRequest,
         modifier = modifier.wrapContentHeight(),
@@ -312,14 +308,15 @@ private fun DateTimePickerDialog(
     ) {
         Surface(
             modifier = Modifier
-                .requiredWidth(DateTimePickerDialogTokens.containerWidth)
+                .padding(start = 25.dp, end = 25.dp)
+                .widthIn(DateTimePickerDialogTokens.containerWidth)
                 .heightIn(DateTimePickerDialogTokens.containerHeight),
             shape = shape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = tonalElevation,
         ) {
             Column(
-                modifier = modifier.padding(top = 20.dp, bottom = 20.dp),
+                modifier = modifier.padding(top = 25.dp, bottom = 10.dp),
                 verticalArrangement = Arrangement.SpaceBetween,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {


### PR DESCRIPTION
### Summary of changes

- After much experimenting with layouts and sizing, it seems like there is a bug within DatePicker and TimePicker in how they handle padding internally. Due to this padding not being managed well they're layouts are being squished together instead of scaling according to the constraints passed in. 
- A solution implemented in this PR is to make the content scrollable vertically, so that when the device is in landscape mode at least the pickers can be used by scrolling them into view.