### PR TITLE
FormTextField description focus fix

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Clear
-import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -131,8 +130,7 @@ internal fun FormTextField(
                         Spacer(modifier = Modifier.weight(1f))
                         Text(
                             text = contentLength,
-                            modifier = Modifier
-                                .semantics { contentDescription = "char count" },
+                            modifier = Modifier.semantics { contentDescription = "char count" },
                             color = textColor
                         )
                     }


### PR DESCRIPTION
### Summary of changes

- Added a clickable modifier to the supporting text which overrides any clicks. This ensures tapping on the supporting text does not bring focus to the TextField. Instead this tap is mapped to clearing the focus.
- Added a preview for the FormTextField.
- Changed supporting text colors to be derived from `MaterialTheme.colors`.