### PR TITLE
clean up the mapview when the composable is disposed.

### DIFF
--- a/toolkit/composable-map/src/main/java/com/arcgismaps/toolkit/composablemap/ComposableMap.kt
+++ b/toolkit/composable-map/src/main/java/com/arcgismaps/toolkit/composablemap/ComposableMap.kt
@@ -129,6 +129,12 @@ public fun ComposableMap(
             }
         }
     }
+    
+    DisposableEffect(Unit) {
+        onDispose {
+            mapView.onDestroy(lifecycleOwner)
+        }
+    }
 
     DisposableEffect(lifecycleOwner) {
         lifecycleOwner.lifecycle.addObserver(mapView)


### PR DESCRIPTION
The MapView's open GL resources are not cleaned up when the composable AndroidView leaves the composition. There is a significant memory leak as the AndroidView instantiates a new MapVIew each time `ComposableMap` enters the composition.

This fixes it and also fixes "object already owned" issues with the Map's Layers.

 It does not address GraphicsOverlay ownership issues observed in samples.

closes https://devtopia.esri.com/runtime/kotlin/issues/2848