### PR TITLE
provide way to publish artifacts without the build number.

### DIFF
--- a/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
+++ b/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
@@ -45,8 +45,13 @@ class ArtifactPublisher : Plugin<Project> {
         val artifactoryUsername: String by project
         val artifactoryPassword: String by project
         val versionNumber: String by project
+        val ignoreBuildNumber: String by project
         val buildNumber: String by project
-        val artifactVersion: String = "$versionNumber-$buildNumber"
+        val artifactVersion: String = if (ignoreBuildNumber == "true") {
+            versionNumber
+        } else {
+            "$versionNumber-$buildNumber"
+        }
         val artifactoryArtifactId: String = "$artifactoryArtifactBaseId-${project.name}"
         
         project.pluginManager.apply(MavenPublishPlugin::class.java)

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,6 +48,9 @@ artifactoryPassword=""
 # and are overridden by the jenkins command line in the daily build
 versionNumber=200.2.0
 buildNumber=0000-snapshot
+#set this flag to `true` to ignore the build number when publishing. This
+# will publish an artifact with a build number like "..:200.2.0" as opposed to "...:200.2.0-3963
+ignoreBuildNumber=true
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.2.0


### PR DESCRIPTION
Provide a flag which will publish artifacts without the build number
Turn on that flag so we can build a release candidate.