### PR TITLE
also provide a way for the bom to be published without a version number

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -31,7 +31,12 @@ val artifactoryUsername: String by project
 val artifactoryPassword: String by project
 val versionNumber: String by project
 val buildNumber: String by project
-val artifactVersion: String = "$versionNumber-$buildNumber"
+val ignoreBuildNumber: String by project
+val artifactVersion: String = if (ignoreBuildNumber == "true") {
+    versionNumber
+} else {
+    "$versionNumber-$buildNumber"
+}
 
 // ensure that the evaluation of the bom project happens after all other projects
 // so that plugins are applied to all projects, and can be used to identify


### PR DESCRIPTION
the previous PR to provide a way to publish a build without version number didn't include the BOM, which is build differently than everything else.