### PR TITLE
bump version and turn on build number logic

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ versionNumber=200.2.0
 buildNumber=0000-snapshot
 #set this flag to `true` to ignore the build number when publishing. This
 # will publish an artifact with a build number like "..:200.2.0" as opposed to "...:200.2.0-3963
-ignoreBuildNumber=true
+ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ artifactoryUsername=""
 artifactoryPassword=""
 # these numbers will define the artifact version on artifactory
 # and are overridden by the jenkins command line in the daily build
-versionNumber=200.2.0
+versionNumber=200.3.0
 buildNumber=0000-snapshot
 #set this flag to `true` to ignore the build number when publishing. This
 # will publish an artifact with a build number like "..:200.2.0" as opposed to "...:200.2.0-3963


### PR DESCRIPTION
200.2.0 -> 200.3.0

when jenkins builds commence for the v.next branch, this will need to be set to something other than true so that the build number is embedded in the version