### PR TITLE
remember saveable DateTimeFields

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -54,9 +54,8 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePicker
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerInput
-import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerState
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerStyle
-import com.arcgismaps.toolkit.featureforms.components.datetime.picker.dateTimePickerStateSaver
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.rememberDateTimePickerState
 import com.arcgismaps.toolkit.featureforms.utils.PlaceholderTransformation
 
 @Composable
@@ -67,7 +66,7 @@ internal fun DateTimeField(
     val isEditable by state.isEditable
     val isRequired by state.isRequired
     val epochMillis by state.value
-    val shouldShowTime = rememberSaveable {
+    val shouldShowTime = remember {
         state.shouldShowTime
     }
     val pickerStyle = if (shouldShowTime) {
@@ -198,17 +197,15 @@ internal fun DateTimeField(
     }
 
     if (openDialog) {
-        val pickerState = rememberSaveable(saver = dateTimePickerStateSaver(epochMillis)) {
-            DateTimePickerState(
-                pickerStyle,
-                state.minEpochMillis,
-                state.maxEpochMillis,
-                epochMillis,
-                state.label,
-                state.description,
-                DateTimePickerInput.Date
-            )
-        }
+        val pickerState = rememberDateTimePickerState(
+            pickerStyle,
+            state.minEpochMillis,
+            state.maxEpochMillis,
+            epochMillis,
+            state.label,
+            state.description,
+            DateTimePickerInput.Date
+        )
         // the picker dialog
         DateTimePicker(
             state = pickerState,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -64,12 +65,15 @@ internal fun DateTimeField(
     val isEditable by state.isEditable
     val isRequired by state.isRequired
     val epochMillis by state.value
-    val pickerStyle = if (state.shouldShowTime) {
+    val shouldShowTime = rememberSaveable {
+        state.shouldShowTime
+    }
+    val pickerStyle = if (shouldShowTime) {
         DateTimePickerStyle.DateTime
     } else {
         DateTimePickerStyle.Date
     }
-    var openDialog by remember { mutableStateOf(false) }
+    var openDialog by rememberSaveable { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
     // the field
     if (isEditable) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -53,8 +53,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePicker
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerInput
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerState
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerStyle
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.dateTimePickerStateSaver
 import com.arcgismaps.toolkit.featureforms.utils.PlaceholderTransformation
 
 @Composable
@@ -196,14 +198,15 @@ internal fun DateTimeField(
     }
 
     if (openDialog) {
-        val pickerState = remember {
+        val pickerState = rememberSaveable(saver = dateTimePickerStateSaver(epochMillis)) {
             DateTimePickerState(
                 pickerStyle,
                 state.minEpochMillis,
                 state.maxEpochMillis,
                 epochMillis,
                 state.label,
-                state.description
+                state.description,
+                DateTimePickerInput.Date
             )
         }
         // the picker dialog

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -48,8 +48,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -115,6 +117,10 @@ internal fun DateTimePicker(
         endInclusive = state.maxDateTime?.toZonedDateTime()?.year
             ?: DatePickerDefaults.YearRange.last
     )
+    
+    val pickerInput = rememberSaveable { state.activePickerInput }.value
+    println("recomposing with input ${pickerInput.name}")
+    
     // DateTime from the state's value
     val dateTime by state.dateTime
     // create and remember a DatePickerState that resets when dateTime changes
@@ -135,6 +141,7 @@ internal fun DateTimePicker(
             is24Hour = false,
         )
     }
+    
     // confirm button is only active when a date has been selected
     val confirmEnabled by remember(dateTime) {
         derivedStateOf { datePickerState.selectedDateMillis != null }
@@ -150,13 +157,14 @@ internal fun DateTimePicker(
             datePickerState = datePickerState,
             timePickerState = timePickerState,
             style = state.pickerStyle,
-            picker = state.activePickerInput.value,
+            picker = pickerInput
         ) {
             state.togglePickerInput()
         }
         PickerFooter(
             state = state,
             confirmEnabled = confirmEnabled,
+            pickerInput = pickerInput,
             onToday = {
                 state.today()
             },
@@ -257,6 +265,7 @@ private fun PickerTitle(
 private fun PickerFooter(
     state: DateTimePickerState,
     confirmEnabled: Boolean,
+    pickerInput: DateTimePickerInput,
     onToday: () -> Unit = {},
     onNow: () -> Unit = {},
     onCancelled: () -> Unit = {},
@@ -268,7 +277,7 @@ private fun PickerFooter(
             .padding(start = 10.dp, end = 10.dp)
             .fillMaxWidth()
     ) {
-        if (state.activePickerInput.value == DateTimePickerInput.Date) {
+        if (pickerInput == DateTimePickerInput.Date) {
             TextButton(
                 onClick = onToday,
                 // only enable Today button if today is within the range if provided

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -48,10 +48,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TimePickerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -118,9 +116,10 @@ internal fun DateTimePicker(
             ?: DatePickerDefaults.YearRange.last
     )
     
-    val pickerInput = rememberSaveable { state.activePickerInput }.value
-    println("recomposing with input ${pickerInput.name}")
-    
+    // State<> properties on state objects are remembered as part of remembering the
+    // state object itself at the call site. Otherwise, when the state object is recreated as part of rememberSaveable
+    // it will have a new instance of the State<> object, and the old is leaked but still observed for recomposition.
+    val pickerInput by state.activePickerInput
     // DateTime from the state's value
     val dateTime by state.dateTime
     // create and remember a DatePickerState that resets when dateTime changes
@@ -349,7 +348,8 @@ private fun DateTimePickerPreview() {
     val state = DateTimePickerState(
         style = DateTimePickerStyle.DateTime,
         label = "Next Inspection Date",
-        description = "Enter a date in the next six months"
+        description = "Enter a date in the next six months",
+        pickerInput  = DateTimePickerInput.Date
     )
     DateTimePicker(state = state, {}, {}, {})
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePickerState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePickerState.kt
@@ -191,8 +191,10 @@ private class DateTimePickerStateImpl(
 
     override fun togglePickerInput() {
         activePickerInput.value = if (activePickerInput.value == DateTimePickerInput.Date) {
+            println("toggling to time")
             DateTimePickerInput.Time
         } else {
+            println("toggling to date")
             DateTimePickerInput.Date
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePickerState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePickerState.kt
@@ -188,10 +188,8 @@ private class DateTimePickerStateImpl(
 
     override fun togglePickerInput() {
         activePickerInput.value = if (activePickerInput.value == DateTimePickerInput.Date) {
-            println("toggling to time")
             DateTimePickerInput.Time
         } else {
-            println("toggling to date")
             DateTimePickerInput.Date
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePickerState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePickerState.kt
@@ -18,10 +18,12 @@
 
 package com.arcgismaps.toolkit.featureforms.components.datetime.picker
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.toolkit.featureforms.components.datetime.toZonedDateTime
 import java.time.Instant
 import java.util.TimeZone
@@ -256,6 +258,40 @@ internal fun DateTimePickerState(
 )
 
 /**
+ * a Composable function to create and remember a DateTimePickerState instance
+ *
+ * @param style the date time picker style
+ * @param minDateTime the minimum pickable date time
+ * @param maxDateTime the maxiimum pickable date time
+ * @param initialValue the initial value in epoch milliseconds for the picker
+ * @param label the label from the element
+ * @param description the description from the element
+ * @param pickerInput the input type to display in the picker.
+ * @return a remembered DateTimePickerState
+ * @since 200.3.0
+ */
+@Composable
+internal fun rememberDateTimePickerState(
+    style: DateTimePickerStyle,
+    minDateTime: Long? = null,
+    maxDateTime: Long? = null,
+    initialValue: Long? = null,
+    label: String,
+    description: String = "",
+    pickerInput: DateTimePickerInput
+): DateTimePickerState = rememberSaveable(saver = dateTimePickerStateSaver(initialValue)) {
+    DateTimePickerState(
+        style,
+        minDateTime,
+        maxDateTime,
+        initialValue,
+        label,
+        description,
+        pickerInput
+    )
+}
+
+/**
  * a StateSaver for the DateTimePickerState.
  *
  * @param initialValue the value needed to initialize a DateTimePickerState
@@ -264,12 +300,27 @@ internal fun DateTimePickerState(
  */
 internal fun dateTimePickerStateSaver(initialValue: Long?): Saver<DateTimePickerState, Any> = listSaver(
     save = {
-        listOf(it.pickerStyle, it.minDateTime, it.maxDateTime, initialValue, it.label, it.description, it.activePickerInput.value)
+        listOf(it.pickerStyle,
+            it.minDateTime,
+            it.maxDateTime,
+            initialValue,
+            it.label,
+            it.description,
+            it.activePickerInput.value
+        )
     },
     restore = {
         // note: passes the date time picker state exactly as saved to
         // set the initial view of the dialog based on how it was saved,
         // not on initial conditions.
-        DateTimePickerStateImpl(it[0] as DateTimePickerStyle, it[1] as Long?, it[2] as Long?, it[3] as Long?, it[4] as String, it[5] as String, it[6] as DateTimePickerInput)
+        DateTimePickerStateImpl(
+            it[0] as DateTimePickerStyle,
+            it[1] as Long?,
+            it[2] as Long?,
+            it[3] as Long?,
+            it[4] as String,
+            it[5] as String,
+            it[6] as DateTimePickerInput
+        )
     }
 )


### PR DESCRIPTION
add savers as needed to save state across orientation changes for DateTimeFields. One thing I figured out was that when a state object holds a `State<>` property, that state object needs to be remembered with a saver so that we don't remember the `State<>` objects individually -- a new one gets created when the app goes through pause/resume.