### PR TITLE
Forms DateTimePicker height fix

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -318,7 +318,7 @@ private fun DateTimePickerDialog(
             modifier = Modifier
                 .padding(start = 25.dp, end = 25.dp)
                 .widthIn(DateTimePickerDialogTokens.containerWidth)
-                .heightIn(DateTimePickerDialogTokens.containerHeight),
+                .height(DateTimePickerDialogTokens.containerHeight),
             shape = shape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = tonalElevation,
@@ -338,7 +338,7 @@ private fun DateTimePickerDialog(
  * Properties for the [DateTimePickerDialog].
  */
 private object DateTimePickerDialogTokens {
-    val containerHeight = 568.0.dp
+    val containerHeight = 600.0.dp
     val containerWidth = 360.0.dp
 }
 


### PR DESCRIPTION
### Summary of changes

Updated the height of the `DateTimePickerDialog` to be of a specific height using a `Modifier.height` instead of `Modifier.heightIn`. Since the content is of a constant size setting a fixed size means both the `DatePicker` and the `TimePicker` are presented with the same dimensions.