### PR TITLE
fix selection on compose

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -132,9 +132,6 @@ internal fun DateTimePicker(
             DisplayMode.Picker
         )
     }
-    
-    //reset the selection if/when the dateTime changes
-    datePickerState.setSelection(dateTime.dateForPicker)
 
     // create and remember a TimePickerState that resets when dateTime changes
     val timePickerState = rememberSaveable(dateTime, saver = TimePickerState.Saver()) {


### PR DESCRIPTION
remove call to datePickerState.setSelection() that runs with each composition, it isn't needed and resets the value to the initial value of the element.