### PR TITLE
DateTimePicker "now" freeze fix

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -120,7 +121,7 @@ internal fun DateTimePicker(
     val dateTime by state.dateTime
     
     // create and remember a DatePickerState
-    val datePickerState = rememberSaveable(saver = DatePickerState.Saver()) {
+    val datePickerState = rememberSaveable(dateTime, saver = DatePickerState.Saver()) {
         DatePickerState(
             initialSelectedDateMillis = dateTime.dateForPicker,
             initialDisplayedMonthMillis = dateTime.dateForPicker
@@ -224,13 +225,15 @@ private fun (ColumnScope).PickerContent(
                 Spacer(modifier = Modifier.height(10.dp))
                 TimePicker(state = timePickerState, modifier = Modifier.padding(10.dp))
             } else {
-                DatePicker(
-                    state = datePickerState,
-                    dateValidator = { timeStamp ->
-                        state.dateValidator(timeStamp)
-                    },
-                    title = { title(if (style == DateTimePickerStyle.Date) null else Icons.Rounded.AccessTime) }
-                )
+                key(state.dateTime.value) {
+                    DatePicker(
+                        state = datePickerState,
+                        dateValidator = { timeStamp ->
+                            state.dateValidator(timeStamp)
+                        },
+                        title = { title(if (style == DateTimePickerStyle.Date) null else Icons.Rounded.AccessTime) }
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

The main fix to solve the "now" freezing and not snapping to the current month is to wrap the DatePicker in a `key(state.dateTime) { }`. 

### Findings

There seems to be unwanted behavior when `DatePicker` is recomposed with a new `DatePickerState` which freezes the current month. From my testing and debugging with the Layout Inspector I suspect it's due to a some internal state and remembered values inconsistency.

Wrapping the `DatePicker` with a key changes the scope of all internal remembered states and forces all recalculations when the key changes. This fixes the issue.