### PR TITLE
small today fix

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -165,10 +165,11 @@ internal fun DateTimePicker(
             onToday = {
                 val now = Instant.now().toEpochMilli().toDateMillis()
                 state.setDateTime(
-                    now.plus(now.defaultTimeZoneOffset),
+                    now.minus(now.defaultTimeZoneOffset),
                     state.dateTime.value.hour,
                     state.dateTime.value.minute
                 )
+                datePickerState.setSelection(state.dateTime.value.dateForPicker)
             },
             onNow = {
                 val now = Instant.now().toEpochMilli().toZonedDateTime()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -165,9 +165,9 @@ internal fun DateTimePicker(
             onToday = {
                 val now = Instant.now().toEpochMilli().toDateMillis()
                 state.setDateTime(
-                    now.minus(now.defaultTimeZoneOffset),
-                    state.dateTime.value.hour,
-                    state.dateTime.value.minute
+                    now.plus(now.defaultTimeZoneOffset).toDateMillis(),
+                    timePickerState.hour,
+                    timePickerState.minute
                 )
                 datePickerState.setSelection(state.dateTime.value.dateForPicker)
             },

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -44,8 +44,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import com.arcgismaps.toolkit.featureforms.components.datetime.picker.time.TimePicker
-import com.arcgismaps.toolkit.featureforms.components.datetime.picker.time.TimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -59,6 +57,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import com.arcgismaps.toolkit.featureforms.R
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.time.TimePicker
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.time.TimePickerState
 import com.arcgismaps.toolkit.featureforms.components.datetime.toDateMillis
 import com.arcgismaps.toolkit.featureforms.components.datetime.toZonedDateTime
 import java.time.Instant
@@ -169,7 +169,6 @@ internal fun DateTimePicker(
                     timePickerState.hour,
                     timePickerState.minute
                 )
-                datePickerState.setSelection(state.dateTime.value.dateForPicker)
             },
             onNow = {
                 val now = Instant.now().toEpochMilli().toZonedDateTime()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -164,7 +164,7 @@ internal fun DateTimePicker(
             } ?: false,
             pickerInput = pickerInput,
             onToday = {
-                val now = Instant.now().toEpochMilli().toDateMillis()
+                val now = Instant.now().toEpochMilli()
                 state.setDateTime(
                     now.plus(now.defaultTimeZoneOffset).toDateMillis(),
                     timePickerState.hour,


### PR DESCRIPTION
I didn't fully test the today function when fixing min/max validation...it was broken when the initial date value is not null (and also lots of other ways that don't manifest in our UI). I had only tested on a field that is initially empty.

This fix changes the "today" value to add the offset to arrive at a picker value, instead of subtracting it. It also gets the millis of the ensuing date after that addition so that the millis do not get counted when hours and minutes are derived from it, which happens when the initial date is not null.