### PR TITLE
required text

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -85,6 +85,11 @@ internal interface FormTextFieldState {
     val isEditable: Boolean
     
     /**
+     * State that indicates if the field is required.
+     */
+    val isRequired: Boolean
+    
+    /**
      * Callback to update the current value of the FormTextFieldState to the given [input].
      */
     fun onValueChanged(input: String)
@@ -133,8 +138,14 @@ private class FormTextFieldStateImpl(
     private val _hasError = mutableStateOf(false)
     override val hasError: State<Boolean> = _hasError
     
+    override val isRequired: Boolean = formElement.requiredExpressionName.isNotEmpty()
+    
     // set the label from the FieldFeatureFormElement
-    override val label = formElement.label
+    override val label = if (!isRequired) {
+        formElement.label
+    } else {
+        "${formElement.label} *"
+    }
     
     // set the description from the FieldFeatureFormElement
     override val description = formElement.description
@@ -210,10 +221,15 @@ private class FormTextFieldStateImpl(
      * [hasError] and [errorMessage] if there was an error in validation.
      */
     private fun validateLength() {
-        _hasError.value = (_value.value.length !in minLength..maxLength).also {
-            if (it) {
-                _errorMessage.value = helperText
-            }
+        _hasError.value = if (_value.value.length !in minLength..maxLength) {
+            _errorMessage.value = helperText
+            true
+            
+        } else if (isRequired && _value.value.isEmpty()) {
+            _errorMessage.value = context.getString(R.string.required)
+            true
+        } else {
+            false
         }
     }
     

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -218,14 +218,13 @@ private class FormTextFieldStateImpl(
     }
     
     /**
-     * Validates the current [value]'s length based on the [minLength] and [maxLength] and sets the
+     * Validates the current [value]'s length based on the [minLength], [maxLength], and [isRequired] and sets the
      * [hasError] and [errorMessage] if there was an error in validation.
      */
     private fun validateLength() {
         _hasError.value = if (_value.value.length !in minLength..maxLength) {
             _errorMessage.value = helperText
             true
-            
         } else if (isRequired && _value.value.isEmpty()) {
             _errorMessage.value = context.getString(R.string.required)
             true

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -141,6 +141,7 @@ private class FormTextFieldStateImpl(
     override val isRequired: Boolean = formElement.requiredExpressionName.isNotEmpty()
     
     // set the label from the FieldFeatureFormElement
+    // note when isRequired becomes a StateFlow, this logic will move into the compose function
     override val label = if (!isRequired) {
         formElement.label
     } else {


### PR DESCRIPTION
Support for required text in FormTextField.

This PR appends an asterisk to the label, and shows "Required" in red in the helper text after focus is gained and the character count of a required field reaches zero. THe text remains after focus is lost.

This deviates from the spec in one minor way: the required text appears while focused if the char count reaches 0, while it shouldn't be shown until after focus is lost when the char count is 0.