### PR TITLE
AGP, gradle upgrade to 8.1.1, 8.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,14 +18,9 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    @Suppress("DSL_SCOPE_VIOLATION") // fixed in gradle 8.1
     alias(libs.plugins.android.application) apply false
-    @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.android.library) apply false
-    @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.kotlin.android) apply false
-    @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.gradle.secrets) apply false
-    @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.0.0"
+androidGradlePlugin = "8.1.1"
 androidxActivity = "1.5.1"
 androidXBrowser = "1.5.0"
 androidxCompose = "1.3.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,6 +19,6 @@
 #Thu May 04 21:42:41 PDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
this upgrade matches the API's versions. These versions are necessary to include the SDK as a composite build. Also clears some false warnings in gradle files.

Android Studio giraffe is required to use AGP 8.1.1