### PR TITLE
Form field states remember saveable

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -34,6 +35,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.arcgismaps.toolkit.composablemap.ComposableMap
 import com.arcgismaps.toolkit.featureforms.EditingTransactionState
 import com.arcgismaps.toolkit.featureforms.FeatureForm
+import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureformsapp.R
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetExpansionHeight
 import kotlinx.coroutines.flow.map
@@ -66,11 +68,13 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
     // create a bottom sheet scaffold
     BottomSheetScaffold(
         sheetContent = {
-            // set bottom sheet content to the FeatureForm
-            FeatureForm(
-                featureFormState = mapViewModel,
-                modifier = Modifier.fillMaxSize()
-            )
+            key(mapViewModel as FeatureFormState) {
+                // set bottom sheet content to the FeatureForm
+                FeatureForm(
+                    featureFormState = mapViewModel,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
         },
         scaffoldState = bottomSheetScaffoldState,
         sheetPeekHeight = 40.dp,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -1,23 +1,29 @@
 package com.arcgismaps.toolkit.featureformsapp.screens.map
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberBottomSheetScaffoldState
+import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberStandardBottomSheetState
+import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -29,11 +35,7 @@ import com.arcgismaps.toolkit.composablemap.ComposableMap
 import com.arcgismaps.toolkit.featureforms.EditingTransactionState
 import com.arcgismaps.toolkit.featureforms.FeatureForm
 import com.arcgismaps.toolkit.featureformsapp.R
-import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.BottomSheetScaffold
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetExpansionHeight
-import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetValue
-import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberBottomSheetScaffoldState
-import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberStandardBottomSheetState
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -1,30 +1,23 @@
 package com.arcgismaps.toolkit.featureformsapp.screens.map
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberBottomSheetScaffoldState
-import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberStandardBottomSheetState
-import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -35,9 +28,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.arcgismaps.toolkit.composablemap.ComposableMap
 import com.arcgismaps.toolkit.featureforms.EditingTransactionState
 import com.arcgismaps.toolkit.featureforms.FeatureForm
-import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureformsapp.R
+import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.BottomSheetScaffold
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetExpansionHeight
+import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetValue
+import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberBottomSheetScaffoldState
+import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberStandardBottomSheetState
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -68,13 +64,11 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
     // create a bottom sheet scaffold
     BottomSheetScaffold(
         sheetContent = {
-            key(mapViewModel as FeatureFormState) {
-                // set bottom sheet content to the FeatureForm
-                FeatureForm(
-                    featureFormState = mapViewModel,
-                    modifier = Modifier.fillMaxSize()
-                )
-            }
+            // set bottom sheet content to the FeatureForm
+            FeatureForm(
+                featureFormState = mapViewModel,
+                modifier = Modifier.fillMaxSize()
+            )
         },
         scaffoldState = bottomSheetScaffoldState,
         sheetPeekHeight = 40.dp,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -39,6 +39,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.combo.rememberComboBoxFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.rememberFormTextFieldState
 import kotlinx.coroutines.CoroutineScope
+import java.util.Objects
 
 /**
  * A composable Form toolkit component that enables users to edit field values of features in a
@@ -141,7 +142,7 @@ private fun rememberFieldStates(
     form: FeatureForm,
     context: Context,
     scope: CoroutineScope
-): Map<String, BaseFieldState?> {
+): Map<Int, BaseFieldState?> {
     return form.elements.filterIsInstance<FieldFormElement>().associateBy(
         { fieldElement ->
             fieldElement.id
@@ -201,7 +202,7 @@ private fun NoDataPreview() {
 /**
  * Unique id for each form element.
  */
-internal val FieldFormElement.id: String
+internal val FieldFormElement.id: Int
     get() {
-        return fieldName + label + description + hint
+        return Objects.hash(fieldName, label, description, hint)
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -1,5 +1,7 @@
 package com.arcgismaps.toolkit.featureforms
 
+import android.content.Context
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -9,6 +11,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
@@ -18,16 +22,31 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
+import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
+import com.arcgismaps.mapping.featureforms.FormElement
+import com.arcgismaps.mapping.featureforms.TextAreaFormInput
+import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.FieldElement
+import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
+import com.arcgismaps.toolkit.featureforms.components.combo.rememberComboBoxFieldState
+import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
+import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
+import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
+import com.arcgismaps.toolkit.featureforms.components.text.rememberFormTextFieldState
+import kotlinx.coroutines.CoroutineScope
+import java.util.UUID
 
 /**
  * A composable Form toolkit component that enables users to edit field values of features in a
@@ -48,7 +67,7 @@ public fun FeatureForm(
         featureForm?.evaluateExpressions()
         initialEvaluation = true
     }
-    
+
     featureForm?.let {
         if (initialEvaluation) {
             FeatureFormContent(form = it, modifier = modifier)
@@ -67,9 +86,10 @@ internal fun InitializingExpressions(modifier: Modifier = Modifier) {
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.fillMaxSize()
     ) {
-        CircularProgressIndicator(modifier = Modifier
-            .width(80.dp)
-            .height(80.dp)
+        CircularProgressIndicator(
+            modifier = Modifier
+                .width(80.dp)
+                .height(80.dp)
         )
         Text(text = "Initializing")
     }
@@ -89,6 +109,10 @@ internal fun FeatureFormContent(
     form: FeatureForm,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val states = rememberFieldStates(form = form, context = context, scope = scope)
+    val lazyListState = rememberLazyListState()
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -102,16 +126,70 @@ internal fun FeatureFormContent(
         )
         Divider(modifier = Modifier.fillMaxWidth(), thickness = 2.dp)
         // form content
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
-            items(form.elements) { formElement ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            state = lazyListState
+        ) {
+            itemsIndexed(form.elements) { index, formElement ->
                 if (formElement is FieldFormElement) {
-                    FieldElement(
-                        field = formElement,
-                        form = form
-                    )
+                    val state = states.getOrNull(index)
+                    if (state != null) {
+                        FieldElement(
+                            field = formElement,
+                            form = form,
+                            state = state
+                        )
+                    }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun rememberFieldStates(
+    form: FeatureForm,
+    context: Context,
+    scope: CoroutineScope
+): List<BaseFieldState> {
+    return form.elements.mapNotNull {
+        if (it is FieldFormElement) {
+            when (it.input) {
+                is TextBoxFormInput, is TextAreaFormInput -> {
+                    val minLength = if (it.input is TextBoxFormInput) {
+                        (it.input as TextBoxFormInput).minLength.toInt()
+                    } else {
+                        (it.input as TextAreaFormInput).minLength.toInt()
+                    }
+                    val maxLength = if (it.input is TextBoxFormInput) {
+                        (it.input as TextBoxFormInput).maxLength.toInt()
+                    } else {
+                        (it.input as TextAreaFormInput).maxLength.toInt()
+                    }
+                    rememberFormTextFieldState(
+                        field = it,
+                        minLength = minLength,
+                        maxLength = maxLength,
+                        form = form,
+                        context = context,
+                        scope = scope
+                    )
+                }
+
+                is ComboBoxFormInput -> {
+                    rememberComboBoxFieldState(
+                        field = it,
+                        form = form,
+                        context = context,
+                        scope = scope
+                    )
+                }
+
+                else -> {
+                    null
+                }
+            }
+        } else null
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -125,13 +125,11 @@ internal fun FeatureFormContent(
             items(form.elements) { formElement ->
                 if (formElement is FieldFormElement) {
                     val state = states[formElement.id]
-                    if (state != null) {
-                        FieldElement(
-                            field = formElement,
-                            form = form,
-                            state = state
-                        )
-                    }
+                    FieldElement(
+                        field = formElement,
+                        form = form,
+                        state = state
+                    )
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -1,7 +1,6 @@
 package com.arcgismaps.toolkit.featureforms
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
@@ -32,21 +30,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
-import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.mapping.featureforms.FormElement
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.FieldElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.combo.rememberComboBoxFieldState
-import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
-import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
-import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.rememberFormTextFieldState
 import kotlinx.coroutines.CoroutineScope
-import java.util.UUID
 
 /**
  * A composable Form toolkit component that enables users to edit field values of features in a
@@ -60,7 +52,6 @@ public fun FeatureForm(
     featureFormState: FeatureFormState,
     modifier: Modifier = Modifier
 ) {
-    Log.e("TAG", "FeatureForm: recomp")
     val featureForm by featureFormState.featureForm.collectAsState()
     var initialEvaluation by remember(featureForm) { mutableStateOf(false) }
     LaunchedEffect(featureForm) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
@@ -18,37 +19,56 @@ import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeField
 import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
+import com.arcgismaps.toolkit.featureforms.utils.editValue
 
 @Composable
 internal fun FieldElement(field: FieldFormElement, form: FeatureForm) {
     val context = LocalContext.current
     val visible by field.isVisible.collectAsState()
     val scope = rememberCoroutineScope()
-    
+
     if (visible) {
         when (field.input) {
             is TextAreaFormInput -> {
-                FormTextField(
-                    state = FormTextFieldState(
+                val input = field.input as TextAreaFormInput
+                val state = rememberSaveable(
+                    form, saver =
+                    FormTextFieldState.Saver(field, form, context, scope)
+                ) {
+                    FormTextFieldState(
                         formElement = field,
-                        featureForm = form,
-                        context = context,
-                        scope = scope
+                        scope = scope,
+                        onEditValue = { form.editValue(field, it) },
+                        onEvaluateExpression = { form.evaluateExpressions() },
+                        singleLine = false,
+                        minLength = input.minLength.toInt(),
+                        maxLength = input.maxLength.toInt(),
+                        context = context
                     )
-                )
+                }
+                FormTextField(state = state)
             }
-        
+
             is TextBoxFormInput -> {
-                FormTextField(
-                    state = FormTextFieldState(
+                val input = field.input as TextBoxFormInput
+                val state = rememberSaveable(
+                    form, saver =
+                    FormTextFieldState.Saver(field, form, context, scope)
+                ) {
+                    FormTextFieldState(
                         formElement = field,
-                        featureForm = form,
-                        context = context,
-                        scope = scope
+                        scope = scope,
+                        onEditValue = { form.editValue(field, it) },
+                        onEvaluateExpression = { form.evaluateExpressions() },
+                        singleLine = false,
+                        minLength = input.minLength.toInt(),
+                        maxLength = input.maxLength.toInt(),
+                        context = context
                     )
-                )
+                }
+                FormTextField(state = state)
             }
-        
+
             is DateTimePickerFormInput -> {
                 DateTimeField(
                     state = DateTimeFieldState(
@@ -69,7 +89,7 @@ internal fun FieldElement(field: FieldFormElement, form: FeatureForm) {
                     )
                 )
             }
-        
+
             else -> { /* TO-DO: add support for other input types */
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -20,13 +20,15 @@ import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
 
 @Composable
-internal fun FieldElement(field: FieldFormElement, form: FeatureForm, state: BaseFieldState) {
+internal fun FieldElement(field: FieldFormElement, form: FeatureForm, state: BaseFieldState?) {
     val visible by field.isVisible.collectAsState()
     val scope = rememberCoroutineScope()
     if (visible) {
         when (field.input) {
             is TextBoxFormInput, is TextAreaFormInput -> {
-                FormTextField(state = state as FormTextFieldState)
+                state?.let {
+                    FormTextField(state = state as FormTextFieldState)
+                }
             }
 
             is DateTimePickerFormInput -> {
@@ -40,7 +42,9 @@ internal fun FieldElement(field: FieldFormElement, form: FeatureForm, state: Bas
             }
 
             is ComboBoxFormInput -> {
-                ComboBoxField(state = state as ComboBoxFieldState)
+                state?.let {
+                    ComboBoxField(state = state as ComboBoxFieldState)
+                }
             }
 
             else -> { /* TO-DO: add support for other input types */

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -19,6 +19,7 @@ import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeField
 import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
+import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 
 @Composable
@@ -29,41 +30,37 @@ internal fun FieldElement(field: FieldFormElement, form: FeatureForm) {
 
     if (visible) {
         when (field.input) {
-            is TextAreaFormInput -> {
-                val input = field.input as TextAreaFormInput
-                val state = rememberSaveable(
-                    form, saver =
-                    FormTextFieldState.Saver(field, form, context, scope)
-                ) {
-                    FormTextFieldState(
-                        formElement = field,
-                        scope = scope,
-                        onEditValue = { form.editValue(field, it) },
-                        onEvaluateExpression = { form.evaluateExpressions() },
-                        singleLine = false,
-                        minLength = input.minLength.toInt(),
-                        maxLength = input.maxLength.toInt(),
-                        context = context
-                    )
+            is TextBoxFormInput, is TextAreaFormInput -> {
+                val minLength = if (field.input is TextBoxFormInput) {
+                    (field.input as TextBoxFormInput).minLength.toInt()
+                } else {
+                    (field.input as TextAreaFormInput).minLength.toInt()
                 }
-                FormTextField(state = state)
-            }
-
-            is TextBoxFormInput -> {
-                val input = field.input as TextBoxFormInput
+                val maxLength = if (field.input is TextBoxFormInput) {
+                    (field.input as TextBoxFormInput).minLength.toInt()
+                } else {
+                    (field.input as TextAreaFormInput).minLength.toInt()
+                }
                 val state = rememberSaveable(
                     form, saver =
                     FormTextFieldState.Saver(field, form, context, scope)
                 ) {
                     FormTextFieldState(
-                        formElement = field,
+                        properties = TextFieldProperties(
+                            label = field.label,
+                            placeholder = field.hint,
+                            description = field.description,
+                            value = field.value,
+                            editable = field.isEditable,
+                            required = field.isRequired,
+                            singleLine = field.input is TextBoxFormInput,
+                            minLength = minLength,
+                            maxLength = maxLength,
+                        ),
                         scope = scope,
+                        context = context,
                         onEditValue = { form.editValue(field, it) },
                         onEvaluateExpression = { form.evaluateExpressions() },
-                        singleLine = false,
-                        minLength = input.minLength.toInt(),
-                        maxLength = input.maxLength.toInt(),
-                        context = context
                     )
                 }
                 FormTextField(state = state)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -1,11 +1,9 @@
 package com.arcgismaps.toolkit.featureforms.components
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -15,7 +13,6 @@ import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.combo.ComboBoxField
-import com.arcgismaps.toolkit.featureforms.components.combo.ComboBoxFieldProperties
 import com.arcgismaps.toolkit.featureforms.components.combo.ComboBoxFieldState
 import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeField
 import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
@@ -27,28 +24,26 @@ internal fun FieldElement(field: FieldFormElement, form: FeatureForm, state: Bas
     val visible by field.isVisible.collectAsState()
     val scope = rememberCoroutineScope()
     if (visible) {
-        Column {
-            when (field.input) {
-                is TextBoxFormInput, is TextAreaFormInput -> {
-                    FormTextField(state = state as FormTextFieldState)
-                }
+        when (field.input) {
+            is TextBoxFormInput, is TextAreaFormInput -> {
+                FormTextField(state = state as FormTextFieldState)
+            }
 
-                is DateTimePickerFormInput -> {
-                    DateTimeField(
-                        state = DateTimeFieldState(
-                            formElement = field,
-                            form = form,
-                            scope = scope
-                        )
+            is DateTimePickerFormInput -> {
+                DateTimeField(
+                    state = DateTimeFieldState(
+                        formElement = field,
+                        form = form,
+                        scope = scope
                     )
-                }
+                )
+            }
 
-                is ComboBoxFormInput -> {
-                    ComboBoxField(state = state as ComboBoxFieldState)
-                }
+            is ComboBoxFormInput -> {
+                ComboBoxField(state = state as ComboBoxFieldState)
+            }
 
-                else -> { /* TO-DO: add support for other input types */
-                }
+            else -> { /* TO-DO: add support for other input types */
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -1,12 +1,11 @@
 package com.arcgismaps.toolkit.featureforms.components
 
-import android.util.Log
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.platform.LocalContext
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -14,6 +13,7 @@ import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.GroupFormElement
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
+import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.combo.ComboBoxField
 import com.arcgismaps.toolkit.featureforms.components.combo.ComboBoxFieldProperties
 import com.arcgismaps.toolkit.featureforms.components.combo.ComboBoxFieldState
@@ -21,95 +21,34 @@ import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeField
 import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
-import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
-import com.arcgismaps.toolkit.featureforms.utils.editValue
-import kotlinx.coroutines.launch
 
 @Composable
-internal fun FieldElement(field: FieldFormElement, form: FeatureForm) {
-    val context = LocalContext.current
+internal fun FieldElement(field: FieldFormElement, form: FeatureForm, state: BaseFieldState) {
     val visible by field.isVisible.collectAsState()
     val scope = rememberCoroutineScope()
-
-    val onEditValue: (Any?) -> Unit = { value ->
-        form.editValue(field, value)
-        scope.launch { form.evaluateExpressions() }
-    }
-
     if (visible) {
-        when (field.input) {
-            is TextBoxFormInput, is TextAreaFormInput -> {
-                val minLength = if (field.input is TextBoxFormInput) {
-                    (field.input as TextBoxFormInput).minLength.toInt()
-                } else {
-                    (field.input as TextAreaFormInput).minLength.toInt()
+        Column {
+            when (field.input) {
+                is TextBoxFormInput, is TextAreaFormInput -> {
+                    FormTextField(state = state as FormTextFieldState)
                 }
-                val maxLength = if (field.input is TextBoxFormInput) {
-                    (field.input as TextBoxFormInput).maxLength.toInt()
-                } else {
-                    (field.input as TextAreaFormInput).maxLength.toInt()
-                }
-                val state = rememberSaveable(
-                    field,
-                    saver = FormTextFieldState.Saver(field, form, context, scope)
-                ) {
-                    FormTextFieldState(
-                        properties = TextFieldProperties(
-                            label = field.label,
-                            placeholder = field.hint,
-                            description = field.description,
-                            value = field.value,
-                            editable = field.isEditable,
-                            required = field.isRequired,
-                            singleLine = field.input is TextBoxFormInput,
-                            minLength = minLength,
-                            maxLength = maxLength,
-                        ),
-                        scope = scope,
-                        context = context,
-                        onEditValue = { onEditValue(it) }
+
+                is DateTimePickerFormInput -> {
+                    DateTimeField(
+                        state = DateTimeFieldState(
+                            formElement = field,
+                            form = form,
+                            scope = scope
+                        )
                     )
                 }
-                FormTextField(state = state)
-            }
 
-            is DateTimePickerFormInput -> {
-                DateTimeField(
-                    state = DateTimeFieldState(
-                        formElement = field,
-                        form = form,
-                        scope = scope
-                    )
-                )
-            }
-
-            is ComboBoxFormInput -> {
-                val input = field.input as ComboBoxFormInput
-                val state = rememberSaveable(
-                    field,
-                    saver = ComboBoxFieldState.Saver(field, form, context, scope)
-                ) {
-                    ComboBoxFieldState(
-                        properties = ComboBoxFieldProperties(
-                            label = field.label,
-                            placeholder = field.hint,
-                            description = field.description,
-                            value = field.value,
-                            editable = field.isEditable,
-                            required = field.isRequired,
-                            codedValues = input.codedValues,
-                            showNoValueOption = input.noValueOption,
-                            noValueLabel = input.noValueLabel
-                        ),
-                        context = context,
-                        scope = scope,
-                        onEditValue = { onEditValue(it) }
-                    )
+                is ComboBoxFormInput -> {
+                    ComboBoxField(state = state as ComboBoxFieldState)
                 }
-                ComboBoxField(state = state)
-            }
 
-            else -> { /* TO-DO: add support for other input types */
+                else -> { /* TO-DO: add support for other input types */
+                }
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -37,9 +37,9 @@ internal fun FieldElement(field: FieldFormElement, form: FeatureForm) {
                     (field.input as TextAreaFormInput).minLength.toInt()
                 }
                 val maxLength = if (field.input is TextBoxFormInput) {
-                    (field.input as TextBoxFormInput).minLength.toInt()
+                    (field.input as TextBoxFormInput).maxLength.toInt()
                 } else {
-                    (field.input as TextAreaFormInput).minLength.toInt()
+                    (field.input as TextAreaFormInput).maxLength.toInt()
                 }
                 val state = rememberSaveable(
                     form, saver =

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -25,36 +25,40 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+internal open class FieldProperties(
+    val label: String,
+    val placeholder: String,
+    val description: String,
+    val value: StateFlow<String>,
+    val required: StateFlow<Boolean>,
+    val editable: StateFlow<Boolean>
+)
+
 /**
  * Base state class for any Field within a feature form. It provides the default set of properties
  * that are common to all [FieldFormElement]'s.
  */
 internal open class BaseFieldState(
-    open val label : String,
-    open val placeholder : String,
-    val description: String,
-    initialValue: String,
-    valueFlow : StateFlow<String>,
-    val isEditable : StateFlow<Boolean>,
-    val isRequired: StateFlow<Boolean>,
+    properties: FieldProperties,
+    initialValue: String = properties.value.value,
     private val scope: CoroutineScope,
-    private val onEditValue : (Any?) -> Unit,
+    private val onEditValue: (Any?) -> Unit,
     private val onEvaluateExpression: suspend () -> Unit,
 ) {
     /**
      * Title for the field.
      */
-    // open val label: String = formElement.label
-
-    /**
-     * Description text for the field.
-     */
-    // val description: String = formElement.description
+    open val label: String = properties.label
 
     /**
      * Placeholder hint for the field.
      */
-    // open val placeholder: String = formElement.hint
+    open val placeholder: String = properties.placeholder
+
+    /**
+     * Description text for the field.
+     */
+    val description: String = properties.description
 
     // a state flow to handle user input changes
     private val _value = MutableStateFlow(initialValue)
@@ -64,8 +68,8 @@ internal open class BaseFieldState(
      */
     val value: StateFlow<String> = combine(
         _value,
-        valueFlow,
-        isEditable
+        properties.value,
+        properties.editable
     ) { userEdit, exprResult, editable ->
         // transform the user input value flow with the formElement value and required into a single
         // value flow based on if the field is editable
@@ -79,12 +83,12 @@ internal open class BaseFieldState(
     /**
      * Property that indicates if the field is editable.
      */
-    // val isEditable: StateFlow<Boolean> = isEditable
+    val isEditable: StateFlow<Boolean> = properties.editable
 
     /**
      * Property that indicates if the field is required.
      */
-    // val isRequired: StateFlow<Boolean> = isRequired
+    val isRequired: StateFlow<Boolean> = properties.required
 
     /**
      * Callback to update the current value of the FormTextFieldState to the given [input].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -16,9 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.components.base
 
-import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.toolkit.featureforms.utils.editValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -32,35 +30,42 @@ import kotlinx.coroutines.launch
  * that are common to all [FieldFormElement]'s.
  */
 internal open class BaseFieldState(
-    private val formElement: FieldFormElement,
-    private val featureForm: FeatureForm,
-    private val scope: CoroutineScope
+    open val label : String,
+    open val placeholder : String,
+    val description: String,
+    initialValue: String,
+    valueFlow : StateFlow<String>,
+    val isEditable : StateFlow<Boolean>,
+    val isRequired: StateFlow<Boolean>,
+    private val scope: CoroutineScope,
+    private val onEditValue : (Any?) -> Unit,
+    private val onEvaluateExpression: suspend () -> Unit,
 ) {
     /**
      * Title for the field.
      */
-    open val label: String = formElement.label
+    // open val label: String = formElement.label
 
     /**
      * Description text for the field.
      */
-    val description: String = formElement.description
+    // val description: String = formElement.description
 
     /**
      * Placeholder hint for the field.
      */
-    open val placeholder: String = formElement.hint
+    // open val placeholder: String = formElement.hint
 
     // a state flow to handle user input changes
-    private val _value = MutableStateFlow(formElement.value.value)
+    private val _value = MutableStateFlow(initialValue)
 
     /**
      * Current value state for the field.
      */
     val value: StateFlow<String> = combine(
         _value,
-        formElement.value,
-        formElement.isEditable
+        valueFlow,
+        isEditable
     ) { userEdit, exprResult, editable ->
         // transform the user input value flow with the formElement value and required into a single
         // value flow based on if the field is editable
@@ -69,41 +74,41 @@ internal open class BaseFieldState(
         } else {
             exprResult
         }
-    }.stateIn(scope, SharingStarted.Eagerly, _value.value)
+    }.stateIn(scope, SharingStarted.Eagerly, initialValue)
 
     /**
      * Property that indicates if the field is editable.
      */
-    val isEditable: StateFlow<Boolean> = formElement.isEditable
+    // val isEditable: StateFlow<Boolean> = isEditable
 
     /**
      * Property that indicates if the field is required.
      */
-    val isRequired: StateFlow<Boolean> = formElement.isRequired
+    // val isRequired: StateFlow<Boolean> = isRequired
 
     /**
      * Callback to update the current value of the FormTextFieldState to the given [input].
      */
     fun onValueChanged(input: String) {
-        editValue(input)
+        onEditValue(input)
         _value.value = input
-        scope.launch { evaluateExpressions() }
+        scope.launch { onEvaluateExpression() }
     }
 
     /**
      * Evaluates the underlying expressions for this field. The results can be observed through the
      * [value], [isRequired] and [isEditable] state flows.
      */
-    private suspend fun evaluateExpressions() {
-        featureForm.evaluateExpressions()
-    }
+//    private suspend fun evaluateExpressions() {
+//        featureForm.evaluateExpressions()
+//    }
 
     /**
      * Set the value in the feature's attribute map.
      * Committing the transaction will either discard this edit or persist it in the associated geodatabase,
      * and refresh the feature.
      */
-    private fun editValue(value: Any?) {
-        featureForm.editValue(formElement, value)
-    }
+//    private fun editValue(value: Any?) {
+//        featureForm.editValue(formElement, value)
+//    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 
 internal open class FieldProperties(
     val label: String,
@@ -37,13 +36,19 @@ internal open class FieldProperties(
 /**
  * Base state class for any Field within a feature form. It provides the default set of properties
  * that are common to all [FieldFormElement]'s.
+ *
+ * @param properties the [FieldProperties] associated with this state.
+ * @param initialValue optional initial value to set for this field. It is set to the value of
+ * [FieldProperties.value] by default.
+ * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
+ * @param onEditValue a callback to invoke when the user edits result in a change of value. This
+ * is called on [BaseFieldState.onValueChanged].
  */
 internal open class BaseFieldState(
     properties: FieldProperties,
     initialValue: String = properties.value.value,
-    private val scope: CoroutineScope,
+    scope: CoroutineScope,
     private val onEditValue: (Any?) -> Unit,
-    private val onEvaluateExpression: suspend () -> Unit,
 ) {
     /**
      * Title for the field.
@@ -96,23 +101,5 @@ internal open class BaseFieldState(
     fun onValueChanged(input: String) {
         onEditValue(input)
         _value.value = input
-        scope.launch { onEvaluateExpression() }
     }
-
-    /**
-     * Evaluates the underlying expressions for this field. The results can be observed through the
-     * [value], [isRequired] and [isEditable] state flows.
-     */
-//    private suspend fun evaluateExpressions() {
-//        featureForm.evaluateExpressions()
-//    }
-
-    /**
-     * Set the value in the feature's attribute map.
-     * Committing the transaction will either discard this edit or persist it in the associated geodatabase,
-     * and refresh the feature.
-     */
-//    private fun editValue(value: Any?) {
-//        featureForm.editValue(formElement, value)
-//    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
@@ -22,7 +22,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -114,7 +114,7 @@ internal fun BaseTextField(
             value = text,
             onValueChange = onValueChange,
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
                 .focusable(isEditable, interactionSource)
                 .semantics { contentDescription = "outlined text field" },
             readOnly = readOnly,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
@@ -163,7 +163,7 @@ internal fun BaseTextField(
                                 contentDescription = "Done"
                             )
                         }
-                    } else {
+                    } else if(text.isNotEmpty()) {
                         // show a clear icon instead if the multiline field is not empty
                         IconButton(
                             onClick = { onValueChange("") },

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
@@ -149,7 +149,7 @@ internal fun BaseTextField(
                     // show a trailing icon to indicate field type
                     Icon(imageVector = trailingIcon, contentDescription = "field icon")
                     // multiline editable field
-                } else if (!singleLine && isEditable && text.isNotEmpty()) {
+                } else if (!singleLine && isEditable) {
                     if (isFocused) {
                         // show a done button only when focused
                         IconButton(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
@@ -25,6 +25,7 @@ import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.FieldElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
+import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import kotlinx.coroutines.CoroutineScope
 
@@ -42,12 +43,14 @@ internal class ComboBoxFieldState(
     context: Context,
     scope: CoroutineScope
 ) : BaseFieldState(
-    label = formElement.label,
-    placeholder = formElement.hint,
-    description = formElement.description,
-    valueFlow = formElement.value,
-    isEditable = formElement.isEditable,
-    isRequired = formElement.isRequired,
+    properties = FieldProperties(
+        label = formElement.label,
+        placeholder = formElement.hint,
+        description = formElement.description,
+        value = formElement.value,
+        editable = formElement.isEditable,
+        required = formElement.isRequired,
+    ),
     scope = scope,
     initialValue = formElement.value.value,
     onEditValue = { featureForm.editValue(formElement, it) },

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
@@ -18,6 +18,7 @@ package com.arcgismaps.toolkit.featureforms.components.combo
 
 import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -60,6 +61,7 @@ internal class ComboBoxFieldProperties(
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
  * is called on [ComboBoxFieldState.onValueChanged].
  */
+@Stable
 internal class ComboBoxFieldState(
     properties: ComboBoxFieldProperties,
     initialValue: String = properties.value.value,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
@@ -17,8 +17,10 @@
 package com.arcgismaps.toolkit.featureforms.components.combo
 
 import android.content.Context
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.data.CodedValue
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -130,4 +132,35 @@ internal class ComboBoxFieldState(
             }
         )
     }
+}
+
+@Composable
+internal fun rememberComboBoxFieldState(
+    field: FieldFormElement,
+    form: FeatureForm,
+    context: Context,
+    scope: CoroutineScope
+): ComboBoxFieldState = rememberSaveable(
+    saver = ComboBoxFieldState.Saver(field, form, context, scope)
+) {
+    val input = field.input as ComboBoxFormInput
+    ComboBoxFieldState(
+        properties = ComboBoxFieldProperties(
+            label = field.label,
+            placeholder = field.hint,
+            description = field.description,
+            value = field.value,
+            editable = field.isEditable,
+            required = field.isRequired,
+            codedValues = input.codedValues,
+            showNoValueOption = input.noValueOption,
+            noValueLabel = input.noValueLabel
+        ),
+        context = context,
+        scope = scope,
+        onEditValue = {
+            form.editValue(field, it)
+            scope.launch { form.evaluateExpressions() }
+        }
+    )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
@@ -25,6 +25,7 @@ import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.FieldElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
+import com.arcgismaps.toolkit.featureforms.utils.editValue
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -40,7 +41,18 @@ internal class ComboBoxFieldState(
     featureForm: FeatureForm,
     context: Context,
     scope: CoroutineScope
-) : BaseFieldState(formElement, featureForm, scope) {
+) : BaseFieldState(
+    label = formElement.label,
+    placeholder = formElement.hint,
+    description = formElement.description,
+    valueFlow = formElement.value,
+    isEditable = formElement.isEditable,
+    isRequired = formElement.isRequired,
+    scope = scope,
+    initialValue = formElement.value.value,
+    onEditValue = { featureForm.editValue(formElement, it) },
+    onEvaluateExpression = { featureForm.evaluateExpressions() }
+) {
 
     /**
      * The list of coded values associated with this field.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
@@ -30,7 +30,6 @@ import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.FieldElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
-import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import kotlinx.coroutines.CoroutineScope

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxFieldState.kt
@@ -17,6 +17,8 @@
 package com.arcgismaps.toolkit.featureforms.components.combo
 
 import android.content.Context
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
 import com.arcgismaps.data.CodedValue
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -26,58 +28,106 @@ import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.FieldElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
+import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
+import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+internal class ComboBoxFieldProperties(
+    label: String,
+    placeholder: String,
+    description: String,
+    value: StateFlow<String>,
+    required: StateFlow<Boolean>,
+    editable: StateFlow<Boolean>,
+    val codedValues: List<CodedValue>,
+    val showNoValueOption: FormInputNoValueOption,
+    val noValueLabel: String
+) : FieldProperties(label, placeholder, description, value, required, editable)
 
 /**
  * A class to handle the state of a [ComboBoxField]. Essential properties are inherited from the
  * [BaseFieldState].
  *
- * @param formElement The [FieldFormElement] to create the state from.
- * @param featureForm The [FeatureForm] that the [formElement] is a part of.
+ * @param properties the [ComboBoxFieldProperties] associated with this state.
+ * @param initialValue optional initial value to set for this field. It is set to the value of
+ * [TextFieldProperties.value] by default.
+ * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param context a Context scoped to the lifetime of a call to the [FieldElement] composable function.
+ * @param onEditValue a callback to invoke when the user edits result in a change of value. This
+ * is called on [ComboBoxFieldState.onValueChanged].
  */
 internal class ComboBoxFieldState(
-    formElement: FieldFormElement,
-    featureForm: FeatureForm,
+    properties: ComboBoxFieldProperties,
+    initialValue: String = properties.value.value,
+    scope: CoroutineScope,
     context: Context,
-    scope: CoroutineScope
+    onEditValue: ((Any?) -> Unit)
 ) : BaseFieldState(
-    properties = FieldProperties(
-        label = formElement.label,
-        placeholder = formElement.hint,
-        description = formElement.description,
-        value = formElement.value,
-        editable = formElement.isEditable,
-        required = formElement.isRequired,
-    ),
+    properties = properties,
     scope = scope,
-    initialValue = formElement.value.value,
-    onEditValue = { featureForm.editValue(formElement, it) },
-    onEvaluateExpression = { featureForm.evaluateExpressions() }
+    initialValue = initialValue,
+    onEditValue = onEditValue
 ) {
-
     /**
      * The list of coded values associated with this field.
      */
-    val codedValues: List<CodedValue> = (formElement.input as ComboBoxFormInput).codedValues
+    val codedValues: List<CodedValue> = properties.codedValues
 
     /**
      * This property defines whether to display a special "no value" option if this field is
      * optional.
      */
-    val showNoValueOption: FormInputNoValueOption =
-        (formElement.input as ComboBoxFormInput).noValueOption
+    val showNoValueOption: FormInputNoValueOption = properties.showNoValueOption
 
     /**
      * The custom label to use if [showNoValueOption] is enabled.
      */
-    val noValueLabel: String =
-        (formElement.input as ComboBoxFormInput).noValueLabel
+    val noValueLabel: String = properties.noValueLabel
 
     override val placeholder = if (isRequired.value) {
         context.getString(R.string.enter_value)
     } else if (showNoValueOption == FormInputNoValueOption.Show) {
         noValueLabel.ifEmpty { context.getString(R.string.no_value) }
     } else ""
+
+    companion object {
+        fun Saver(
+            formElement: FieldFormElement,
+            form: FeatureForm,
+            context: Context,
+            scope: CoroutineScope
+        ): Saver<ComboBoxFieldState, Any> = listSaver(
+            save = {
+                listOf(
+                    it.value.value
+                )
+            },
+            restore = { list ->
+                val input = formElement.input as ComboBoxFormInput
+                ComboBoxFieldState(
+                    properties = ComboBoxFieldProperties(
+                        label = formElement.label,
+                        placeholder = formElement.hint,
+                        description = formElement.description,
+                        value = formElement.value,
+                        editable = formElement.isEditable,
+                        required = formElement.isRequired,
+                        codedValues = input.codedValues,
+                        showNoValueOption = input.noValueOption,
+                        noValueLabel = input.noValueLabel
+                    ),
+                    initialValue = list[0],
+                    context = context,
+                    scope = scope,
+                    onEditValue = { newValue ->
+                        form.editValue(formElement, newValue)
+                        scope.launch { form.evaluateExpressions() }
+                    }
+                )
+            }
+        )
+    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -22,8 +22,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -19,6 +19,7 @@ package com.arcgismaps.toolkit.featureforms.components.text
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -55,7 +56,7 @@ internal fun FormTextField(
         onValueChange = {
             state.onValueChanged(it)
         },
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxWidth(),
         readOnly = false,
         isEditable = isEditable,
         label = label,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -18,7 +18,6 @@ package com.arcgismaps.toolkit.featureforms.components.text
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -17,7 +17,6 @@
 package com.arcgismaps.toolkit.featureforms.components.text
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
@@ -27,6 +29,7 @@ import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.FieldElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
+import com.arcgismaps.toolkit.featureforms.utils.editValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -45,12 +48,28 @@ import kotlinx.coroutines.launch
  */
 internal class FormTextFieldState(
     formElement: FieldFormElement,
-    featureForm: FeatureForm,
-    private val context: Context,
     scope: CoroutineScope,
-) : BaseFieldState(formElement, featureForm, scope) {
+    initialValue: String = formElement.value.value,
+    onEditValue: (Any?) -> Unit,
+    onEvaluateExpression: suspend () -> Unit,
+    val singleLine: Boolean,
+    val minLength: Int,
+    val maxLength: Int,
+    private val context: Context
+) : BaseFieldState(
+    label = formElement.label,
+    placeholder = formElement.hint,
+    description = formElement.description,
+    initialValue = initialValue,
+    valueFlow = formElement.value,
+    isEditable = formElement.isEditable,
+    isRequired = formElement.isRequired,
+    scope = scope,
+    onEditValue = onEditValue,
+    onEvaluateExpression = onEvaluateExpression
+) {
     // indicates singleLine only if TextBoxFeatureFormInput
-    val singleLine = formElement.input is TextBoxFormInput
+    //val singleLine = formElement.input is TextBoxFormInput
 
     // supporting text will depend on multiple other states. If there is an error, it will display
     // error message. Otherwise description is displayed, unless it is empty in which case
@@ -71,35 +90,34 @@ internal class FormTextFieldState(
     private val _hasError = mutableStateOf(false)
     val hasError: State<Boolean> = _hasError
 
-    // fetch the minLength based on the featureFormElement.inputType
-    val minLength = when (formElement.input) {
-        is TextAreaFormInput -> (formElement.input as TextAreaFormInput).minLength
-        is TextBoxFormInput -> (formElement.input as TextBoxFormInput).minLength
-        else -> throw IllegalArgumentException()
-    }.toInt()
-
-    // fetch the maxLength based on the featureFormElement.inputType
-    val maxLength = when (formElement.input) {
-        is TextAreaFormInput -> (formElement.input as TextAreaFormInput).maxLength
-        is TextBoxFormInput -> (formElement.input as TextBoxFormInput).maxLength
-        else -> throw IllegalArgumentException()
-    }.toInt()
+//    // fetch the minLength based on the featureFormElement.inputType
+//    //val minLength = when (formElement.input) {
+//        is TextAreaFormInput -> (formElement.input as TextAreaFormInput).minLength
+//        is TextBoxFormInput -> (formElement.input as TextBoxFormInput).minLength
+//        else -> throw IllegalArgumentException()
+//    }.toInt()
+//
+//    // fetch the maxLength based on the featureFormElement.inputType
+//    /val maxLength = when (formElement.input) {
+//        is TextAreaFormInput -> (formElement.input as TextAreaFormInput).maxLength
+//        is TextBoxFormInput -> (formElement.input as TextBoxFormInput).maxLength
+//        else -> throw IllegalArgumentException()
+//    }.toInt()
 
     // build helper text
-    private val helperText =
-        if (minLength > 0 && maxLength > 0) {
-            if (minLength == maxLength) {
-                context.getString(R.string.enter_n_chars, minLength)
-            } else {
-                context.getString(R.string.enter_min_to_max_chars, minLength, maxLength)
-            }
-        } else if (maxLength > 0) {
-            context.getString(R.string.maximum_n_chars, maxLength)
+    private val helperText = if (minLength > 0 && maxLength > 0) {
+        if (minLength == maxLength) {
+            context.getString(R.string.enter_n_chars, minLength)
         } else {
-            context.getString(R.string.maximum_n_chars, 254)
-            // TODO: when consuming the core API throw here and remove the line above.
-            //throw IllegalStateException("invalid form data or attribute: text field must have a nonzero max length")
+            context.getString(R.string.enter_min_to_max_chars, minLength, maxLength)
         }
+    } else if (maxLength > 0) {
+        context.getString(R.string.maximum_n_chars, maxLength)
+    } else {
+        context.getString(R.string.maximum_n_chars, 254)
+        // TODO: when consuming the core API throw here and remove the line above.
+        //throw IllegalStateException("invalid form data or attribute: text field must have a nonzero max length")
+    }
 
     init {
         scope.launch {
@@ -136,5 +154,31 @@ internal class FormTextFieldState(
 
     fun onFocusChanged(focus: Boolean) {
         _isFocused.value = focus
+    }
+
+    companion object {
+        fun Saver(
+            formElement: FieldFormElement,
+            form: FeatureForm,
+            context: Context,
+            scope: CoroutineScope
+        ): Saver<FormTextFieldState, Any> = listSaver(
+            save = {
+                listOf(it.value.value, it.singleLine, it.minLength, it.maxLength)
+            },
+            restore = { list ->
+                FormTextFieldState(
+                    formElement = formElement,
+                    scope = scope,
+                    initialValue = list[0] as String,
+                    onEditValue = { newValue -> form.editValue(formElement, newValue) },
+                    onEvaluateExpression = { form.evaluateExpressions() },
+                    singleLine = list[1] as Boolean,
+                    minLength = list[2] as Int,
+                    maxLength = list[3] as Int,
+                    context = context
+                )
+            }
+        )
     }
 }


### PR DESCRIPTION
### Summary of changes

- Added custom Saver objects to implement `rememberSaveable()` for FormTextFieldState and `ComboBoxFieldState` by providing a `rememberFormTextFieldState`, `rememberComboBoxFieldState`.
- The field states must be saved outside the `LazyColumn` since the current `LazyColumn` implementation does not save any states within it that are not visible when a configuration change occurs.
- Additionally, wrapped the appropriate properties for a `BaseFieldState` into a `FieldProperties` class which essentially provides the properties of `FieldFormElement`. This is necessary because `BaseFieldState` needs be constructed without a dependency on `FormFieldElement` or `FeatureForm` for both `rememberSaveable()` and Compose preview purposes. It also helps to be passed as a single constructor parameter as opposed to having a long list of parameters. 
- Similarly, `FormTextFieldState` uses `TextFieldProperties` which inherits from `FieldProperties` while adding its own properties. `ComboBoxFieldState` uses `ComboBoxFieldProperties` in the same way.

#### Note
This PR does not address the `DateTimeFieldState` since it does not inherit from `BaseFieldState`.