### PR TITLE
remember to evaluate expressions

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
@@ -90,7 +90,7 @@ class FormTextFieldTests {
     val composeTestRule = createComposeRule()
     
     @Before
-    fun setContent()  {
+    fun setContent()  = runTest {
         composeTestRule.setContent {
             val scope = rememberCoroutineScope()
             FormTextField(
@@ -102,6 +102,7 @@ class FormTextFieldTests {
                 )
             )
         }
+        featureForm.evaluateExpressions()
     }
     
     @After


### PR DESCRIPTION
This doesn't fix everything up -- the semantics nodes don't seem to get focus like they used to. But it does solve the fact that tests don't even initialize and so more tests can be written.