### PR TITLE
Forms combo box required validation

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxField.kt
@@ -90,7 +90,12 @@ internal fun ComboBoxField(state: ComboBoxFieldState, modifier: Modifier = Modif
 
     BaseTextField(
         text = value,
-        onValueChange = { state.onValueChanged(it) },
+        onValueChange = {
+            state.onValueChanged(it)
+            // consider a "clear" operation to be a focused state even though the clear icon
+            // is not part of the field's focus target
+            if (it.isEmpty()) wasFocused = true
+        },
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/combo/ComboBoxField.kt
@@ -78,6 +78,15 @@ internal fun ComboBoxField(state: ComboBoxFieldState, modifier: Modifier = Modif
     val isRequired by state.isRequired.collectAsState()
     var showDialog by rememberSaveable { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
+    // to check if the field was ever focused by the user
+    var wasFocused by rememberSaveable { mutableStateOf(false) }
+    val label = remember(isRequired) {
+        if (isRequired) {
+            "${state.label} *"
+        } else {
+            state.label
+        }
+    }
 
     BaseTextField(
         text = value,
@@ -85,15 +94,23 @@ internal fun ComboBoxField(state: ComboBoxFieldState, modifier: Modifier = Modif
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
-        label = state.label,
+        label = label,
         placeholder = state.placeholder,
         singleLine = true,
         trailingIcon = Icons.Outlined.List,
         supportingText = {
-            Text(
-                text = state.description,
-                modifier = Modifier.semantics { contentDescription = "description" },
-            )
+            // if the field was focused and is required, validate the current value
+            if (wasFocused && isRequired && value.isEmpty()) {
+                Text(
+                    text = stringResource(id = R.string.required),
+                    color = MaterialTheme.colorScheme.error
+                )
+            } else {
+                Text(
+                    text = state.description,
+                    modifier = Modifier.semantics { contentDescription = "description" },
+                )
+            }
         },
         interactionSource = interactionSource
     )
@@ -118,6 +135,7 @@ internal fun ComboBoxField(state: ComboBoxFieldState, modifier: Modifier = Modif
     LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect {
             if (it is PressInteraction.Release) {
+                wasFocused = true
                 showDialog = true
             }
         }


### PR DESCRIPTION
### Summary of changes

- Added required expression validation for `ComboBoxField`.
- Uses a flag that checks if the field ever received focus to present a "Required" validation error if the field is empty.

For an additional test use the web map titled "**Validation Domain ComboBox FormElement**" from the gallery.