### PR TITLE
Forms : Refactor `ComboBoxFieldState` into `CodedValueFieldState`

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -37,7 +37,7 @@ import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.FieldElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
-import com.arcgismaps.toolkit.featureforms.components.combo.rememberComboBoxFieldState
+import com.arcgismaps.toolkit.featureforms.components.codedvalue.rememberCodedValueFieldState
 import com.arcgismaps.toolkit.featureforms.components.datetime.rememberDateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.rememberFormTextFieldState
 import kotlinx.coroutines.CoroutineScope
@@ -186,10 +186,9 @@ private fun rememberFieldStates(
                 }
 
                 is ComboBoxFormInput -> {
-                    rememberComboBoxFieldState(
+                    rememberCodedValueFieldState(
                         field = fieldElement,
                         form = form,
-                        context = context,
                         scope = scope
                     )
                 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -11,8 +11,8 @@ import com.arcgismaps.mapping.featureforms.GroupFormElement
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
-import com.arcgismaps.toolkit.featureforms.components.combo.ComboBoxField
-import com.arcgismaps.toolkit.featureforms.components.combo.ComboBoxFieldState
+import com.arcgismaps.toolkit.featureforms.components.codedvalue.ComboBoxField
+import com.arcgismaps.toolkit.featureforms.components.codedvalue.CodedValueFieldState
 import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeField
 import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
@@ -32,7 +32,7 @@ internal fun FieldElement(field: FieldFormElement, state: BaseFieldState) {
             }
 
             is ComboBoxFormInput -> {
-                ComboBoxField(state = state as ComboBoxFieldState)
+                ComboBoxField(state = state as CodedValueFieldState)
             }
 
             else -> { /* TO-DO: add support for other input types */

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -41,7 +41,7 @@ internal open class CodedValueFieldProperties(
     value: StateFlow<String>,
     required: StateFlow<Boolean>,
     editable: StateFlow<Boolean>,
-    val codedValues: List<String>,
+    val codedValues: List<CodedValue>,
     val showNoValueOption: FormInputNoValueOption,
     val noValueLabel: String
 ) : FieldProperties(label, placeholder, description, value, required, editable)
@@ -72,7 +72,7 @@ internal open class CodedValueFieldState(
     /**
      * The list of coded values associated with this field.
      */
-    val codedValues: List<String> = properties.codedValues
+    val codedValues: List<CodedValue> = properties.codedValues
 
     /**
      * This property defines whether to display a special "no value" option if this field is
@@ -111,7 +111,7 @@ internal open class CodedValueFieldState(
                         value = formElement.value,
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
-                        codedValues = input.codedValues.map { it.code.toString() },
+                        codedValues = input.codedValues,
                         showNoValueOption = input.noValueOption,
                         noValueLabel = input.noValueLabel
                     ),
@@ -144,7 +144,7 @@ internal fun rememberCodedValueFieldState(
             value = field.value,
             editable = field.isEditable,
             required = field.isRequired,
-            codedValues = input.codedValues.map { it.code.toString() },
+            codedValues = input.codedValues,
             showNoValueOption = input.noValueOption,
             noValueLabel = input.noValueLabel
         ),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -41,7 +41,7 @@ internal open class CodedValueFieldProperties(
     value: StateFlow<String>,
     required: StateFlow<Boolean>,
     editable: StateFlow<Boolean>,
-    val codedValues: List<CodedValue>,
+    val codedValues: List<String>,
     val showNoValueOption: FormInputNoValueOption,
     val noValueLabel: String
 ) : FieldProperties(label, placeholder, description, value, required, editable)
@@ -72,7 +72,7 @@ internal open class CodedValueFieldState(
     /**
      * The list of coded values associated with this field.
      */
-    val codedValues: List<CodedValue> = properties.codedValues
+    val codedValues: List<String> = properties.codedValues
 
     /**
      * This property defines whether to display a special "no value" option if this field is
@@ -111,7 +111,7 @@ internal open class CodedValueFieldState(
                         value = formElement.value,
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
-                        codedValues = input.codedValues,
+                        codedValues = input.codedValues.map { it.code.toString() },
                         showNoValueOption = input.noValueOption,
                         noValueLabel = input.noValueLabel
                     ),
@@ -144,7 +144,7 @@ internal fun rememberCodedValueFieldState(
             value = field.value,
             editable = field.isEditable,
             required = field.isRequired,
-            codedValues = input.codedValues,
+            codedValues = input.codedValues.map { it.code.toString() },
             showNoValueOption = input.noValueOption,
             noValueLabel = input.noValueLabel
         ),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -85,12 +85,6 @@ internal open class CodedValueFieldState(
      */
     val noValueLabel: String = properties.noValueLabel
 
-//    override val placeholder = if (isRequired.value) {
-//        context.getString(R.string.enter_value)
-//    } else if (showNoValueOption == FormInputNoValueOption.Show) {
-//        noValueLabel.ifEmpty { context.getString(R.string.no_value) }
-//    } else ""
-
     companion object {
 
         /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.arcgismaps.toolkit.featureforms.components.combo
+package com.arcgismaps.toolkit.featureforms.components.codedvalue
 
-import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.saveable.Saver
@@ -27,8 +26,6 @@ import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
-import com.arcgismaps.toolkit.featureforms.R
-import com.arcgismaps.toolkit.featureforms.components.FieldElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
@@ -37,7 +34,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-internal class ComboBoxFieldProperties(
+internal open class CodedValueFieldProperties(
     label: String,
     placeholder: String,
     description: String,
@@ -50,23 +47,21 @@ internal class ComboBoxFieldProperties(
 ) : FieldProperties(label, placeholder, description, value, required, editable)
 
 /**
- * A class to handle the state of a [ComboBoxField]. Essential properties are inherited from the
- * [BaseFieldState].
+ * A class to handle the state of a [ComboBoxField]. Essential properties are inherited
+ * from the [BaseFieldState].
  *
- * @param properties the [ComboBoxFieldProperties] associated with this state.
+ * @param properties the [CodedValueFieldProperties] associated with this state.
  * @param initialValue optional initial value to set for this field. It is set to the value of
  * [TextFieldProperties.value] by default.
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
- * @param context a Context scoped to the lifetime of a call to the [FieldElement] composable function.
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
- * is called on [ComboBoxFieldState.onValueChanged].
+ * is called on [CodedValueFieldState.onValueChanged].
  */
 @Stable
-internal class ComboBoxFieldState(
-    properties: ComboBoxFieldProperties,
+internal open class CodedValueFieldState(
+    properties: CodedValueFieldProperties,
     initialValue: String = properties.value.value,
     scope: CoroutineScope,
-    context: Context,
     onEditValue: ((Any?) -> Unit)
 ) : BaseFieldState(
     properties = properties,
@@ -90,19 +85,23 @@ internal class ComboBoxFieldState(
      */
     val noValueLabel: String = properties.noValueLabel
 
-    override val placeholder = if (isRequired.value) {
-        context.getString(R.string.enter_value)
-    } else if (showNoValueOption == FormInputNoValueOption.Show) {
-        noValueLabel.ifEmpty { context.getString(R.string.no_value) }
-    } else ""
+//    override val placeholder = if (isRequired.value) {
+//        context.getString(R.string.enter_value)
+//    } else if (showNoValueOption == FormInputNoValueOption.Show) {
+//        noValueLabel.ifEmpty { context.getString(R.string.no_value) }
+//    } else ""
 
     companion object {
+
+        /**
+         * The default saver for a [CodedValueFieldState] implemented for a [ComboBoxFormInput] type.
+         * Hence for [formElement] the [FieldFormElement.input] type must be a [ComboBoxFormInput].
+         */
         fun Saver(
             formElement: FieldFormElement,
             form: FeatureForm,
-            context: Context,
             scope: CoroutineScope
-        ): Saver<ComboBoxFieldState, Any> = listSaver(
+        ): Saver<CodedValueFieldState, Any> = listSaver(
             save = {
                 listOf(
                     it.value.value
@@ -110,8 +109,8 @@ internal class ComboBoxFieldState(
             },
             restore = { list ->
                 val input = formElement.input as ComboBoxFormInput
-                ComboBoxFieldState(
-                    properties = ComboBoxFieldProperties(
+                CodedValueFieldState(
+                    properties = CodedValueFieldProperties(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
@@ -123,7 +122,6 @@ internal class ComboBoxFieldState(
                         noValueLabel = input.noValueLabel
                     ),
                     initialValue = list[0],
-                    context = context,
                     scope = scope,
                     onEditValue = { newValue ->
                         form.editValue(formElement, newValue)
@@ -136,17 +134,16 @@ internal class ComboBoxFieldState(
 }
 
 @Composable
-internal fun rememberComboBoxFieldState(
+internal fun rememberCodedValueFieldState(
     field: FieldFormElement,
     form: FeatureForm,
-    context: Context,
     scope: CoroutineScope
-): ComboBoxFieldState = rememberSaveable(
-    saver = ComboBoxFieldState.Saver(field, form, context, scope)
+): CodedValueFieldState = rememberSaveable(
+    saver = CodedValueFieldState.Saver(field, form, scope)
 ) {
     val input = field.input as ComboBoxFormInput
-    ComboBoxFieldState(
-        properties = ComboBoxFieldProperties(
+    CodedValueFieldState(
+        properties = CodedValueFieldProperties(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
@@ -157,7 +154,6 @@ internal fun rememberComboBoxFieldState(
             showNoValueOption = input.noValueOption,
             noValueLabel = input.noValueLabel
         ),
-        context = context,
         scope = scope,
         onEditValue = {
             form.editValue(field, it)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -70,6 +71,9 @@ import androidx.compose.ui.window.DialogProperties
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
+import com.arcgismaps.toolkit.featureforms.utils.editValue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Modifier) {
@@ -128,14 +132,14 @@ internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Mod
     if (showDialog) {
         ComboBoxDialog(
             initialValue = value,
-            values = state.codedValues,
+            values = state.codedValues.associateBy({ it.code }, { it.name }),
             label = state.label,
             description = state.description,
             isRequired = isRequired,
             noValueOption = state.showNoValueOption,
             noValueLabel = state.noValueLabel.ifEmpty { stringResource(R.string.no_value) },
-            onValueChange = {
-                state.onValueChanged(it)
+            onValueChange = { code ->
+                state.onValueChanged(code?.toString() ?: "")
             }
         ) {
             showDialog = false
@@ -155,26 +159,26 @@ internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Mod
 @Composable
 internal fun ComboBoxDialog(
     initialValue: String,
-    values: List<String>,
+    values: Map<Any?, String>,
     label: String,
     description: String,
     isRequired: Boolean,
     noValueOption: FormInputNoValueOption,
     noValueLabel: String,
-    onValueChange: (String) -> Unit,
+    onValueChange: (Any?) -> Unit,
     onDismissRequest: () -> Unit
 ) {
     var searchText by rememberSaveable { mutableStateOf("") }
     val codedValues = if (!isRequired) {
         if (noValueOption == FormInputNoValueOption.Show) {
-            listOf(noValueLabel) + values
+            mapOf("" to noValueLabel) + values
         } else values
     } else values
 
     val filteredList by remember {
         derivedStateOf {
             codedValues.filter {
-                it.contains(searchText, ignoreCase = true)
+                it.value.contains(searchText, ignoreCase = true)
             }
         }
     }
@@ -245,12 +249,14 @@ internal fun ComboBoxDialog(
                         .fillMaxWidth()
                 )
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(filteredList) {
+                    items(filteredList.count()) {
+                        val code = filteredList.keys.elementAt(it)
+                        val name = filteredList.getValue(code)
                         ListItem(
                             headlineContent = {
                                 Text(
-                                    text = it,
-                                    style = if (it == noValueLabel) LocalTextStyle.current.copy(
+                                    text = name,
+                                    style = if (name == noValueLabel) LocalTextStyle.current.copy(
                                         fontStyle = FontStyle.Italic,
                                         fontWeight = FontWeight.Light
                                     )
@@ -261,10 +267,12 @@ internal fun ComboBoxDialog(
                                 .fillMaxWidth()
                                 .clickable {
                                     // if the no value label was selected, set the value to be empty
-                                    onValueChange(if (it == noValueLabel) "" else it)
+                                    onValueChange(code)
                                 },
                             trailingContent = {
-                                if (it == initialValue || (it == noValueLabel && initialValue.isEmpty())) {
+                                if ((code?.toString()
+                                        ?: "") == initialValue || (name == noValueLabel && initialValue.isEmpty())
+                                ) {
                                     Icon(
                                         imageVector = Icons.Outlined.Check,
                                         contentDescription = null
@@ -280,12 +288,41 @@ internal fun ComboBoxDialog(
     }
 }
 
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun ComboBoxPreview() {
+    val scope = rememberCoroutineScope()
+    val state = CodedValueFieldState(
+        properties = CodedValueFieldProperties(
+            label = "Types",
+            placeholder = "",
+            description = "Select the tree species",
+            value = MutableStateFlow(""),
+            editable = MutableStateFlow(true),
+            required = MutableStateFlow(false),
+            codedValues = listOf(),
+            showNoValueOption = FormInputNoValueOption.Show,
+            noValueLabel = "No value"
+        ),
+        scope = scope,
+        onEditValue = {}
+    )
+    ComboBoxField(state = state)
+}
+
 @Preview
 @Composable
 private fun ComboBoxDialogPreview() {
     ComboBoxDialog(
-        initialValue = "Birch",
-        values = listOf("Birch", "Maple", "Oak", "Spruce", "Hickory", "Hemlock"),
+        initialValue = "x",
+        values = mapOf(
+            "Birch" to "Birch",
+            "Maple" to "Maple",
+            "Oak" to "Oak",
+            "Spruce" to "Spruce",
+            "Hickory" to "Hickory",
+            "Hemlock" to "Hemlock"
+        ),
         label = "Types",
         description = "Select the tree species",
         isRequired = false,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -128,7 +128,7 @@ internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Mod
     if (showDialog) {
         ComboBoxDialog(
             initialValue = value,
-            values = state.codedValues.map { it.code.toString() },
+            values = state.codedValues,
             label = state.label,
             description = state.description,
             isRequired = isRequired,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.arcgismaps.toolkit.featureforms.components.combo
+package com.arcgismaps.toolkit.featureforms.components.codedvalue
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -72,7 +72,7 @@ import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
 
 @Composable
-internal fun ComboBoxField(state: ComboBoxFieldState, modifier: Modifier = Modifier) {
+internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Modifier) {
     val value by state.value.collectAsState()
     val isEditable by state.isEditable.collectAsState()
     val isRequired by state.isRequired.collectAsState()
@@ -87,6 +87,11 @@ internal fun ComboBoxField(state: ComboBoxFieldState, modifier: Modifier = Modif
             state.label
         }
     }
+    val placeholder = if (isRequired) {
+        stringResource(R.string.enter_value)
+    } else if (state.showNoValueOption == FormInputNoValueOption.Show) {
+        state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
+    } else ""
 
     BaseTextField(
         text = value,
@@ -100,7 +105,7 @@ internal fun ComboBoxField(state: ComboBoxFieldState, modifier: Modifier = Modif
         readOnly = true,
         isEditable = isEditable,
         label = label,
-        placeholder = state.placeholder,
+        placeholder = placeholder,
         singleLine = true,
         trailingIcon = Icons.Outlined.List,
         supportingText = {


### PR DESCRIPTION
### Summary of changes

- Renamed `ComboBoxFieldState` to `CodedValueFieldState`.
- `CodedValueFieldState` class is now `open`.
- Renamed `ComboBoxFieldProperties` to `CodedValueFieldProperties`.
- `CodedValueFieldProperties` is now `open`.
- Renamed `combo` package to `codedvalue`.
- Moved placeholder calculation from `CodedValueFieldState` and into the `ComboBoxField`. This removes the `Context` dependency for the state object and a possible bug when the `isRequired` flow changes.
- Changed `List<CodedValue>` to a `List<String>` in `CodedValueFieldProperties`, since this mapping happens at the picker level anyway.
- Updated the `ComboBoxDialog` to use a `Map<Any?,String>` which represents `<CodedValue.code, CodedValue.name>` and to display the `name` instead of the `code`. `ComboBoxDialog.onValueChange` is called with the `code`.
- Added compose preview for a `ComboBox`.