### PR TITLE
Forms : Updated `ComboboxField` to display `CodedValue.name`

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -85,6 +85,15 @@ internal open class CodedValueFieldState(
      */
     val noValueLabel: String = properties.noValueLabel
 
+    /**
+     * Returns the name of the [code] if it is present in [codedValues] else returns null.
+     */
+    fun getCodedValueNameOrNull(code: Any?): String? {
+        return codedValues.find {
+            it.code.toString() == code.toString()
+        }?.name
+    }
+
     companion object {
 
         /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.components.codedvalue
 
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -97,8 +98,10 @@ internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Mod
         state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
     } else ""
 
+    Log.e("TAG", "ComboBoxField: ${state.getCodedValueNameOrNull(value)}", )
+
     BaseTextField(
-        text = value,
+        text = state.getCodedValueNameOrNull(value) ?: value,
         onValueChange = {
             state.onValueChanged(it)
             // consider a "clear" operation to be a focused state even though the clear icon

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.components.codedvalue
 
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -28,7 +27,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -72,9 +70,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
-import com.arcgismaps.toolkit.featureforms.utils.editValue
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 
 @Composable
 internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Modifier) {
@@ -97,8 +93,6 @@ internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Mod
     } else if (state.showNoValueOption == FormInputNoValueOption.Show) {
         state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
     } else ""
-
-    Log.e("TAG", "ComboBoxField: ${state.getCodedValueNameOrNull(value)}", )
 
     BaseTextField(
         text = state.getCodedValueNameOrNull(value) ?: value,


### PR DESCRIPTION
### Summary of changes

- Updated `ComboboxField` to display `CodedValue.name` instead of `CodedValue.code`.
- If the `value` as a code does not exist in the list of codedValues, then the `code` is displayed as is.