### PR TITLE
Sor10874/disappearing edits

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -18,10 +18,12 @@ package com.arcgismaps.toolkit.featureforms.components.base
 
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flattenMerge
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 
 internal open class FieldProperties(
@@ -71,19 +73,10 @@ internal open class BaseFieldState(
     /**
      * Current value state for the field.
      */
-    val value: StateFlow<String> = combine(
-        _value,
-        properties.value,
-        properties.editable
-    ) { userEdit, exprResult, editable ->
-        // transform the user input value flow with the formElement value and required into a single
-        // value flow based on if the field is editable
-        if (editable) {
-            userEdit
-        } else {
-            exprResult
-        }
-    }.stateIn(scope, SharingStarted.Eagerly, initialValue)
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val value: StateFlow<String> = flowOf(_value, properties.value)
+        .flattenMerge()
+        .stateIn(scope, SharingStarted.Eagerly, initialValue)
 
     /**
      * Property that indicates if the field is editable.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flattenMerge
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
@@ -74,7 +75,7 @@ internal open class BaseFieldState(
      * Current value state for the field.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    val value: StateFlow<String> = flowOf(_value, properties.value)
+    val value: StateFlow<String> = flowOf(_value, properties.value.drop(1))
         .flattenMerge()
         .stateIn(scope, SharingStarted.Eagerly, initialValue)
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -24,6 +24,7 @@ import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.toolkit.featureforms.utils.editValue
+import com.arcgismaps.toolkit.featureforms.utils.fieldType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -80,6 +81,7 @@ internal class RadioButtonFieldState(
                         value = formElement.value,
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
+                        fieldType = form.fieldType(formElement),
                         codedValues = input.codedValues,
                         showNoValueOption = input.noValueOption,
                         noValueLabel = input.noValueLabel
@@ -113,6 +115,7 @@ internal fun rememberRadioButtonFieldState(
             value = field.value,
             editable = field.isEditable,
             required = field.isRequired,
+            fieldType = form.fieldType(field),
             codedValues = input.codedValues,
             showNoValueOption = input.noValueOption,
             noValueLabel = input.noValueLabel

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -370,9 +370,7 @@ internal class FormTextFieldState(
         } else {
             val error = validateNumber(value)
             if (error != NoError) {
-                if (error != NoError) {
-                    ret += error
-                }
+                ret += error
             }
         }
         


### PR DESCRIPTION
For BaseFieldState `value` Flow, this fixes an issue where user edits to the field disappear when the `isEditable` flow emits `false`. The use of `Flow.combine` to combine `isEditable`, `properties.value`, and `_value` will toggle the displayed value between the `properties.value` and `_value` when `isEditable` emits. So user edits disappear, and reappear as `isEditable` goes from true to false to true. 

The solution is to use the latest value of either `properties.value` and `_value`, since values changing from editing and values changing from expression evaluation are mutually exclusive.