### PR TITLE
Forms : Fix orientation changes for Dialogs

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -1,7 +1,6 @@
 package com.arcgismaps.toolkit.featureforms
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -171,7 +170,6 @@ private fun FeatureFormBody(
                             field = formElement,
                             state = state,
                             onDialogRequest = {
-                                Log.e("TAG", "FeatureFormBody: tapped")
                                 onFieldDialogRequest?.invoke(state, formElement.id)
                             }
                         )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -49,7 +49,7 @@ import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldStat
 import com.arcgismaps.toolkit.featureforms.components.datetime.rememberDateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.rememberFormTextFieldState
 import com.arcgismaps.toolkit.featureforms.utils.DialogType
-import com.arcgismaps.toolkit.featureforms.utils.makeDialog
+import com.arcgismaps.toolkit.featureforms.utils.FeatureFormDialog
 import kotlinx.coroutines.CoroutineScope
 import java.util.Objects
 
@@ -127,7 +127,7 @@ internal fun FeatureFormContent(
             dialogType = DialogType.ComboBoxDialog(id)
         }
     }
-    val dialog = makeDialog(
+    FeatureFormDialog(
         dialogType = dialogType,
         state = dialogType.getStateKey()?.let { stateKey ->
             states[stateKey]
@@ -136,7 +136,6 @@ internal fun FeatureFormContent(
             dialogType = DialogType.NoDialog
         }
     )
-    dialog?.invoke()
 }
 
 @Composable

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -1,6 +1,7 @@
 package com.arcgismaps.toolkit.featureforms
 
 import android.content.Context
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -21,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,11 +41,15 @@ import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.FieldElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
+import com.arcgismaps.toolkit.featureforms.components.codedvalue.CodedValueFieldState
 import com.arcgismaps.toolkit.featureforms.components.codedvalue.rememberCodedValueFieldState
 import com.arcgismaps.toolkit.featureforms.components.codedvalue.rememberRadioButtonFieldState
 import com.arcgismaps.toolkit.featureforms.components.codedvalue.rememberSwitchFieldState
+import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.components.datetime.rememberDateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.rememberFormTextFieldState
+import com.arcgismaps.toolkit.featureforms.utils.DialogType
+import com.arcgismaps.toolkit.featureforms.utils.makeDialog
 import kotlinx.coroutines.CoroutineScope
 import java.util.Objects
 
@@ -111,6 +117,35 @@ internal fun FeatureFormContent(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val states = rememberFieldStates(form = form, context = context, scope = scope)
+    var dialogType: DialogType by rememberSaveable {
+        mutableStateOf(DialogType.NoDialog)
+    }
+    FeatureFormBody(form = form, states = states, modifier = modifier) { state, id ->
+        if (state is DateTimeFieldState) {
+            dialogType = DialogType.DatePickerDialog(id)
+        } else if (state is CodedValueFieldState) {
+            dialogType = DialogType.ComboBoxDialog(id)
+        }
+    }
+    val dialog = makeDialog(
+        dialogType = dialogType,
+        state = dialogType.getStateKey()?.let { stateKey ->
+            states[stateKey]
+        },
+        onDismissRequest = {
+            dialogType = DialogType.NoDialog
+        }
+    )
+    dialog?.invoke()
+}
+
+@Composable
+private fun FeatureFormBody(
+    form: FeatureForm,
+    states: Map<Int, BaseFieldState?>,
+    modifier: Modifier = Modifier,
+    onDialogRequest: ((BaseFieldState, Int) -> Unit)? = null
+) {
     val lazyListState = rememberLazyListState()
     Column(
         modifier = modifier.fillMaxSize(),
@@ -135,7 +170,11 @@ internal fun FeatureFormContent(
                     if (state != null) {
                         FieldElement(
                             field = formElement,
-                            state = state
+                            state = state,
+                            onDialogRequest = {
+                                Log.e("TAG", "FeatureFormBody: tapped")
+                                onDialogRequest?.invoke(state, formElement.id)
+                            }
                         )
                     }
                 }
@@ -196,7 +235,7 @@ private fun rememberFieldStates(
                         scope = scope
                     )
                 }
-                
+
                 is SwitchFormInput -> {
                     val input = fieldElement.input as SwitchFormInput
                     val initialValue = fieldElement.value.value

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -144,7 +144,7 @@ private fun FeatureFormBody(
     form: FeatureForm,
     states: Map<Int, BaseFieldState?>,
     modifier: Modifier = Modifier,
-    onDialogRequest: ((BaseFieldState, Int) -> Unit)? = null
+    onFieldDialogRequest: ((BaseFieldState, Int) -> Unit)? = null
 ) {
     val lazyListState = rememberLazyListState()
     Column(
@@ -173,7 +173,7 @@ private fun FeatureFormBody(
                             state = state,
                             onDialogRequest = {
                                 Log.e("TAG", "FeatureFormBody: tapped")
-                                onDialogRequest?.invoke(state, formElement.id)
+                                onFieldDialogRequest?.invoke(state, formElement.id)
                             }
                         )
                     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -56,7 +56,10 @@ internal fun FieldElement(
                 if (!switchState.fallback) {
                     SwitchField(state = state)
                 } else {
-                    ComboBoxField(state = state)
+                    ComboBoxField(
+                        state = state,
+                        onDialogRequest = onDialogRequest
+                    )
                 }
             }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -45,7 +45,10 @@ internal fun FieldElement(
             }
 
             is ComboBoxFormInput -> {
-                ComboBoxField(state = state as CodedValueFieldState)
+                ComboBoxField(
+                    state = state as CodedValueFieldState,
+                    onDialogRequest = onDialogRequest
+                )
             }
 
             is SwitchFormInput -> {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/FormElements.kt
@@ -25,7 +25,11 @@ import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
 
 @Composable
-internal fun FieldElement(field: FieldFormElement, state: BaseFieldState) {
+internal fun FieldElement(
+    field: FieldFormElement,
+    state: BaseFieldState,
+    onDialogRequest: () -> Unit = {}
+) {
     val visible by field.isVisible.collectAsState()
     if (visible) {
         when (field.input) {
@@ -34,13 +38,16 @@ internal fun FieldElement(field: FieldFormElement, state: BaseFieldState) {
             }
 
             is DateTimePickerFormInput -> {
-                DateTimeField(state = state as DateTimeFieldState)
+                DateTimeField(
+                    state = state as DateTimeFieldState,
+                    onDialogRequest = onDialogRequest
+                )
             }
 
             is ComboBoxFormInput -> {
                 ComboBoxField(state = state as CodedValueFieldState)
             }
-    
+
             is SwitchFormInput -> {
                 val switchState = state as SwitchFieldState
                 if (!switchState.fallback) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -72,15 +72,17 @@ import com.arcgismaps.data.FieldType
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
-import com.arcgismaps.toolkit.featureforms.utils.isNumeric
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
-internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Modifier) {
+internal fun ComboBoxField(
+    state: CodedValueFieldState,
+    modifier: Modifier = Modifier,
+    onDialogRequest: () -> Unit = {}
+) {
     val value by state.value.collectAsState()
     val isEditable by state.isEditable.collectAsState()
     val isRequired by state.isRequired.collectAsState()
-    var showDialog by rememberSaveable { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
     // to check if the field was ever focused by the user
     var wasFocused by rememberSaveable { mutableStateOf(false) }
@@ -129,33 +131,11 @@ internal fun ComboBoxField(state: CodedValueFieldState, modifier: Modifier = Mod
         interactionSource = interactionSource
     )
 
-    if (showDialog) {
-        ComboBoxDialog(
-            initialValue = value,
-            values = state.codedValues.associateBy({ it.code }, { it.name }),
-            label = state.label,
-            description = state.description,
-            isRequired = isRequired,
-            noValueOption = state.showNoValueOption,
-            keyboardType = if (state.fieldType.isNumeric) {
-                KeyboardType.Number
-            } else {
-                KeyboardType.Ascii
-            },
-            noValueLabel = state.noValueLabel.ifEmpty { stringResource(R.string.no_value) },
-            onValueChange = { code ->
-                state.onValueChanged(code?.toString() ?: "")
-            }
-        ) {
-            showDialog = false
-        }
-    }
-
     LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect {
             if (it is PressInteraction.Release) {
                 wasFocused = true
-                showDialog = true
+                onDialogRequest()
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -40,10 +40,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -53,11 +50,6 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.featureforms.R
-import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePicker
-import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerInput
-import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerState
-import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerStyle
-import com.arcgismaps.toolkit.featureforms.components.datetime.picker.rememberDateTimePickerState
 import com.arcgismaps.toolkit.featureforms.utils.PlaceholderTransformation
 
 @Composable

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -70,15 +70,6 @@ internal fun DateTimeField(
     val isRequired by state.isRequired.collectAsState()
     val epochMillis by state.epochMillis.collectAsState()
 
-    val shouldShowTime = remember {
-        state.shouldShowTime
-    }
-    val pickerStyle = if (shouldShowTime) {
-        DateTimePickerStyle.DateTime
-    } else {
-        DateTimePickerStyle.Date
-    }
-    //var openDialog by rememberSaveable { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
     // the field
     if (isEditable) {
@@ -202,27 +193,6 @@ internal fun DateTimeField(
             supportingText = state.description
         )
     }
-
-//    if (openDialog) {
-//        val pickerState = rememberDateTimePickerState(
-//            pickerStyle,
-//            state.minEpochMillis,
-//            state.maxEpochMillis,
-//            epochMillis,
-//            state.label,
-//            state.description,
-//            DateTimePickerInput.Date
-//        )
-//        // the picker dialog
-//        DateTimePicker(
-//            state = pickerState,
-//            onDismissRequest = { openDialog = false },
-//            onCancelled = { openDialog = false },
-//            onConfirmed = {
-//                state.onValueChanged(pickerState.selectedDateTimeMillis.toString())
-//                openDialog = false
-//            })
-//    }
 
     LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -61,7 +61,6 @@ internal fun DateTimeField(
     val isEditable by state.isEditable.collectAsState()
     val isRequired by state.isRequired.collectAsState()
     val epochMillis by state.epochMillis.collectAsState()
-
     val interactionSource = remember { MutableInteractionSource() }
     // the field
     if (isEditable) {
@@ -149,7 +148,6 @@ internal fun DateTimeField(
                     } else {
                         IconButton(
                             onClick = {
-                                // openDialog = true
                                 onDialogRequest()
                             },
                             modifier = Modifier.semantics {
@@ -189,8 +187,7 @@ internal fun DateTimeField(
     LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect {
             if (it is PressInteraction.Release) {
-                // open the date picker dialog only when the touch is released
-                // openDialog = true
+                // request to show the date picker dialog only when the touch is released
                 onDialogRequest()
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePicker
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerInput
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerState
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerStyle
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.rememberDateTimePickerState
 import com.arcgismaps.toolkit.featureforms.utils.PlaceholderTransformation
@@ -62,7 +63,8 @@ import com.arcgismaps.toolkit.featureforms.utils.PlaceholderTransformation
 @Composable
 internal fun DateTimeField(
     state: DateTimeFieldState,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onDialogRequest: () -> Unit = {}
 ) {
     val isEditable by state.isEditable.collectAsState()
     val isRequired by state.isRequired.collectAsState()
@@ -76,7 +78,7 @@ internal fun DateTimeField(
     } else {
         DateTimePickerStyle.Date
     }
-    var openDialog by rememberSaveable { mutableStateOf(false) }
+    //var openDialog by rememberSaveable { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
     // the field
     if (isEditable) {
@@ -163,7 +165,10 @@ internal fun DateTimeField(
                         }
                     } else {
                         IconButton(
-                            onClick = { openDialog = true },
+                            onClick = {
+                                // openDialog = true
+                                onDialogRequest()
+                            },
                             modifier = Modifier.semantics {
                                 contentDescription = "Show datetime picker"
                             }
@@ -198,32 +203,33 @@ internal fun DateTimeField(
         )
     }
 
-    if (openDialog) {
-        val pickerState = rememberDateTimePickerState(
-            pickerStyle,
-            state.minEpochMillis,
-            state.maxEpochMillis,
-            epochMillis,
-            state.label,
-            state.description,
-            DateTimePickerInput.Date
-        )
-        // the picker dialog
-        DateTimePicker(
-            state = pickerState,
-            onDismissRequest = { openDialog = false },
-            onCancelled = { openDialog = false },
-            onConfirmed = {
-                state.onValueChanged(pickerState.selectedDateTimeMillis.toString())
-                openDialog = false
-            })
-    }
+//    if (openDialog) {
+//        val pickerState = rememberDateTimePickerState(
+//            pickerStyle,
+//            state.minEpochMillis,
+//            state.maxEpochMillis,
+//            epochMillis,
+//            state.label,
+//            state.description,
+//            DateTimePickerInput.Date
+//        )
+//        // the picker dialog
+//        DateTimePicker(
+//            state = pickerState,
+//            onDismissRequest = { openDialog = false },
+//            onCancelled = { openDialog = false },
+//            onConfirmed = {
+//                state.onValueChanged(pickerState.selectedDateTimeMillis.toString())
+//                openDialog = false
+//            })
+//    }
 
     LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect {
             if (it is PressInteraction.Release) {
                 // open the date picker dialog only when the touch is released
-                openDialog = true
+                // openDialog = true
+                onDialogRequest()
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -55,73 +55,68 @@ internal sealed class DialogType : Serializable {
 }
 
 @Composable
-internal fun makeDialog(
+internal fun FeatureFormDialog(
     dialogType: DialogType,
     state: BaseFieldState?,
     onDismissRequest: () -> Unit
-): (@Composable () -> Unit)? {
-    return when (dialogType) {
+) {
+    when (dialogType) {
         is DialogType.NoDialog -> {
             /* show nothing */
-            null
         }
 
         is DialogType.DatePickerDialog -> {
-            {
-                if (state is DateTimeFieldState) {
-                    val shouldShowTime = remember {
-                        state.shouldShowTime
-                    }
-                    val pickerStyle = if (shouldShowTime) {
-                        DateTimePickerStyle.DateTime
-                    } else {
-                        DateTimePickerStyle.Date
-                    }
-                    val pickerState = rememberDateTimePickerState(
-                        pickerStyle,
-                        state.minEpochMillis,
-                        state.maxEpochMillis,
-                        state.epochMillis.collectAsState().value,
-                        state.label,
-                        state.description,
-                        DateTimePickerInput.Date
-                    )
-                    // the picker dialog
-                    DateTimePicker(
-                        state = pickerState,
-                        onDismissRequest = onDismissRequest,
-                        onCancelled = onDismissRequest,
-                        onConfirmed = {
-                            state.onValueChanged(pickerState.selectedDateTimeMillis.toString())
-                            onDismissRequest()
-                        }
-                    )
+            if (state is DateTimeFieldState) {
+                val shouldShowTime = remember {
+                    state.shouldShowTime
                 }
+                val pickerStyle = if (shouldShowTime) {
+                    DateTimePickerStyle.DateTime
+                } else {
+                    DateTimePickerStyle.Date
+                }
+                val pickerState = rememberDateTimePickerState(
+                    pickerStyle,
+                    state.minEpochMillis,
+                    state.maxEpochMillis,
+                    state.epochMillis.collectAsState().value,
+                    state.label,
+                    state.description,
+                    DateTimePickerInput.Date
+                )
+                // the picker dialog
+                DateTimePicker(
+                    state = pickerState,
+                    onDismissRequest = onDismissRequest,
+                    onCancelled = onDismissRequest,
+                    onConfirmed = {
+                        state.onValueChanged(pickerState.selectedDateTimeMillis.toString())
+                        onDismissRequest()
+                    }
+                )
             }
         }
 
         is DialogType.ComboBoxDialog -> {
-            {
-                if (state is CodedValueFieldState) {
-                    ComboBoxDialog(
-                        initialValue = state.value.collectAsState().value,
-                        values = state.codedValues.associateBy({ it.code }, { it.name }),
-                        label = state.label,
-                        description = state.description,
-                        isRequired = state.isRequired.collectAsState().value,
-                        noValueOption = state.showNoValueOption,
-                        keyboardType = if (state.fieldType.isNumeric) {
-                            KeyboardType.Number
-                        } else {
-                            KeyboardType.Ascii
-                        },
-                        noValueLabel = state.noValueLabel.ifEmpty { stringResource(R.string.no_value) },
-                        onValueChange = { code ->
-                            state.onValueChanged(code?.toString() ?: "")
-                        },
-                        onDismissRequest = onDismissRequest
-                    )
-                }
+            if (state is CodedValueFieldState) {
+                ComboBoxDialog(
+                    initialValue = state.value.collectAsState().value,
+                    values = state.codedValues.associateBy({ it.code }, { it.name }),
+                    label = state.label,
+                    description = state.description,
+                    isRequired = state.isRequired.collectAsState().value,
+                    noValueOption = state.showNoValueOption,
+                    keyboardType = if (state.fieldType.isNumeric) {
+                        KeyboardType.Number
+                    } else {
+                        KeyboardType.Ascii
+                    },
+                    noValueLabel = state.noValueLabel.ifEmpty { stringResource(R.string.no_value) },
+                    onValueChange = { code ->
+                        state.onValueChanged(code?.toString() ?: "")
+                    },
+                    onDismissRequest = onDismissRequest
+                )
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -19,7 +19,12 @@ package com.arcgismaps.toolkit.featureforms.utils
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
+import com.arcgismaps.toolkit.featureforms.components.codedvalue.CodedValueFieldState
+import com.arcgismaps.toolkit.featureforms.components.codedvalue.ComboBoxDialog
 import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePicker
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerInput
@@ -55,13 +60,14 @@ internal fun makeDialog(
     state: BaseFieldState?,
     onDismissRequest: () -> Unit
 ): (@Composable () -> Unit)? {
-    return {
-        when (dialogType) {
-            is DialogType.NoDialog -> { /* show nothing */
-                null
-            }
+    return when (dialogType) {
+        is DialogType.NoDialog -> {
+            /* show nothing */
+            null
+        }
 
-            is DialogType.DatePickerDialog -> {
+        is DialogType.DatePickerDialog -> {
+            {
                 if (state is DateTimeFieldState) {
                     val shouldShowTime = remember {
                         state.shouldShowTime
@@ -92,9 +98,30 @@ internal fun makeDialog(
                     )
                 }
             }
+        }
 
-            is DialogType.ComboBoxDialog -> {
-
+        is DialogType.ComboBoxDialog -> {
+            {
+                if (state is CodedValueFieldState) {
+                    ComboBoxDialog(
+                        initialValue = state.value.collectAsState().value,
+                        values = state.codedValues.associateBy({ it.code }, { it.name }),
+                        label = state.label,
+                        description = state.description,
+                        isRequired = state.isRequired.collectAsState().value,
+                        noValueOption = state.showNoValueOption,
+                        keyboardType = if (state.fieldType.isNumeric) {
+                            KeyboardType.Number
+                        } else {
+                            KeyboardType.Ascii
+                        },
+                        noValueLabel = state.noValueLabel.ifEmpty { stringResource(R.string.no_value) },
+                        onValueChange = { code ->
+                            state.onValueChanged(code?.toString() ?: "")
+                        },
+                        onDismissRequest = onDismissRequest
+                    )
+                }
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
+import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePicker
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerInput
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePickerStyle
+import com.arcgismaps.toolkit.featureforms.components.datetime.picker.rememberDateTimePickerState
+import java.io.Serializable
+
+internal sealed class DialogType : Serializable {
+    object NoDialog : DialogType()
+    data class DatePickerDialog(val stateKey: Int) : DialogType()
+    data class ComboBoxDialog(val stateKey: Int) : DialogType()
+
+    fun getStateKey(): Int? {
+        return when (this) {
+            is DatePickerDialog -> {
+                stateKey
+            }
+
+            is ComboBoxDialog -> {
+                stateKey
+            }
+
+            is NoDialog -> {
+                null
+            }
+        }
+    }
+}
+
+@Composable
+internal fun makeDialog(
+    dialogType: DialogType,
+    state: BaseFieldState?,
+    onDismissRequest: () -> Unit
+): (@Composable () -> Unit)? {
+    return {
+        when (dialogType) {
+            is DialogType.NoDialog -> { /* show nothing */
+                null
+            }
+
+            is DialogType.DatePickerDialog -> {
+                if (state is DateTimeFieldState) {
+                    val shouldShowTime = remember {
+                        state.shouldShowTime
+                    }
+                    val pickerStyle = if (shouldShowTime) {
+                        DateTimePickerStyle.DateTime
+                    } else {
+                        DateTimePickerStyle.Date
+                    }
+                    val pickerState = rememberDateTimePickerState(
+                        pickerStyle,
+                        state.minEpochMillis,
+                        state.maxEpochMillis,
+                        state.epochMillis.collectAsState().value,
+                        state.label,
+                        state.description,
+                        DateTimePickerInput.Date
+                    )
+                    // the picker dialog
+                    DateTimePicker(
+                        state = pickerState,
+                        onDismissRequest = onDismissRequest,
+                        onCancelled = onDismissRequest,
+                        onConfirmed = {
+                            state.onValueChanged(pickerState.selectedDateTimeMillis.toString())
+                            onDismissRequest()
+                        }
+                    )
+                }
+            }
+
+            is DialogType.ComboBoxDialog -> {
+
+            }
+        }
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -32,11 +32,32 @@ import com.arcgismaps.toolkit.featureforms.components.datetime.picker.DateTimePi
 import com.arcgismaps.toolkit.featureforms.components.datetime.picker.rememberDateTimePickerState
 import java.io.Serializable
 
+/**
+ * Specifies the type of dialog to use for a [FeatureFormDialog].
+ */
 internal sealed class DialogType : Serializable {
+    /**
+     * Indicates no dialog should be shown.
+     */
     object NoDialog : DialogType()
+
+    /**
+     * Indicates a [DatePickerDialog] should be shown.
+     *
+     * @param stateKey the key for a [DateTimeFieldState].
+     */
     data class DatePickerDialog(val stateKey: Int) : DialogType()
+
+    /**
+     * Indicates a [ComboBoxDialog]
+     *
+     * @param stateKey the key for a [CodedValueFieldState].
+     */
     data class ComboBoxDialog(val stateKey: Int) : DialogType()
 
+    /**
+     * Returns the key for this dialog type state. Null is returned if its a [NoDialog].
+     */
     fun getStateKey(): Int? {
         return when (this) {
             is DatePickerDialog -> {
@@ -54,6 +75,15 @@ internal sealed class DialogType : Serializable {
     }
 }
 
+/**
+ * A dialog container for different field types.
+ *
+ * @param dialogType the [DialogType] to show.
+ * @param state the [BaseFieldState] associated with the field element. This will be cast to its
+ * appropriate subtype based on the [dialogType].
+ * @param onDismissRequest a callback invoked to dismiss the dialog when the user clicks outside
+ * the dialog or on the back button.
+ */
 @Composable
 internal fun FeatureFormDialog(
     dialogType: DialogType,


### PR DESCRIPTION
### Summary of changes

- Adds proper support for configuration changes for both `DateTimePicker` and `ComboBoxDialog`.
- These layout nodes creation is moved from inside a `FieldElement` to the `FeatureFormContent`. Hence it will survive configuration changes.
- the `FeatureFormDialog` and the `DialogType` are used as a container for these dialogs.
- `DialogType` is made serializable to support `rememberSaveable`.