### PR TITLE
consume update value

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -55,5 +55,5 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.3.0
-sdkBuildNumber=4030
+sdkBuildNumber=4036
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,5 +55,5 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.3.0
-sdkBuildNumber=4019
+sdkBuildNumber=4030
 

--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -27,21 +27,7 @@ android {
             useSupportLibrary = true
         }
     }
-    signingConfigs {
-        create("release") {
-            // You need to specify either an absolute path or include the
-            // keystore file in the same directory as the build.gradle file.
-            storeFile = file("/Users/sor10874/Desktop/keystore")
-            storePassword = "featureform"
-            keyAlias = "key0"
-            keyPassword = "featureform"
-        }
-    }
     buildTypes {
-        getByName("release") {
-            signingConfig = signingConfigs.getByName("release")
-            isMinifyEnabled = false
-        }
         release {
             isMinifyEnabled = false
             //proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"),("proguard-rules.pro"

--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -27,8 +27,21 @@ android {
             useSupportLibrary = true
         }
     }
-
+    signingConfigs {
+        create("release") {
+            // You need to specify either an absolute path or include the
+            // keystore file in the same directory as the build.gradle file.
+            storeFile = file("/Users/sor10874/Desktop/keystore")
+            storePassword = "featureform"
+            keyAlias = "key0"
+            keyPassword = "featureform"
+        }
+    }
     buildTypes {
+        getByName("release") {
+            signingConfig = signingConfigs.getByName("release")
+            isMinifyEnabled = false
+        }
         release {
             isMinifyEnabled = false
             //proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"),("proguard-rules.pro"

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -1,5 +1,6 @@
 package com.arcgismaps.toolkit.featureformsapp.screens.map
 
+import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -57,7 +58,12 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                     scope.launch { mapViewModel.rollbackEdits(EditingTransactionState.NotEditing) }
                 },
                 onSave = {
-                    scope.launch { mapViewModel.commitEdits(EditingTransactionState.NotEditing) }
+                    scope.launch {
+                        mapViewModel.commitEdits(EditingTransactionState.NotEditing)
+                            .onFailure {
+                                Log.w("Forms","applying edits from feature form failed with ${it.message}")
+                            }
+                    }
                 }) {
                 onBackPressed()
             }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -1,6 +1,7 @@
 package com.arcgismaps.toolkit.featureformsapp.screens.map
 
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -20,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,6 +36,7 @@ import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetValue
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.StandardBottomSheet
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.StandardBottomSheetLayout
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberStandardBottomSheetState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -44,6 +47,7 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
     val editingFlow =
         remember { mapViewModel.transactionState.map { it is EditingTransactionState.Editing } }
     val inEditingMode by editingFlow.collectAsState(initial = false)
+    val context = LocalContext.current
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -61,7 +65,14 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                     scope.launch {
                         mapViewModel.commitEdits(EditingTransactionState.NotEditing)
                             .onFailure {
-                                Log.w("Forms","applying edits from feature form failed with ${it.message}")
+                                Log.w("Forms", "applying edits from feature form failed with ${it.message}")
+                                launch(Dispatchers.Main) {
+                                    Toast.makeText(
+                                        context,
+                                        "applying edits from feature form failed with ${it.message}",
+                                        Toast.LENGTH_LONG
+                                    ).show()
+                                }
                             }
                     }
                 }) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -273,7 +273,7 @@ private fun rememberFieldStates(
                     val input = fieldElement.input as SwitchFormInput
                     val initialValue = fieldElement.formattedValue
                     val fallback = initialValue.isEmpty()
-                        || (fieldElement.value.value != input.onValue.name && fieldElement.value.value != input.offValue.name)
+                        || (fieldElement.value.value != input.onValue.code && fieldElement.value.value != input.offValue.code)
                     rememberSwitchFieldState(
                         field = fieldElement,
                         form = form,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -201,7 +201,7 @@ private fun rememberFieldStates(
                     val input = fieldElement.input as SwitchFormInput
                     val initialValue = fieldElement.formattedValue
                     val fallback = initialValue.isEmpty()
-                        || (initialValue != input.onValue.code.toString() && initialValue != input.offValue.code.toString())
+                        || (fieldElement.value.value != input.onValue.name && fieldElement.value.value != input.offValue.name)
                     rememberSwitchFieldState(
                         field = fieldElement,
                         form = form,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -199,7 +199,7 @@ private fun rememberFieldStates(
                 
                 is SwitchFormInput -> {
                     val input = fieldElement.input as SwitchFormInput
-                    val initialValue = fieldElement.value.value
+                    val initialValue = fieldElement.formattedValue
                     val fallback = initialValue.isEmpty()
                         || (initialValue != input.onValue.code.toString() && initialValue != input.offValue.code.toString())
                     rememberSwitchFieldState(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -51,7 +51,7 @@ internal open class BaseFieldState(
     properties: FieldProperties,
     initialValue: String = properties.value.value,
     scope: CoroutineScope,
-    private val onEditValue: (Any?) -> Unit,
+    protected val onEditValue: (Any?) -> Unit,
 ) {
     /**
      * Title for the field.
@@ -69,7 +69,7 @@ internal open class BaseFieldState(
     val description: String = properties.description
 
     // a state flow to handle user input changes
-    private val _value = MutableStateFlow(initialValue)
+    protected val _value = MutableStateFlow(initialValue)
 
     /**
      * Current value state for the field.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -136,7 +136,7 @@ internal open class CodedValueFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = { newValue ->
-                        formElement.editValue(newValue)
+                        form.editValue(formElement, newValue)
                         scope.launch { form.evaluateExpressions() }
                     }
                 )
@@ -169,7 +169,7 @@ internal fun rememberCodedValueFieldState(
         ),
         scope = scope,
         onEditValue = {
-            field.editValue(it)
+            form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -102,6 +102,14 @@ internal open class CodedValueFieldState(
             it.code.toString() == code.toString()
         }?.name
     }
+    
+    override fun onValueChanged(input: String) {
+        val code = codedValues.firstOrNull {
+            it.name == input
+        }?.code
+        onEditValue(code)
+        _value.value = input
+    }
 
     companion object {
         /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -32,6 +32,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldType
+import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -124,7 +125,7 @@ internal open class CodedValueFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.value,
+                        value = formElement.formattedFlow(scope),
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         codedValues = input.codedValues,
@@ -158,7 +159,7 @@ internal fun rememberCodedValueFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.value,
+            value = field.formattedFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             codedValues = input.codedValues,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -32,7 +32,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldType
-import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
+import com.arcgismaps.toolkit.featureforms.utils.formattedValueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -133,7 +133,7 @@ internal open class CodedValueFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.formattedFlow(scope),
+                        value = formElement.formattedValueFlow(scope),
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         codedValues = input.codedValues,
@@ -167,7 +167,7 @@ internal fun rememberCodedValueFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.formattedFlow(scope),
+            value = field.formattedValueFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             codedValues = input.codedValues,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -136,7 +136,7 @@ internal open class CodedValueFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = { newValue ->
-                        form.editValue(formElement, newValue)
+                        formElement.editValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     }
                 )
@@ -169,7 +169,7 @@ internal fun rememberCodedValueFieldState(
         ),
         scope = scope,
         onEditValue = {
-            form.editValue(field, it)
+            field.editValue(it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -151,7 +151,7 @@ internal fun ComboBoxDialog(
     noValueOption: FormInputNoValueOption,
     noValueLabel: String,
     keyboardType: KeyboardType,
-    onValueChange: (Any?) -> Unit,
+    onValueChange: (String) -> Unit,
     onDismissRequest: () -> Unit
 ) {
     var searchText by rememberSaveable { mutableStateOf("") }
@@ -254,11 +254,10 @@ internal fun ComboBoxDialog(
                                 .fillMaxWidth()
                                 .clickable {
                                     // if the no value label was selected, set the value to be empty
-                                    onValueChange(code)
+                                    onValueChange(name)
                                 },
                             trailingContent = {
-                                if ((code?.toString()
-                                        ?: "") == initialValue || (name == noValueLabel && initialValue.isEmpty())
+                                if (name == initialValue || (name == noValueLabel && initialValue.isEmpty())
                                 ) {
                                     Icon(
                                         imageVector = Icons.Outlined.Check,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
@@ -116,13 +116,12 @@ private fun RadioButtonField(
             CompositionLocalProvider(
                 LocalContentColor provides colors.textColor(enabled = editable)
             ) {
-                options.forEach { (code, name) ->
+                options.forEach { (_, name) ->
                     RadioButtonRow(
                         value = name,
-                        selected = (code?.toString()
-                            ?: "") == value || (name == noValueLabel && value.isEmpty()),
+                        selected = name == value || (name == noValueLabel && value.isEmpty()),
                         enabled = editable,
-                        onClick = { onValueChanged(code?.toString() ?: "") }
+                        onClick = { onValueChanged(name) }
                     )
                 }
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -52,7 +52,7 @@ internal class RadioButtonFieldState(
             false
         } else {
             !codedValues.any {
-                it.code.toString() == value.value
+                it.name == value.value
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -56,14 +56,6 @@ internal class RadioButtonFieldState(
             }
         }
     }
-    
-    override fun onValueChanged(input: String) {
-        val code = codedValues.firstOrNull {
-            it.name == input
-        }?.code
-        onEditValue(code)
-        _value.value = input
-    }
 
     companion object {
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -25,6 +25,7 @@ import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldType
+import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -78,7 +79,7 @@ internal class RadioButtonFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.value,
+                        value = formElement.formattedFlow(scope),
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         fieldType = form.fieldType(formElement),
@@ -112,7 +113,7 @@ internal fun rememberRadioButtonFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.value,
+            value = field.formattedFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             fieldType = form.fieldType(field),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -90,7 +90,7 @@ internal class RadioButtonFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = { newValue ->
-                        formElement.editValue(newValue)
+                        form.editValue(formElement, newValue)
                         scope.launch { form.evaluateExpressions() }
                     }
                 )
@@ -123,7 +123,7 @@ internal fun rememberRadioButtonFieldState(
         ),
         scope = scope,
         onEditValue = {
-            field.editValue(it)
+            form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -56,6 +56,14 @@ internal class RadioButtonFieldState(
             }
         }
     }
+    
+    override fun onValueChanged(input: String) {
+        val code = codedValues.firstOrNull {
+            it.name == input
+        }?.code
+        onEditValue(code)
+        _value.value = input
+    }
 
     companion object {
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -25,7 +25,7 @@ import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldType
-import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
+import com.arcgismaps.toolkit.featureforms.utils.formattedValueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -79,7 +79,7 @@ internal class RadioButtonFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.formattedFlow(scope),
+                        value = formElement.formattedValueFlow(scope),
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         fieldType = form.fieldType(formElement),
@@ -113,7 +113,7 @@ internal fun rememberRadioButtonFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.formattedFlow(scope),
+            value = field.formattedValueFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             fieldType = form.fieldType(field),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -90,7 +90,7 @@ internal class RadioButtonFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = { newValue ->
-                        form.editValue(formElement, newValue)
+                        formElement.editValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     }
                 )
@@ -123,7 +123,7 @@ internal fun rememberRadioButtonFieldState(
         ),
         scope = scope,
         onEditValue = {
-            form.editValue(field, it)
+            field.editValue(it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
@@ -34,8 +34,8 @@ import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
 
 @Composable
 internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier) {
-    val valueCode by state.value.collectAsState()
-    val checkedState = valueCode == state.onValue.code!!.toString()
+    val codeName by state.value.collectAsState()
+    val checkedState = codeName == state.onValue.name
     val value = if (checkedState) state.onValue.name else state.offValue.name
     val isEditable by state.isEditable.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }
@@ -63,10 +63,10 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
             onCheckedChange = { newState ->
                 val newValue = (
                     if (newState)
-                        state.onValue.code?.toString()
+                        state.onValue.name
                     else
-                        state.offValue.code?.toString()
-                    ) ?: throw IllegalStateException("coded value code must not be null")
+                        state.offValue.name
+                    )
                 state.onValueChanged(newValue)
             },
             modifier = Modifier
@@ -76,15 +76,15 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
         )
     }
     
-    LaunchedEffect(valueCode) {
+    LaunchedEffect(codeName) {
         interactionSource.interactions.collect {
             if (it is PressInteraction.Release) {
                 val newValue = (
                     if (checkedState)
-                        state.offValue.code?.toString()
+                        state.offValue.name
                     else
-                        state.onValue.code?.toString()
-                    ) ?: throw IllegalStateException("coded value code must not be null")
+                        state.onValue.name
+                    )
                 state.onValueChanged(newValue)
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -135,7 +135,8 @@ internal class SwitchFieldState(
                     initialValue = list[0] as String,
                     scope = scope,
                     onEditValue = { codedValueName ->
-                        formElement.editValue(
+                        form.editValue(
+                            formElement,
                             if (codedValueName == input.onValue.name) input.onValue.code else input.offValue.code
                         )
                         scope.launch { form.evaluateExpressions() }
@@ -177,7 +178,7 @@ internal fun rememberSwitchFieldState(
         ),
         scope = scope,
         onEditValue = {
-            field.editValue(it)
+            form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -31,7 +31,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldIsNullable
 import com.arcgismaps.toolkit.featureforms.utils.fieldType
-import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
+import com.arcgismaps.toolkit.featureforms.utils.formattedValueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -119,7 +119,7 @@ internal class SwitchFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.formattedFlow(scope),
+                        value = formElement.formattedValueFlow(scope),
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         fieldType = form.fieldType(formElement),
@@ -163,7 +163,7 @@ internal fun rememberSwitchFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.formattedFlow(scope),
+            value = field.formattedValueFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             fieldType = form.fieldType(field),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -135,8 +135,7 @@ internal class SwitchFieldState(
                     initialValue = list[0] as String,
                     scope = scope,
                     onEditValue = { codedValueName ->
-                        form.editValue(
-                            formElement,
+                        formElement.editValue(
                             if (codedValueName == input.onValue.name) input.onValue.code else input.offValue.code
                         )
                         scope.launch { form.evaluateExpressions() }
@@ -178,7 +177,7 @@ internal fun rememberSwitchFieldState(
         ),
         scope = scope,
         onEditValue = {
-            form.editValue(field, it)
+            field.editValue(it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -31,6 +31,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldIsNullable
 import com.arcgismaps.toolkit.featureforms.utils.fieldType
+import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -118,7 +119,7 @@ internal class SwitchFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.value,
+                        value = formElement.formattedFlow(scope),
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         fieldType = form.fieldType(formElement),
@@ -162,7 +163,7 @@ internal fun rememberSwitchFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.value,
+            value = field.formattedFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             fieldType = form.fieldType(field),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -216,7 +216,8 @@ internal fun DateTimeField(
             onConfirmed = {
                 state.onValueChanged(pickerState.selectedDateTimeMillis.toString())
                 openDialog = false
-            })
+            }
+        )
     }
 
     LaunchedEffect(interactionSource) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -31,7 +31,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
 import com.arcgismaps.toolkit.featureforms.utils.editValue
-import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
+import com.arcgismaps.toolkit.featureforms.utils.formattedValueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
@@ -113,7 +113,7 @@ internal class DateTimeFieldState(
                         label = field.label,
                         placeholder = field.hint,
                         description = field.description,
-                        value = field.formattedFlow(scope),
+                        value = field.formattedValueFlow(scope),
                         editable = field.isEditable,
                         required = field.isRequired,
                         minEpochMillis = input.min?.toEpochMilli(),
@@ -152,7 +152,7 @@ internal fun rememberDateTimeFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.formattedFlow(scope),
+            value = field.formattedValueFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             minEpochMillis = minEpochMillis,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -123,7 +123,7 @@ internal class DateTimeFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = {
-                        form.editValue(field, it)
+                        field.editValue(it)
                         scope.launch { form.evaluateExpressions() }
                     }
                 )
@@ -161,7 +161,7 @@ internal fun rememberDateTimeFieldState(
         ),
         scope = scope,
         onEditValue = {
-            form.editValue(field, it)
+            field.editValue(it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -31,6 +31,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
 import com.arcgismaps.toolkit.featureforms.utils.editValue
+import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
@@ -112,7 +113,7 @@ internal class DateTimeFieldState(
                         label = field.label,
                         placeholder = field.hint,
                         description = field.description,
-                        value = field.value,
+                        value = field.formattedFlow(scope),
                         editable = field.isEditable,
                         required = field.isRequired,
                         minEpochMillis = input.min?.toEpochMilli(),
@@ -151,7 +152,7 @@ internal fun rememberDateTimeFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.value,
+            value = field.formattedFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             minEpochMillis = minEpochMillis,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -123,7 +123,7 @@ internal class DateTimeFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = {
-                        field.editValue(it)
+                        form.editValue(field, it)
                         scope.launch { form.evaluateExpressions() }
                     }
                 )
@@ -161,7 +161,7 @@ internal fun rememberDateTimeFieldState(
         ),
         scope = scope,
         onEditValue = {
-            field.editValue(it)
+            form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -418,7 +418,7 @@ internal class FormTextFieldState(
                     scope = scope,
                     context = context,
                     onEditValue = { newValue ->
-                        formElement.editValue(newValue)
+                        form.editValue(formElement, newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
                 ).apply {
@@ -459,7 +459,7 @@ internal fun rememberFormTextFieldState(
         scope = scope,
         context = context,
         onEditValue = {
-            field.editValue(it)
+            form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -418,7 +418,7 @@ internal class FormTextFieldState(
                     scope = scope,
                     context = context,
                     onEditValue = { newValue ->
-                        form.editValue(formElement, newValue)
+                        formElement.editValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
                 ).apply {
@@ -459,7 +459,7 @@ internal fun rememberFormTextFieldState(
         scope = scope,
         context = context,
         onEditValue = {
-            form.editValue(field, it)
+            field.editValue(it)
             scope.launch { form.evaluateExpressions() }
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -51,7 +51,7 @@ import com.arcgismaps.toolkit.featureforms.utils.asLongTuple
 import com.arcgismaps.toolkit.featureforms.utils.domain
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldType
-import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
+import com.arcgismaps.toolkit.featureforms.utils.formattedValueFlow
 import com.arcgismaps.toolkit.featureforms.utils.isFloatingPoint
 import com.arcgismaps.toolkit.featureforms.utils.isIntegerType
 import com.arcgismaps.toolkit.featureforms.utils.isNumeric
@@ -403,7 +403,7 @@ internal class FormTextFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.formattedFlow(scope),
+                        value = formElement.formattedValueFlow(scope),
                         required = formElement.isRequired,
                         editable = formElement.isEditable,
                         domain = form.domain(formElement) as? RangeDomain,
@@ -445,7 +445,7 @@ internal fun rememberFormTextFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.formattedFlow(scope),
+            value = field.formattedValueFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             singleLine = field.input is TextBoxFormInput,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -51,6 +51,7 @@ import com.arcgismaps.toolkit.featureforms.utils.asLongTuple
 import com.arcgismaps.toolkit.featureforms.utils.domain
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldType
+import com.arcgismaps.toolkit.featureforms.utils.formattedFlow
 import com.arcgismaps.toolkit.featureforms.utils.isFloatingPoint
 import com.arcgismaps.toolkit.featureforms.utils.isIntegerType
 import com.arcgismaps.toolkit.featureforms.utils.isNumeric
@@ -404,7 +405,7 @@ internal class FormTextFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.value,
+                        value = formElement.formattedFlow(scope),
                         required = formElement.isRequired,
                         editable = formElement.isEditable,
                         domain = form.domain(formElement) as? RangeDomain,
@@ -446,7 +447,7 @@ internal fun rememberFormTextFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.value,
+            value = field.formattedFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             singleLine = field.input is TextBoxFormInput,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -72,7 +72,7 @@ internal fun FeatureForm.fieldType(element: FieldFormElement): FieldType {
 internal fun FeatureForm.domain(element: FieldFormElement): Domain? =
     feature.featureTable?.getField(element.fieldName)?.domain
 
-internal fun FieldFormElement.formattedFlow(scope: CoroutineScope): StateFlow<String> =
+internal fun FieldFormElement.formattedValueFlow(scope: CoroutineScope): StateFlow<String> =
     value.map { formattedValue }.stateIn(scope, SharingStarted.Eagerly, formattedValue)
 
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -199,6 +199,7 @@ private fun cast(value: Any?, fieldType: FieldType): Any? =
             when (value) {
                 is String -> value.toLongOrNull()?.let { Instant.ofEpochMilli(it) }
                 is Long -> Instant.ofEpochMilli(value)
+                is Instant -> value
                 else -> null
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -23,6 +23,11 @@ import com.arcgismaps.data.RangeDomain
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FeatureFormDefinition
 import com.arcgismaps.mapping.featureforms.FieldFormElement
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import java.time.Instant
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
@@ -70,6 +75,10 @@ internal fun FeatureForm.fieldType(element: FieldFormElement): FieldType {
 
 internal fun FeatureForm.domain(element: FieldFormElement): Domain? =
     feature.featureTable?.getField(element.fieldName)?.domain
+
+internal fun FieldFormElement.formattedFlow(scope: CoroutineScope): StateFlow<String> =
+    value.map { formattedValue }.stateIn(scope, SharingStarted.Eagerly, formattedValue)
+
 
 internal val FieldType.isNumeric: Boolean
     get() {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -192,6 +192,7 @@ private fun cast(value: Any?, fieldType: FieldType): Any? =
                 is String -> value.toDoubleOrNull()
                 is Int -> value.toDouble()
                 is Float -> value.toDouble()
+                is Double -> value.toDouble()
                 else -> null
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -54,8 +54,10 @@ internal fun FeatureForm.editValue(element: FieldFormElement, value: Any?) {
     try {
         element.updateValue(cast(value, fieldType(element)))
     } catch (e: Exception) {
-        //TODO: remove before release.
-        Log.w("FieldFormElement.editValue", "caught ${e.message} while updating value of field ${element.label}")
+        //TODO: remove before release. (and also the try catch)
+        Log.w(
+            "Form.editValue", "caught ${e.message} while updating value of field ${element.label} to $value"
+        )
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -16,35 +16,22 @@
 
 package com.arcgismaps.toolkit.featureforms.utils
 
+import android.util.Log
 import com.arcgismaps.data.Domain
-import com.arcgismaps.data.Feature
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.data.RangeDomain
 import com.arcgismaps.mapping.featureforms.FeatureForm
-import com.arcgismaps.mapping.featureforms.FeatureFormDefinition
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import java.time.Instant
-import kotlin.math.roundToInt
-import kotlin.math.roundToLong
 
 /**
  * This file contains logic which will eventually be provided by core. Do not add anything to this file that isn't
  * scheduled for core implementation. This entire file will be removed before the 200.3.0 release.
  */
-
-/**
- * Retrieve the value of a [FieldFormElement] from the [FeatureFormDefinition].
- * This call is likely to be pushed into core.
- */
-@Suppress("unused")
-internal fun FeatureForm.getElementValue(formElement: FieldFormElement): Any? {
-    return feature.attributes[formElement.fieldName]
-}
 
 internal fun FeatureForm.fieldIsNullable(element: FieldFormElement): Boolean {
     val isNullable = feature.featureTable?.getField(element.fieldName)?.nullable
@@ -56,13 +43,17 @@ internal fun FeatureForm.fieldIsNullable(element: FieldFormElement): Boolean {
 
 /**
  * Set the value in the feature's attribute map. This call can only be made when a transaction is open.
- * Committing the transaction will either discard this edit or persist it in the associated geodatabase,
- * and refresh the feature.
+ * Catches and swallows exceptions. Remove this function when [FieldFormElement.updateValue] no longer throws.
  *
- * This call is likely to be pushed into core.
+ * @param value the value to be set on the attribute represented by this FieldFormElement.
  */
-internal fun FeatureForm.editValue(formElement: FieldFormElement, value: Any?) {
-    feature.castAndSetAttributeValue(value, formElement.fieldName)
+internal fun FieldFormElement.editValue(value: Any?) {
+    try {
+        updateValue(value)
+    } catch (e: Exception) {
+        //TODO: remove before release.
+        Log.w("FieldFormElement.editValue", "caught ${e.message} while updating value of field $label")
+    }
 }
 
 internal fun FeatureForm.fieldType(element: FieldFormElement): FieldType {
@@ -158,63 +149,3 @@ internal val RangeDomain.asLongTuple: MinMax<Long>
     }
 
 internal data class MinMax<T: Number>(val min: T?, val max: T?)
-
-private fun Feature.castAndSetAttributeValue(value: Any?, key: String) {
-    val field = featureTable?.getField(key) ?: run {
-        attributes[key] = value
-        return
-    }
-    
-    var finalValue = value
-    when (field.fieldType) {
-        FieldType.Int16 -> {
-            finalValue = when (value) {
-                is String -> value.toIntOrNull()?.toShort()
-                is Int -> value.toShort()
-                is Double -> value.roundToInt().toShort()
-                else -> null
-            }
-        }
-        FieldType.Int32 -> {
-            finalValue = when (value) {
-                is String -> value.toIntOrNull()
-                is Int -> value
-                is Double -> value.roundToInt()
-                else -> null
-            }
-        }
-        FieldType.Int64 -> {
-            finalValue = when (value) {
-                is String -> value.toLongOrNull()
-                is Int -> value.toLong()
-                is Double -> value.roundToLong()
-                else -> null
-            }
-        }
-        FieldType.Float32 -> {
-            finalValue = when (value) {
-                is String -> value.toFloatOrNull()
-                is Int -> value.toFloat()
-                is Double -> value.toFloat()
-                else -> null
-            }
-        }
-        FieldType.Float64 -> {
-            finalValue = when (value) {
-                is String -> value.toDoubleOrNull()
-                is Int -> value.toDouble()
-                is Float -> value.toDouble()
-                else -> null
-            }
-        }
-        FieldType.Date -> {
-            finalValue = when (value) {
-                is String -> value.toLongOrNull()?.let { Instant.ofEpochMilli(it) }
-                is Long -> Instant.ofEpochMilli(value)
-                else -> null
-            }
-        }
-        else -> Unit
-    }
-    attributes[key] = finalValue
-}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -142,8 +142,8 @@ internal fun FeatureFormDialog(
                         KeyboardType.Ascii
                     },
                     noValueLabel = state.noValueLabel.ifEmpty { stringResource(R.string.no_value) },
-                    onValueChange = { code ->
-                        state.onValueChanged(code?.toString() ?: "")
+                    onValueChange = { nameOrEmpty ->
+                        state.onValueChanged(nameOrEmpty)
                     },
                     onDismissRequest = onDismissRequest
                 )


### PR DESCRIPTION
This updates the SDK to 4036 and uses the `formattedValue` when the `valueChanged` event is emitted. `updateValue` is used to update attribute values. Its usage is wrapped in a try-catch until the API is changed so it no longer throws.

There are some known issues with this version of core but I think we can work with it for a weekly build.

issue 1: [TreeTrimmingHealthCheck](https://devtopia.esri.com/runtime/apollo/issues/254) map
issue 2: [AdhocUItest_Switch](https://devtopia.esri.com/runtime/apollo/issues/181) map