### PR TITLE
Compose MapView: SelectionProperties

### DIFF
--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
@@ -43,12 +43,12 @@ import kotlinx.coroutines.launch
 /**
  * The default instance of [MapViewInteractionOptions]
  */
-public val MapViewInteractionOptionDefaults: MapViewInteractionOptions = MapViewInteractionOptions()
+public val DefaultMapViewInteractionOptions: MapViewInteractionOptions = MapViewInteractionOptions()
 
 /**
  * The default instance of [SelectionProperties]
  */
-public val MapViewSelectionPropertiesDefaults: SelectionProperties = SelectionProperties()
+public val DefaultMapViewSelectionProperties: SelectionProperties = SelectionProperties()
 
 /**
  * A compose equivalent of the [MapView].
@@ -58,7 +58,7 @@ public val MapViewSelectionPropertiesDefaults: SelectionProperties = SelectionPr
  * @param locationDisplay the [LocationDisplay] used by the composable [com.arcgismaps.toolkit.geocompose.MapView]
  * @param geometryEditor the [GeometryEditor] used by the composable [com.arcgismaps.toolkit.geocompose.MapView] to create and edit geometries by user interaction.
  * @param mapViewInteractionOptions the [MapViewInteractionOptions] used by this composable [com.arcgismaps.toolkit.geocompose.MapView]
- * @param selectionProperties the [SelectionProperties] used by the composable [com.arcgismaps.toolkit.geocompose.MapView] to set a selection color.
+ * @param selectionProperties the [SelectionProperties] used by the composable [com.arcgismaps.toolkit.geocompose.MapView].
  * @param onViewpointChanged lambda invoked when the viewpoint of the composable MapView has changed
  * @param overlay the composable overlays to display on top of the composable MapView. Example, a compass, floorfilter etc.
  * @since 200.3.0
@@ -69,8 +69,8 @@ public fun MapView(
     arcGISMap: ArcGISMap? = null,
     locationDisplay: LocationDisplay = rememberLocationDisplay(),
     geometryEditor: GeometryEditor? = null,
-    mapViewInteractionOptions: MapViewInteractionOptions = MapViewInteractionOptionDefaults,
-    selectionProperties: SelectionProperties = MapViewSelectionPropertiesDefaults,
+    mapViewInteractionOptions: MapViewInteractionOptions = DefaultMapViewInteractionOptions,
+    selectionProperties: SelectionProperties = DefaultMapViewSelectionProperties,
     onViewpointChanged: (() -> Unit)? = null,
     overlay: @Composable () -> Unit = {}
 ) {

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
@@ -36,12 +36,18 @@ import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.view.LocationDisplay
 import com.arcgismaps.mapping.view.MapView
 import com.arcgismaps.mapping.view.MapViewInteractionOptions
+import com.arcgismaps.mapping.view.SelectionProperties
 import kotlinx.coroutines.launch
 
 /**
  * The default instance of [MapViewInteractionOptions]
  */
 public val MapViewInteractionOptionDefaults: MapViewInteractionOptions = MapViewInteractionOptions()
+
+/**
+ * The default instance of [SelectionProperties]
+ */
+public val MapViewDefaultSelectionProperties: SelectionProperties = SelectionProperties()
 
 /**
  * A compose equivalent of the [MapView].
@@ -58,6 +64,7 @@ public val MapViewInteractionOptionDefaults: MapViewInteractionOptions = MapView
 public fun MapView(
     modifier: Modifier = Modifier,
     arcGISMap: ArcGISMap? = null,
+    selectionProperties: SelectionProperties = MapViewDefaultSelectionProperties,
     locationDisplay: LocationDisplay = rememberLocationDisplay(),
     mapViewInteractionOptions: MapViewInteractionOptions = MapViewInteractionOptionDefaults,
     onViewpointChanged: (() -> Unit)? = null,
@@ -77,6 +84,7 @@ public fun MapView(
             factory = { mapView },
             update = {
                 it.map = arcGISMap
+                it.selectionProperties = selectionProperties
                 it.interactionOptions = mapViewInteractionOptions
                 it.locationDisplay = locationDisplay
             })

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
@@ -41,16 +41,6 @@ import com.arcgismaps.mapping.view.geometryeditor.GeometryEditor
 import kotlinx.coroutines.launch
 
 /**
- * The default instance of [MapViewInteractionOptions]
- */
-public val DefaultMapViewInteractionOptions: MapViewInteractionOptions = MapViewInteractionOptions()
-
-/**
- * The default instance of [SelectionProperties]
- */
-public val DefaultMapViewSelectionProperties: SelectionProperties = SelectionProperties()
-
-/**
  * A compose equivalent of the [MapView].
  *
  * @param modifier Modifier to be applied to the composable MapView
@@ -69,8 +59,8 @@ public fun MapView(
     arcGISMap: ArcGISMap? = null,
     locationDisplay: LocationDisplay = rememberLocationDisplay(),
     geometryEditor: GeometryEditor? = null,
-    mapViewInteractionOptions: MapViewInteractionOptions = DefaultMapViewInteractionOptions,
-    selectionProperties: SelectionProperties = DefaultMapViewSelectionProperties,
+    mapViewInteractionOptions: MapViewInteractionOptions = MapViewInteractionOptions(),
+    selectionProperties: SelectionProperties = SelectionProperties(),
     onViewpointChanged: (() -> Unit)? = null,
     overlay: @Composable () -> Unit = {}
 ) {

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
@@ -47,7 +47,7 @@ public val MapViewInteractionOptionDefaults: MapViewInteractionOptions = MapView
 /**
  * The default instance of [SelectionProperties]
  */
-public val MapViewDefaultSelectionProperties: SelectionProperties = SelectionProperties()
+public val MapViewSelectionPropertiesDefaults: SelectionProperties = SelectionProperties()
 
 /**
  * A compose equivalent of the [MapView].
@@ -56,6 +56,7 @@ public val MapViewDefaultSelectionProperties: SelectionProperties = SelectionPro
  * @param arcGISMap the [ArcGISMap] to be rendered by this composable
  * @param locationDisplay the [LocationDisplay] used by the composable [com.arcgismaps.toolkit.geocompose.MapView]
  * @param mapViewInteractionOptions the [MapViewInteractionOptions] used by this composable [com.arcgismaps.toolkit.geocompose.MapView]
+ * @param selectionProperties the [SelectionProperties] used by the composable [com.arcgismaps.toolkit.geocompose.MapView] to set a selection color.
  * @param onViewpointChanged lambda invoked when the viewpoint of the composable MapView has changed
  * @param overlay the composable overlays to display on top of the composable MapView. Example, a compass, floorfilter etc.
  * @since 200.3.0
@@ -66,7 +67,7 @@ public fun MapView(
     arcGISMap: ArcGISMap? = null,
     locationDisplay: LocationDisplay = rememberLocationDisplay(),
     mapViewInteractionOptions: MapViewInteractionOptions = MapViewInteractionOptionDefaults,
-    selectionProperties: SelectionProperties = MapViewDefaultSelectionProperties,
+    selectionProperties: SelectionProperties = MapViewSelectionPropertiesDefaults,
     onViewpointChanged: (() -> Unit)? = null,
     overlay: @Composable () -> Unit = {}
 ) {

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
@@ -64,9 +64,9 @@ public val MapViewDefaultSelectionProperties: SelectionProperties = SelectionPro
 public fun MapView(
     modifier: Modifier = Modifier,
     arcGISMap: ArcGISMap? = null,
-    selectionProperties: SelectionProperties = MapViewDefaultSelectionProperties,
     locationDisplay: LocationDisplay = rememberLocationDisplay(),
     mapViewInteractionOptions: MapViewInteractionOptions = MapViewInteractionOptionDefaults,
+    selectionProperties: SelectionProperties = MapViewDefaultSelectionProperties,
     onViewpointChanged: (() -> Unit)? = null,
     overlay: @Composable () -> Unit = {}
 ) {


### PR DESCRIPTION
Related issue: `#2969`

### Description

PR to add SelectionProperties property to the compose MapView

### Testing

Here is the code snippet for my local testing. It would query a feature table and select the state of California in Color.Red

```kotlin
private const val usPopulationURL =
    "https://services.arcgis.com/jIL9msH9OI208GCb/arcgis/rest/services/USA_Daytime_Population_2016/FeatureServer/0"


@Composable
fun MainScreen() {
    val featureLayer = FeatureLayer.createWithFeatureTable(ServiceFeatureTable(usPopulationURL))

    val arcGISMap by remember {
        mutableStateOf(ArcGISMap(BasemapStyle.ArcGISStreets).apply {
            // add the feature layer to the map's operational layers
            operationalLayers.add(featureLayer)
        })
    }

    // set the selection properties
    val selectionProperties = SelectionProperties(Color.red)

    MapView(
        modifier = Modifier.fillMaxSize(),
        arcGISMap = arcGISMap,
        selectionProperties = selectionProperties
    )

    LaunchedEffect(Unit) {
        val queryParameters = QueryParameters().apply {
            whereClause = ("upper(STATE_NAME) LIKE '%" + "CALI" + "%'")
        }
        val featureQueryResult = featureLayer.featureTable?.queryFeatures(queryParameters)?.getOrThrow() ?: return@LaunchedEffect
        featureLayer.selectFeature(featureQueryResult.first())
    }
}

```