### PR TITLE
Patch GraphicsOverlaysUpdater

### DIFF
--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
@@ -145,6 +145,8 @@ public fun MapView(
         onTwoPointerTap,
         onPan
     )
+
+    GraphicsOverlaysUpdater(graphicsOverlays, mapView)
 }
 
 /**
@@ -256,8 +258,6 @@ private fun MapViewEventHandler(
             }
         }
     }
-
-    GraphicsOverlaysUpdater(graphicsOverlays, mapView)
 }
 
 /**


### PR DESCRIPTION
Looks like while merging in `GraphicsOverlaysUpdater` the callee was merged to be called inside `MapViewEventHandler`. This PR moves it inside of the composable `MapView` instead