### PR TITLE
ComboBox `noValueLabel` selection fix

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -254,7 +254,11 @@ internal fun ComboBoxDialog(
                                 .fillMaxWidth()
                                 .clickable {
                                     // if the no value label was selected, set the value to be empty
-                                    onValueChange(name)
+                                    if (name == noValueLabel) {
+                                        onValueChange("")
+                                    } else {
+                                        onValueChange(name)
+                                    }
                                 },
                             trailingContent = {
                                 if (name == initialValue || (name == noValueLabel && initialValue.isEmpty())


### PR DESCRIPTION
### Summary of changes

For the `ComboBoxDialog` if the selection was a `noValueLabel` then the value set should be an empty string.