### PR TITLE
Forms: DatePickerDialog scaling

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -18,6 +18,8 @@
 
 package com.arcgismaps.toolkit.featureforms.components.datetime.picker
 
+import android.content.res.Configuration
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -27,6 +29,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -227,7 +230,6 @@ private fun (ColumnScope).PickerContent(
                 key(state.dateTime.value) {
                     DatePicker(
                         state = datePickerState,
-                        modifier = Modifier.scaleIfNarrow(DateTimePickerDialogTokens.containerWidth),
                         dateValidator = { timeStamp ->
                             state.dateValidator(timeStamp)
                         },
@@ -329,9 +331,10 @@ private fun DateTimePickerDialog(
     ) {
         Surface(
             modifier = Modifier
-                .padding(start = 25.dp, end = 25.dp)
-                .requiredWidth(DateTimePickerDialogTokens.containerWidth)
-                .height(DateTimePickerDialogTokens.containerHeight),
+                .padding(horizontal = DateTimePickerDialogTokens.horizontalPadding)
+                .widthWithOrientation(DateTimePickerDialogTokens.containerWidth)
+                .height(DateTimePickerDialogTokens.containerHeight)
+                .scaleIfNarrow(DateTimePickerDialogTokens.containerWidth + DateTimePickerDialogTokens.horizontalPadding * 2),
             shape = shape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = tonalElevation,
@@ -353,8 +356,27 @@ private fun DateTimePickerDialog(
 private object DateTimePickerDialogTokens {
     val containerHeight = 600.0.dp
     val containerWidth = 360.0.dp
+    val horizontalPadding = 25.dp
 }
 
+/**
+ * Constraints the width of the content based on the orientation and the [width]. If the
+ * current orientation is portrait, [Modifier.requiredWidth] used. If it is landscape then
+ * [Modifier.widthIn] is used. This is useful when different layouts are needed in portrait
+ * and landscape orientations.
+ */
+internal fun Modifier.widthWithOrientation(width: Dp) : Modifier = composed {
+    val configuration = LocalConfiguration.current
+    if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        this.widthIn(width)
+    } else {
+        this.requiredWidth(width)
+    }
+}
+
+/**
+ * Scales the content appropriately if the current screen width is less than the [minWidth].
+ */
 internal fun Modifier.scaleIfNarrow(minWidth: Dp): Modifier = composed {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
     val scale = if (screenWidth <= minWidth)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -26,7 +26,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -50,8 +50,11 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -224,6 +227,7 @@ private fun (ColumnScope).PickerContent(
                 key(state.dateTime.value) {
                     DatePicker(
                         state = datePickerState,
+                        modifier = Modifier.scaleIfNarrow(DateTimePickerDialogTokens.containerWidth),
                         dateValidator = { timeStamp ->
                             state.dateValidator(timeStamp)
                         },
@@ -326,7 +330,7 @@ private fun DateTimePickerDialog(
         Surface(
             modifier = Modifier
                 .padding(start = 25.dp, end = 25.dp)
-                .widthIn(DateTimePickerDialogTokens.containerWidth)
+                .requiredWidth(DateTimePickerDialogTokens.containerWidth)
                 .height(DateTimePickerDialogTokens.containerHeight),
             shape = shape,
             color = MaterialTheme.colorScheme.surface,
@@ -351,7 +355,15 @@ private object DateTimePickerDialogTokens {
     val containerWidth = 360.0.dp
 }
 
-@Preview
+internal fun Modifier.scaleIfNarrow(minWidth: Dp): Modifier = composed {
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val scale = if (screenWidth <= minWidth)
+        screenWidth / minWidth
+    else 1f
+    this.scale(scale)
+}
+
+@Preview(showSystemUi = true, showBackground = true, backgroundColor = 0xFFFFFF, widthDp = 392)
 @Composable
 private fun DateTimePickerPreview() {
     val state = DateTimePickerState(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -19,7 +19,6 @@
 package com.arcgismaps.toolkit.featureforms.components.datetime.picker
 
 import android.content.res.Configuration
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -378,7 +378,7 @@ internal fun Modifier.widthWithOrientation(width: Dp) : Modifier = composed {
  */
 internal fun Modifier.scaleIfNarrow(minWidth: Dp): Modifier = composed {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
-    val scale = if (screenWidth <= minWidth)
+    val scale = if (screenWidth < minWidth)
         screenWidth / minWidth
     else 1f
     this.scale(scale)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/DateTimePicker.kt
@@ -384,7 +384,7 @@ internal fun Modifier.scaleIfNarrow(minWidth: Dp): Modifier = composed {
     this.scale(scale)
 }
 
-@Preview(showSystemUi = true, showBackground = true, backgroundColor = 0xFFFFFF, widthDp = 392)
+@Preview
 @Composable
 private fun DateTimePickerPreview() {
     val state = DateTimePickerState(


### PR DESCRIPTION
### Summary of changes

Fixes the improper scaling of `DateTimePickerDialog` on devices that are narrower than the minimum width needed to fit the `DatePicker`. This is 360dp as mentioned [here](https://issuetracker.google.com/issues/297249202#comment3).

The fix is to scale down the Dialog using the extension `Modifier.scaleIfNarrow(minWidth: Dp)` if the available screen width is less than required. Hence it will not effect devices that have sufficient width. 

Since this effect occurs only in portrait mode, the extension `Modifier.widthWithOrientation(width: Dp)` is provided that sets the width constraint accordingly.

| Before  | After |
| ------------- | ------------- |
|   <img src="https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/assets/12847934/6aec895f-d03d-4810-bcde-c84aa04cf92d" width="275"> | <img src="https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/assets/12847934/927c0bd0-c976-47cf-a318-37ecf3b5e207" width="275"> |