### PR TITLE
make values focusable (and copyable) when not editable

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
@@ -152,8 +152,8 @@ internal fun BaseTextField(
     text: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    readOnly: Boolean,
     isEditable: Boolean,
+    readOnly: Boolean = !isEditable,
     label: String,
     placeholder: String,
     singleLine: Boolean,
@@ -189,7 +189,6 @@ internal fun BaseTextField(
                 .focusable(isEditable, interactionSource)
                 .semantics { contentDescription = "outlined text field" },
             readOnly = readOnly,
-            enabled = isEditable,
             label = {
                 Text(
                     text = label,
@@ -247,7 +246,6 @@ private fun BaseTextFieldPreview() {
         BaseTextField(
             text = "",
             onValueChange = {},
-            readOnly = false,
             isEditable = true,
             label = "Title",
             placeholder = "Enter Value",

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -43,7 +42,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.contentDescription
@@ -153,10 +151,10 @@ internal fun BaseTextField(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     isEditable: Boolean,
-    readOnly: Boolean = !isEditable,
     label: String,
     placeholder: String,
     singleLine: Boolean,
+    readOnly: Boolean = !isEditable,
     keyboardType: KeyboardType = KeyboardType.Ascii,
     trailingIcon: ImageVector? = null,
     supportingText: @Composable (ColumnScope.() -> Unit)? = null,
@@ -228,16 +226,15 @@ internal fun BaseTextField(
             ),
             singleLine = singleLine,
             interactionSource = interactionSource,
-            colors = if (text.isEmpty() && placeholder.isNotEmpty())
-                OutlinedTextFieldDefaults.colors(
-                    unfocusedTextColor = Color.Gray,
-                    focusedTextColor = Color.Gray
-                )
-            else
-                OutlinedTextFieldDefaults.colors()
+            colors = baseTextFieldColors(
+                isEditable = isEditable,
+                isEmpty = text.isEmpty(),
+                isPlaceholderEmpty = placeholder.isEmpty()
+            )
         )
     }
 }
+
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.components.base
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+@Composable
+internal fun baseTextFieldColors(isEditable: Boolean, isEmpty: Boolean, isPlaceholderEmpty: Boolean): TextFieldColors {
+    val textColor = BaseTextFieldColors.textColor(
+        isEditable = isEditable,
+        isEmpty = isEmpty,
+        isPlaceHolderEmpty = isPlaceholderEmpty
+    )
+    val borderColor = BaseTextFieldColors.borderColor(
+        isEditable = isEditable
+    )
+    val labelColor = BaseTextFieldColors.labelColor(
+        isEditable = isEditable
+    )
+    return OutlinedTextFieldDefaults.colors(
+        focusedTextColor = textColor,
+        unfocusedTextColor = textColor,
+        focusedBorderColor = borderColor,
+        focusedLabelColor = labelColor
+    )
+}
+/**
+ * Color properties of a base text field.
+ */
+internal object BaseTextFieldColors {
+    @Composable
+    fun borderColor(isEditable: Boolean) =
+        if (isEditable)
+            MaterialTheme.colorScheme.primary
+        else
+            MaterialTheme.colorScheme.secondary.copy(alpha = 0.8f)
+    
+    @Composable
+    fun labelColor(isEditable: Boolean) =
+        if (isEditable)
+            MaterialTheme.colorScheme.primary
+        else
+            MaterialTheme.colorScheme.secondary.copy(alpha = 0.8f)
+    
+    @Composable
+    fun textColor(isEditable: Boolean, isEmpty: Boolean, isPlaceHolderEmpty: Boolean): Color {
+        val color = if (isEmpty && !isPlaceHolderEmpty) {
+            Color.Gray
+        } else {
+            MaterialTheme.colorScheme.secondary
+        }
+        
+        return if (isEditable) color else color.copy(alpha = 0.6f)
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -135,7 +135,9 @@ internal fun ComboBoxField(
         interactionSource.interactions.collect {
             if (it is PressInteraction.Release) {
                 wasFocused = true
-                onDialogRequest()
+                if (isEditable) {
+                    onDialogRequest()
+                }
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
@@ -102,19 +102,19 @@ private fun RadioButtonField(
                 label
             },
             style = MaterialTheme.typography.bodyMedium,
-            color = colors.labelColor(enabled = editable)
+            color = colors.labelColor
         )
         Column(
             modifier = Modifier
                 .selectableGroup()
                 .border(
                     width = 1.dp,
-                    color = colors.containerBorderColor(enabled = editable),
+                    color = colors.containerBorderColor,
                     shape = RoundedCornerShape(5.dp)
                 )
         ) {
             CompositionLocalProvider(
-                LocalContentColor provides colors.textColor(enabled = editable)
+                LocalContentColor provides colors.textColor
             ) {
                 options.forEach { (_, name) ->
                     RadioButtonRow(
@@ -130,7 +130,7 @@ private fun RadioButtonField(
             Text(
                 text = description,
                 style = MaterialTheme.typography.bodySmall,
-                color = colors.supportingTextColor(enabled = editable)
+                color = colors.supportingTextColor
             )
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldDefaults.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldDefaults.kt
@@ -22,94 +22,30 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
 internal object RadioButtonFieldDefaults {
-
-    private const val textDisabledAlpha = 0.38f
-    private const val containerDisabledAlpha = 0.12f
-
     @Composable
     fun colors(): RadioButtonFieldColors = RadioButtonFieldColors(
-        defaultLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        disabledLabelColor = MaterialTheme.colorScheme.onSurface.copy(
-            alpha = textDisabledAlpha
-        ),
-        defaultSupportingTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        disabledSupportingTextColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-            alpha = textDisabledAlpha
-        ),
+        labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        supportingTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
         errorColor = MaterialTheme.colorScheme.error,
-        defaultContainerBorderColor = MaterialTheme.colorScheme.outline,
-        disabledContainerBorderColor = MaterialTheme.colorScheme.outline.copy(
-            alpha = containerDisabledAlpha
-        ),
-        defaultTextColor = LocalContentColor.current,
-        disabledTextColor = LocalContentColor.current.copy(alpha = textDisabledAlpha)
+        containerBorderColor = MaterialTheme.colorScheme.outline,
+        textColor = LocalContentColor.current
     )
 }
 
+/**
+ * Color properties of a radio button field.
+ *
+ * @property labelColor The color used for the label of this radio button field.
+ * @property supportingTextColor The color used for the supporting text of this radio button field.
+ * @property errorColor The color used for the supporting text of this radio button field when the value is considered
+ * invalid.
+ * @property containerBorderColor The color used for the container border of this radio button field.
+ * @property textColor The color used for the text of this radio button field options.
+ */
 internal data class RadioButtonFieldColors(
-    val defaultLabelColor: Color,
-    val disabledLabelColor: Color,
-    val defaultSupportingTextColor: Color,
-    val disabledSupportingTextColor: Color,
+    val labelColor: Color,
+    val supportingTextColor: Color,
     val errorColor: Color,
-    val defaultContainerBorderColor: Color,
-    val disabledContainerBorderColor: Color,
-    val defaultTextColor: Color,
-    val disabledTextColor: Color
-) {
-    /**
-     * Represents the color used for the label of this radio button field.
-     *
-     * @param enabled whether the field is enabled
-     */
-    @Composable
-    fun labelColor(enabled: Boolean): Color {
-        return if (enabled) {
-            defaultLabelColor
-        } else {
-            disabledLabelColor
-        }
-    }
-
-    /**
-     * Represents the color used for the supporting text of this radio button field.
-     *
-     * @param enabled whether the field is enabled
-     */
-    @Composable
-    fun supportingTextColor(enabled: Boolean): Color {
-        return if (enabled) {
-            defaultSupportingTextColor
-        } else {
-            disabledSupportingTextColor
-        }
-    }
-
-    /**
-     * Represents the color used for the container border of this radio button field.
-     *
-     * @param enabled whether the field is enabled
-     */
-    @Composable
-    fun containerBorderColor(enabled: Boolean): Color {
-        return if (enabled) {
-            defaultContainerBorderColor
-        } else {
-            disabledContainerBorderColor
-        }
-    }
-
-    /**
-     * Represents the color used for the text of this radio button field options.
-     *
-     * @param enabled whether the field is enabled
-     */
-    @Composable
-    fun textColor(enabled: Boolean): Color {
-        return if (enabled) {
-            defaultTextColor
-        } else {
-            disabledTextColor
-        }
-    }
-}
+    val containerBorderColor: Color,
+    val textColor: Color
+)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
@@ -78,14 +78,16 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
     
     LaunchedEffect(codeName) {
         interactionSource.interactions.collect {
-            if (it is PressInteraction.Release) {
-                val newValue = (
-                    if (checkedState)
-                        state.offValue.name
-                    else
-                        state.onValue.name
-                    )
-                state.onValueChanged(newValue)
+            if (isEditable) {
+                if (it is PressInteraction.Release) {
+                    val newValue = (
+                        if (checkedState)
+                            state.offValue.name
+                        else
+                            state.onValue.name
+                        )
+                    state.onValueChanged(newValue)
+                }
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -21,6 +21,7 @@ package com.arcgismaps.toolkit.featureforms.components.datetime
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CalendarMonth
 import androidx.compose.material.icons.rounded.EditCalendar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -75,7 +76,7 @@ internal fun DateTimeField(
         placeholder = state.placeholder.ifEmpty { stringResource(id = R.string.no_value) },
         singleLine = true,
         interactionSource = interactionSource,
-        trailingIcon = Icons.Rounded.EditCalendar,
+        trailingIcon = if (isEditable) Icons.Rounded.EditCalendar else Icons.Rounded.CalendarMonth,
         supportingText = {
             // if the field was focused and is required, validate the current value
             if (wasFocused && isRequired && instant == null) {
@@ -98,7 +99,8 @@ internal fun DateTimeField(
                 wasFocused = true
                 // request to show the date picker dialog only when the touch is released
                 // the dialog is responsible for updating the value on the state
-                onDialogRequest()
+                if (isEditable)
+                    onDialogRequest()
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -58,7 +58,6 @@ internal fun FormTextField(
             state.onValueChanged(it)
         },
         modifier = modifier.fillMaxWidth(),
-        readOnly = false,
         isEditable = isEditable,
         label = label,
         placeholder = state.placeholder,
@@ -76,7 +75,7 @@ internal fun FormTextField(
                         color = textColor
                     )
                 }
-                if (isFocused) {
+                if (isFocused && isEditable) {
                     Spacer(modifier = Modifier.weight(1f))
                     Text(
                         text = contentLength,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -226,7 +226,11 @@ internal class FormTextFieldState(
             errorMessages[errorToDisplay] ?: throw IllegalStateException("validation error must have a message")
         } else {
             description.ifEmpty {
-                if (_isFocused.value) helperText else ""
+                if (_isFocused.value && isEditable.value) {
+                    helperText
+                } else {
+                    ""
+                }
             }
         }
         _hasError.value = errors.isNotEmpty()
@@ -328,7 +332,7 @@ internal class FormTextFieldState(
         value: String,
         validationErrors: List<ValidationErrorState>
     ): ValidationErrorState =
-        if (validationErrors.isEmpty()) {
+        if (validationErrors.isEmpty() || !isEditable.value) {
             NoError
         } else if (isFocused.value) {
             if (value.isEmpty()) {


### PR DESCRIPTION
Instead of disabling fields when isEditable = false, allow the fields to gain focus so the value can be copied. Various styling changes to align the look and feel of read only and editable fields.