### PR TITLE
Floor filter patch

### DIFF
--- a/toolkit/indoors/build.gradle.kts
+++ b/toolkit/indoors/build.gradle.kts
@@ -53,5 +53,6 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     testImplementation(libs.bundles.unitTest)
     androidTestImplementation(libs.bundles.composeTest)
+    androidTestImplementation(project(mapOf("path" to ":composable-map")))
     debugImplementation(libs.bundles.debug)
 }


### PR DESCRIPTION
PR to fix the test dependency issue with FloorFilter [tests](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/blob/feature-branches/geo-compose/toolkit/indoors/src/androidTest/java/com/arcgismaps/toolkit/indoors/FloorFilterTests.kt)
