### PR TITLE
Improve WebView Display

### DIFF
--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
@@ -60,6 +60,7 @@ public fun Authenticator(
 ) {
     AuthenticatorDelegate(
         authenticatorState = authenticatorState,
+        // `fillMaxSize()` is needed, otherwise the prompts are displayed at the top of the screen.
         modifier = modifier.fillMaxSize(),
         onPendingOAuthUserSignIn = onPendingOAuthUserSignIn
     )

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
@@ -24,7 +24,6 @@ import android.content.ContextWrapper
 import android.security.KeyChain
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -57,6 +56,26 @@ public fun Authenticator(
     Shareable(authenticatorState = authenticatorState, modifier = modifier, onPendingOAuthUserSignIn = onPendingOAuthUserSignIn)
 }
 
+
+/**
+ * Displays the [Authenticator] in an [AlertDialog]. See the Authenticator component for more details.
+ *
+ * @param authenticatorState an [AuthenticatorState]. See [AuthenticatorState.Companion.Factory].
+ * @param onPendingOAuthUserSignIn if not null, this will be called when an OAuth challenge is pending
+ * and the browser should be launched. Use this if you wish to handle OAuth challenges from your own
+ * activity rather than using the [OAuthUserSignInActivity].
+ * @since 200.2.0
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+public fun DialogAuthenticator(authenticatorState: AuthenticatorState, onPendingOAuthUserSignIn: ((OAuthUserSignIn) -> Unit)? = null) {
+    val showDialog = authenticatorState.isDisplayed.collectAsStateWithLifecycle(initialValue = false).value
+    if (showDialog) {
+        val modifier =  Modifier.clip(MaterialTheme.shapes.extraLarge)
+        Shareable(displayOnDialog = true, authenticatorState = authenticatorState, modifier = modifier, onPendingOAuthUserSignIn)
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun Shareable(
@@ -82,7 +101,7 @@ private fun Shareable(
     pendingServerTrustChallenge?.let {
         if (displayOnDialog) {
             AlertDialog(onDismissRequest = { /*TODO*/ }) {
-                ServerTrustAuthenticator(it, modifier)        
+                ServerTrustAuthenticator(it, modifier)
             }
         } else {
             ServerTrustAuthenticator(it, modifier)
@@ -126,23 +145,4 @@ private fun Context.findActivity(): Activity {
         context = context.baseContext
     }
     throw IllegalStateException("Could not find an activity from which to launch client certificate picker.")
-}
-
-/**
- * Displays the [Authenticator] in an [AlertDialog]. See the Authenticator component for more details.
- *
- * @param authenticatorState an [AuthenticatorState]. See [AuthenticatorState.Companion.Factory].
- * @param onPendingOAuthUserSignIn if not null, this will be called when an OAuth challenge is pending
- * and the browser should be launched. Use this if you wish to handle OAuth challenges from your own
- * activity rather than using the [OAuthUserSignInActivity].
- * @since 200.2.0
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-public fun DialogAuthenticator(authenticatorState: AuthenticatorState, onPendingOAuthUserSignIn: ((OAuthUserSignIn) -> Unit)? = null) {
-    val showDialog = authenticatorState.isDisplayed.collectAsStateWithLifecycle(initialValue = false).value
-    if (showDialog) {
-        val modifier =  Modifier.clip(MaterialTheme.shapes.extraLarge)
-        Shareable(displayOnDialog = true, authenticatorState = authenticatorState, modifier = modifier, onPendingOAuthUserSignIn)
-    }
 }

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
@@ -54,6 +54,16 @@ public fun Authenticator(
     modifier: Modifier = Modifier.fillMaxSize(),
     onPendingOAuthUserSignIn: ((OAuthUserSignIn) -> Unit)? = null
 ) {
+    Shareable(authenticatorState = authenticatorState, modifier = modifier, onPendingOAuthUserSignIn = onPendingOAuthUserSignIn)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun Shareable(
+    displayOnDialog: Boolean = false, authenticatorState: AuthenticatorState,
+    modifier: Modifier = Modifier.fillMaxSize(),
+    onPendingOAuthUserSignIn: ((OAuthUserSignIn) -> Unit)? = null
+) {
     // If the back button is pressed, this ensures that any prompts get dismissed.
     BackHandler {
         authenticatorState.dismissAll()
@@ -70,14 +80,26 @@ public fun Authenticator(
         authenticatorState.pendingServerTrustChallenge.collectAsStateWithLifecycle().value
 
     pendingServerTrustChallenge?.let {
-        ServerTrustAuthenticator(it, modifier)
+        if (displayOnDialog) {
+            AlertDialog(onDismissRequest = { /*TODO*/ }) {
+                ServerTrustAuthenticator(it, modifier)        
+            }
+        } else {
+            ServerTrustAuthenticator(it, modifier)
+        }
     }
 
     val pendingUsernamePasswordChallenge =
         authenticatorState.pendingUsernamePasswordChallenge.collectAsStateWithLifecycle().value
 
     pendingUsernamePasswordChallenge?.let {
-        UsernamePasswordAuthenticator(it, modifier)
+        if (displayOnDialog) {
+            AlertDialog(onDismissRequest = { /*TODO*/ }) {
+                UsernamePasswordAuthenticator(it, modifier)
+            }
+        } else {
+            UsernamePasswordAuthenticator(it, modifier)
+        }
     }
 
     val pendingClientCertificateChallenge =
@@ -120,11 +142,7 @@ private fun Context.findActivity(): Activity {
 public fun DialogAuthenticator(authenticatorState: AuthenticatorState, onPendingOAuthUserSignIn: ((OAuthUserSignIn) -> Unit)? = null) {
     val showDialog = authenticatorState.isDisplayed.collectAsStateWithLifecycle(initialValue = false).value
     if (showDialog) {
-        AlertDialog(
-            onDismissRequest = { authenticatorState.dismissAll() },
-            modifier = Modifier.clip(MaterialTheme.shapes.extraLarge),
-        ) {
-            Authenticator(authenticatorState = authenticatorState, modifier = Modifier.fillMaxWidth(), onPendingOAuthUserSignIn)
-        }
+        val modifier =  Modifier.clip(MaterialTheme.shapes.extraLarge)
+        Shareable(displayOnDialog = true, authenticatorState = authenticatorState, modifier = modifier, onPendingOAuthUserSignIn)
     }
 }

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
@@ -37,14 +37,14 @@ import com.arcgismaps.httpcore.authentication.OAuthUserConfiguration
 import com.arcgismaps.httpcore.authentication.OAuthUserSignIn
 
 /**
- * Displays appropriate Authentication UI when a challenge is issued.
+ * Displays appropriate Authentication UI when an authentication challenge is issued.
  *
  * For example, when an [ArcGISAuthenticationChallenge] is issued and the [AuthenticatorState] has a corresponding
  * [OAuthUserConfiguration], then a Custom Tab will be launched to complete the OAuth sign in.
  *
  * All Authentication components will be displayed in full screen. See [DialogAuthenticator] for alternate behavior.
  *
- * @param authenticatorState the application viewModel's [AuthenticatorState].
+ * @param authenticatorState the object that holds the state to handle authentication challenges.
  * @param modifier the [Modifier] to apply to this Authenticator.
  * @param onPendingOAuthUserSignIn if not null, this will be called when an OAuth challenge is pending
  * and the browser should be launched. Use this if you wish to handle OAuth challenges from your own
@@ -66,21 +66,22 @@ public fun Authenticator(
 }
 
 /**
- * Displays appropriate Authentication UI when a challenge is issued.
+ * Displays appropriate Authentication UI when an authentication challenge is issued.
  *
  * For example, when an [ArcGISAuthenticationChallenge] is issued and the [AuthenticatorState] has a corresponding
  * [OAuthUserConfiguration], then a Custom Tab will be launched to complete the OAuth sign in.
  *
- * The [ServerTrustAuthenticator] and [UsernamePasswordAuthenticator] components will be displayed in an [AlertDialog].
- * All other components are displayed in full screen.
+ * Server trust prompts and username/password prompts will be displayed in an [AlertDialog].
+ * All other prompts are displayed in full screen.
  *
  * For alternate behavior, see the [Authenticator] component.
  *
- * @param authenticatorState the application viewModel's [AuthenticatorState].
+ * @param authenticatorState the object that holds the state to handle authentication challenges.
  * @param modifier the [Modifier] to be applied to this DialogAuthenticator.
  * @param onPendingOAuthUserSignIn if not null, this will be called when an OAuth challenge is pending
  * and the browser should be launched. Use this if you wish to handle OAuth challenges from your own
  * activity rather than using the [OAuthUserSignInActivity].
+ * @see Authenticator
  * @since 200.2.0
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -115,7 +116,7 @@ public fun DialogAuthenticator(
  * otherwise this will not work.
  *
  * @sample [DialogAuthenticator]
- * @param authenticatorState the application viewModel's [AuthenticatorState].
+ * @param authenticatorState the object that holds the state to handle authentication challenges.
  * @param onPendingOAuthUserSignIn if not null, this will be called when an OAuth challenge is pending
  * and the browser should be launched. Use this if you wish to handle OAuth challenges from your own
  * activity rather than using the [OAuthUserSignInActivity].

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
@@ -96,12 +96,12 @@ public fun DialogAuthenticator(
             authenticatorState = authenticatorState,
             modifier = modifier,
             onPendingOAuthUserSignIn,
-        ) { authenticationComponent ->
+        ) { authenticationPrompt ->
             AlertDialog(
                 onDismissRequest = authenticatorState::dismissAll,
                 modifier = Modifier.clip(MaterialTheme.shapes.extraLarge),
             ) {
-                authenticationComponent()
+                authenticationPrompt()
             }
         }
     }
@@ -120,7 +120,7 @@ public fun DialogAuthenticator(
  * and the browser should be launched. Use this if you wish to handle OAuth challenges from your own
  * activity rather than using the [OAuthUserSignInActivity].
  * @param container if not null, the passed component will be used as a container for [ServerTrustAuthenticator] and
- * [UsernamePasswordAuthenticator].
+ * [UsernamePasswordAuthenticator]. This lambda passes a component which must be called in the content of the container.
  * @since 200.4.0
  */
 @Composable

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/ServerTrustAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/ServerTrustAuthenticator.kt
@@ -48,7 +48,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 internal fun ServerTrustAuthenticator(
     serverTrustChallenge: ServerTrustChallenge,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
@@ -70,7 +70,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 @Composable
 public fun UsernamePasswordAuthenticator(
     usernamePasswordChallenge: UsernamePasswordChallenge,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
 
     Column(


### PR DESCRIPTION
Refactors the Authenticator composable. 

Changes: 
Introduces a new composable `AuthenticatorDelegate` that has all the logic previously held by `Authenticator` with a new parameter `container`. This allows for the calling composable to pass in the desired container to display the `Server trust` and `username/password` prompt. 
This is used by `DialogAuthenticator.`

### Testing
---
The current workflows should work the same way as before. In the micro app, when using a `WebView,` it should use the full app screen and the `server trust /username password` prompts should be displayed in an Alert Dialog 
