### PR TITLE
`Forms`: Microapp optimizations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,6 @@ androidxMaterialIcons = "1.4.3"
 androidxTestExt = "1.1.2"
 androidxViewmodelCompose = "2.6.1"
 androidxWindow = "1.2.0"
-coil = "2.4.0"
 compileSdk = "34"
 compose-material3 = "1.1.0"
 compose-navigation = "2.7.5"
@@ -50,7 +49,6 @@ androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.r
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 androidx-window-core = { group = "androidx.window", name = "window-core", version.ref = "androidxWindow" }
 androidx-window = { group = "androidx.window", name = "window", version.ref = "androidxWindow" }
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 hilt-android-core = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-ext-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltExt" }

--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -76,8 +76,6 @@ dependencies {
     annotationProcessor(libs.room.compiler)
     implementation(libs.room.ext)
     kapt(libs.room.compiler)
-    // coil
-    implementation(libs.coil.compose)
     // jetpack window manager
     implementation(libs.androidx.window)
     implementation(libs.androidx.window.core)

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
@@ -130,12 +130,7 @@ class PortalItemRepository(
                 data.portalItem.load().onFailure {
                     Log.e("PortalItemRepository", "loadAndCachePortalItems: $it")
                 }
-                data.portalItem.thumbnail?.let { thumbnail ->
-                    thumbnail.load()
-                    thumbnail.image?.bitmap?.let { bitmap ->
-                        data.thumbnailUri = createThumbnail(data.portalItem.itemId, bitmap)
-                    }
-                }
+                data.portalItem.thumbnail?.load()
             }
             // suspend till all the portal loading jobs are complete
         }.joinAll()

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
@@ -67,8 +67,10 @@ class PortalItemRepository(
         portalUri: String,
         connection: Portal.Connection
     ) = withContext(dispatcher) {
-        deleteAll()
         mutex.withLock {
+            // delete existing cache items
+            itemCacheDao.deleteAll()
+            portalItems.clear()
             // get local items
             val localItems = getListOfMaps().map { ItemData(it) }
             // get network items

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
@@ -1,7 +1,9 @@
 package com.arcgismaps.toolkit.featureformsapp.data
 
 import android.graphics.Bitmap
+import android.os.FileUtils
 import android.util.Log
+import com.arcgismaps.LoadStatus
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.portal.Portal
 import com.arcgismaps.toolkit.featureformsapp.data.local.ItemCacheDao
@@ -9,16 +11,20 @@ import com.arcgismaps.toolkit.featureformsapp.data.local.ItemCacheEntry
 import com.arcgismaps.toolkit.featureformsapp.data.local.ItemData
 import com.arcgismaps.toolkit.featureformsapp.data.network.ItemRemoteDataSource
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
+import kotlin.system.measureTimeMillis
 
 data class PortalItemData(
     val portalItem: PortalItem,
@@ -31,6 +37,7 @@ data class PortalItemData(
  * mechanism.
  */
 class PortalItemRepository(
+    private val scope: CoroutineScope,
     private val dispatcher: CoroutineDispatcher,
     private val remoteDataSource: ItemRemoteDataSource,
     private val itemCacheDao: ItemCacheDao,
@@ -41,6 +48,8 @@ class PortalItemRepository(
 
     // to protect shared state of portalItems
     private val mutex = Mutex()
+
+    private lateinit var thumbsDirPath: String
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val portalItemsFlow: Flow<List<PortalItemData>> =
@@ -55,6 +64,14 @@ class PortalItemRepository(
                 }
             }
         }.flowOn(dispatcher)
+
+    init {
+        scope.launch(Dispatchers.IO) {
+            val thumbsDir = File("$filesDir/thumbs")
+            if (!thumbsDir.exists()) thumbsDir.mkdirs()
+            thumbsDirPath = thumbsDir.absolutePath
+        }
+    }
 
     /**
      * Returns the list of loaded PortalItemData as a flow.
@@ -71,17 +88,22 @@ class PortalItemRepository(
         portalUri: String,
         connection: Portal.Connection
     ) = withContext(dispatcher) {
+        deleteAll()
         mutex.withLock {
-            portalItems.clear()
             // get local items
             val localItems = getListOfMaps().map { ItemData(it) }
+            val remoteItems: List<ItemData>
             // get network items
-            Log.e("TAG", "refresh: started remote items load", )
-            val remoteItems = remoteDataSource.fetchItemData(portalUri, connection)
-            Log.e("TAG", "refresh: got remote items", )
+            val fetchTime = measureTimeMillis {
+                remoteItems = remoteDataSource.fetchItemData(portalUri, connection)
+            }
+            Log.e("TAG", "refresh: got remote items $fetchTime")
             // load the portal items and add them to cache
-            loadAndCachePortalItems(localItems + remoteItems)
-            Log.e("TAG", "refresh: caching complete", )
+            val cacheTime = measureTimeMillis {
+                // call your function here
+                loadAndCachePortalItems(localItems + remoteItems)
+            }
+            Log.e("TAG", "refresh: caching complete in $cacheTime")
         }
     }
 
@@ -102,34 +124,36 @@ class PortalItemRepository(
     /**
      * Loads the list of [items] into loaded portal items and adds them to the Cache.
      */
-    private suspend fun loadAndCachePortalItems(items: List<ItemData>) {
-        val entries = items.mapNotNull { itemData ->
-            val portalItem = PortalItem(itemData.url)
-            // ignore if the portal items fails to load
-            val result = portalItem.load().onFailure {
-                Log.e("PortalItemRepository", "loadAndCachePortalItems: $it")
+    private suspend fun loadAndCachePortalItems(items: List<ItemData>) = withContext(dispatcher) {
+        val portalItems = items.map { PortalItem(it.url) }
+        portalItems.map { portalItem ->
+            launch {
+                portalItem.load().onFailure {
+                    Log.e("PortalItemRepository", "loadAndCachePortalItems: $it")
+                }
+                portalItem.thumbnail?.let { thumbnail ->
+                    thumbnail.load()
+                    thumbnail.image?.bitmap?.let { bitmap ->
+                        createThumbnail(portalItem.itemId, bitmap)
+                    }
+                }
             }
-            if (result.isFailure) {
+        }.joinAll()
+
+        val entries = portalItems.mapNotNull { portalItem ->
+            // ignore if the portal items fails to load
+            if (portalItem.loadStatus.value is LoadStatus.FailedToLoad || portalItem.loadStatus.value is LoadStatus.NotLoaded) {
                 null
             } else {
-                val thumbnailUri = portalItem.thumbnail?.let { thumbnail ->
-                    //thumbnail.load()
-                    thumbnail.image?.bitmap?.let { bitmap ->
-                        createThumbnail(
-                            portalItem.itemId,
-                            bitmap
-                        )
-                    }
-                } ?: ""
                 ItemCacheEntry(
-                    itemData.url,
+                    portalItem.itemId,
                     portalItem.toJson(),
-                    thumbnailUri,
+                    getThumbnailUri(portalItem.itemId),
                     portalItem.portal.url
                 )
             }
         }
-        // purge existing items and add the updated items
+        // add all the items into the local cache storage
         createCacheEntries(entries)
     }
 
@@ -144,28 +168,34 @@ class PortalItemRepository(
     /**
      * Deletes all entries in the database using the [ItemCacheDao].
      */
-    private suspend fun deleteAllCacheEntries() =
-        withContext(Dispatchers.IO) {
-            itemCacheDao.deleteAll()
-            val thumbsDir = File("$filesDir/thumbs")
-            if (thumbsDir.exists()) thumbsDir.deleteRecursively()
-        }
+    private suspend fun deleteAllCacheEntries() = withContext(Dispatchers.IO) {
+        itemCacheDao.deleteAll()
+    }
 
     /**
-     * Creates a JPEG thumbnail using the [bitmap] with [name] filename in the local files
+     * Creates a JPEG thumbnail using the [bitmap] with [itemId].jpg filename in the local files
      * directory and returns the absolute path to the file.
      */
-    private suspend fun createThumbnail(name: String, bitmap: Bitmap): String =
+    private suspend fun createThumbnail(itemId: String, bitmap: Bitmap): String =
         withContext(Dispatchers.IO) {
-            val thumbsDir = File("$filesDir/thumbs")
-            if (!thumbsDir.exists()) thumbsDir.mkdirs()
-            val file = File("${thumbsDir.absolutePath}/${name}.jpg")
+            val file = File("${thumbsDirPath}/${itemId}.jpg")
             file.createNewFile()
             FileOutputStream(file).use {
                 bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it)
             }
             file.absolutePath
         }
+
+    /**
+     * Returns the thumbnail file path for a portal item with the [itemId]. An empty string
+     * is returned if a thumbnail does not exist.
+     */
+    private suspend fun getThumbnailUri(itemId: String): String = withContext(Dispatchers.IO) {
+        val file = File("${thumbsDirPath}/${itemId}.jpg")
+        return@withContext if (file.exists()) {
+            file.absolutePath
+        } else ""
+    }
 
     operator fun invoke(itemId: String): PortalItem? = portalItems[itemId]
 }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
@@ -62,26 +62,26 @@ class PortalItemRepository(
     fun observe(): Flow<List<PortalItemData>> = portalItemsFlow
 
     /**
-     * Refreshes the underlying data source to fetch the latest content. [forceUpdate] when set to
-     * true, will clear the existing cache.
+     * Refreshes the underlying data source to fetch the latest content.
      *
      * This operation is suspending and will wait until the underlying data source has finished
      * AND the repository has finished loading the portal items.
      */
     suspend fun refresh(
         portalUri: String,
-        connection: Portal.Connection,
-        forceUpdate: Boolean = false
+        connection: Portal.Connection
     ) = withContext(dispatcher) {
         mutex.withLock {
-            if (forceUpdate) deleteAllCacheEntries()
             portalItems.clear()
             // get local items
             val localItems = getListOfMaps().map { ItemData(it) }
             // get network items
+            Log.e("TAG", "refresh: started remote items load", )
             val remoteItems = remoteDataSource.fetchItemData(portalUri, connection)
+            Log.e("TAG", "refresh: got remote items", )
             // load the portal items and add them to cache
             loadAndCachePortalItems(localItems + remoteItems)
+            Log.e("TAG", "refresh: caching complete", )
         }
     }
 
@@ -113,7 +113,7 @@ class PortalItemRepository(
                 null
             } else {
                 val thumbnailUri = portalItem.thumbnail?.let { thumbnail ->
-                    thumbnail.load()
+                    //thumbnail.load()
                     thumbnail.image?.bitmap?.let { bitmap ->
                         createThumbnail(
                             portalItem.itemId,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
@@ -9,7 +9,6 @@ import com.arcgismaps.toolkit.featureformsapp.data.local.ItemCacheEntry
 import com.arcgismaps.toolkit.featureformsapp.data.local.ItemData
 import com.arcgismaps.toolkit.featureformsapp.data.network.ItemRemoteDataSource
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -27,7 +26,6 @@ import kotlinx.coroutines.withContext
  * mechanism.
  */
 class PortalItemRepository(
-    scope: CoroutineScope,
     private val dispatcher: CoroutineDispatcher,
     private val remoteDataSource: ItemRemoteDataSource,
     private val itemCacheDao: ItemCacheDao,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/local/ItemCacheDao.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/local/ItemCacheDao.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.Flow
 data class ItemCacheEntry(
     @PrimaryKey val itemId: String,
     val json: String,
-    val thumbnailUri: String,
     val portalUrl: String
 )
 
@@ -83,7 +82,7 @@ interface ItemCacheDao {
 /**
  * The room database that contains the ItemCacheEntry table.
  */
-@Database(entities = [ItemCacheEntry::class], version = 1, exportSchema = false)
+@Database(entities = [ItemCacheEntry::class], version = 2, exportSchema = false)
 abstract class ItemCacheDatabase : RoomDatabase() {
     abstract fun itemCacheDao() : ItemCacheDao
 }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/di/DataModule.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/di/DataModule.kt
@@ -30,6 +30,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
@@ -67,12 +68,13 @@ class DataModule {
     @Singleton
     @PortalItemRepo
     internal fun providePortalItemRepository(
+        @ApplicationScope scope: CoroutineScope,
         @IoDispatcher dispatcher: CoroutineDispatcher,
         @ItemRemoteSource remoteDataSource: ItemRemoteDataSource,
         @ItemCache itemCacheDao: ItemCacheDao,
         @ApplicationContext context: Context
     ): PortalItemRepository =
-        PortalItemRepository(dispatcher, remoteDataSource, itemCacheDao, context.filesDir.absolutePath)
+        PortalItemRepository(scope, dispatcher, remoteDataSource, itemCacheDao, context.filesDir.absolutePath)
 
     @Singleton
     @Provides

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/di/DataModule.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/di/DataModule.kt
@@ -30,7 +30,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
@@ -68,13 +67,12 @@ class DataModule {
     @Singleton
     @PortalItemRepo
     internal fun providePortalItemRepository(
-        @ApplicationScope scope: CoroutineScope,
         @IoDispatcher dispatcher: CoroutineDispatcher,
         @ItemRemoteSource remoteDataSource: ItemRemoteDataSource,
         @ItemCache itemCacheDao: ItemCacheDao,
         @ApplicationContext context: Context
     ): PortalItemRepository =
-        PortalItemRepository(scope, dispatcher, remoteDataSource, itemCacheDao, context.filesDir.absolutePath)
+        PortalItemRepository(dispatcher, remoteDataSource, itemCacheDao, context.filesDir.absolutePath)
 
     @Singleton
     @Provides

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/AsyncImage.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/AsyncImage.kt
@@ -35,6 +35,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.launch
 
+/**
+ * Loads an image asynchronously using the [ImageLoader].
+ */
 @Composable
 fun AsyncImage(
     imageLoader: ImageLoader,
@@ -56,6 +59,14 @@ fun AsyncImage(
     )
 }
 
+/**
+ * A model to asynchronously load the image from a [LoadableImage]. Once the loading is complete
+ * the loaded image is presented via [image] State.
+ *
+ * @param loadable the [LoadableImage] to load.
+ * @param scope the CoroutineScope to run the loading job on.
+ * @param placeholder the placeholder image to show until the loading is complete.
+ */
 class ImageLoader(
     private val loadable: LoadableImage,
     scope: CoroutineScope,
@@ -73,11 +84,8 @@ class ImageLoader(
     private suspend fun load() {
         loadable.load().onSuccess {
             loadable.image?.let {
-                _image.value = it.toPainter()
+                _image.value = BitmapPainter(it.bitmap.asImageBitmap())
             }
         }
     }
 }
-
-fun BitmapDrawable.toPainter() = BitmapPainter(bitmap.asImageBitmap())
-

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/AsyncImage.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/AsyncImage.kt
@@ -22,7 +22,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
@@ -36,14 +39,20 @@ import kotlinx.coroutines.launch
 fun AsyncImage(
     imageLoader: ImageLoader,
     modifier: Modifier = Modifier,
-    contentScale: ContentScale = ContentScale.Fit
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null
 ) {
     val painter = imageLoader.image.value
     Image(
         painter = painter,
         contentDescription = null,
         modifier = modifier,
-        contentScale = contentScale
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter
     )
 }
 

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/AsyncImage.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/AsyncImage.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureformsapp.screens.browse
+
+import android.graphics.drawable.BitmapDrawable
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import com.arcgismaps.portal.LoadableImage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+import kotlinx.coroutines.launch
+
+@Composable
+fun AsyncImage(
+    imageLoader: ImageLoader,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit
+) {
+    val painter = imageLoader.image.value
+    Image(
+        painter = painter,
+        contentDescription = null,
+        modifier = modifier,
+        contentScale = contentScale
+    )
+}
+
+class ImageLoader(
+    private val loadable: LoadableImage,
+    scope: CoroutineScope,
+    placeholder: Painter,
+) {
+    private val _image: MutableState<Painter> = mutableStateOf(placeholder)
+    val image: State<Painter> = _image
+
+    init {
+        scope.launch(start = UNDISPATCHED) {
+            load()
+        }
+    }
+
+    private suspend fun load() {
+        loadable.load().onSuccess {
+            loadable.image?.let {
+                _image.value = it.toPainter()
+            }
+        }
+    }
+}
+
+fun BitmapDrawable.toPainter() = BitmapPainter(bitmap.asImageBitmap())
+

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
@@ -278,7 +278,7 @@ fun AppSearchBar(
                     Icon(
                         imageVector = Icons.Default.AccountCircle,
                         contentDescription = null,
-                        modifier = Modifier.size(35.dp)
+                        modifier = Modifier.size(30.dp)
                     )
                 }
                 MaterialTheme(

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.with
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -32,7 +31,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.Close
@@ -140,7 +138,7 @@ fun MapListScreen(
                                 lastModified = item.portalItem.modified?.format("MMM dd yyyy")
                                     ?: "",
                                 shareType = item.portalItem.access.encoding.uppercase(Locale.getDefault()),
-                                thumbnailUri = item.thumbnailUri.ifEmpty { null },
+                                thumbnailUri = item.thumbnailUri,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .height(100.dp)
@@ -179,8 +177,8 @@ fun MapListItem(
     title: String,
     lastModified: String,
     shareType: String,
+    thumbnailUri: String,
     modifier: Modifier = Modifier,
-    thumbnailUri: String? = null,
     onClick: () -> Unit = {}
 ) {
     Row(
@@ -190,26 +188,17 @@ fun MapListItem(
     ) {
         Spacer(modifier = Modifier.width(20.dp))
         Box {
-            thumbnailUri?.let {
-                AsyncImage(
-                    model = it,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxHeight(0.8f)
-                        .aspectRatio(16 / 9f)
-                        .clip(RoundedCornerShape(15.dp)),
-                    contentScale = ContentScale.Crop
-                )
-            } // if thumbnail is empty then use the default map placeholder
-                ?: Image(
-                    painter = painterResource(id = R.drawable.ic_default_map),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxHeight(0.8f)
-                        .aspectRatio(16 / 9f)
-                        .clip(RoundedCornerShape(15.dp)),
-                    contentScale = ContentScale.Crop
-                )
+            AsyncImage(
+                model = thumbnailUri,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxHeight(0.8f)
+                    .aspectRatio(16 / 9f)
+                    .clip(RoundedCornerShape(15.dp)),
+                contentScale = ContentScale.Crop,
+                placeholder = painterResource(id = R.drawable.ic_default_map),
+                error = painterResource(id = R.drawable.ic_default_map)
+            )
             Box(
                 modifier = Modifier
                     .padding(5.dp)
@@ -289,7 +278,7 @@ fun AppSearchBar(
                     Icon(
                         imageVector = Icons.Default.AccountCircle,
                         contentDescription = null,
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(35.dp)
                     )
                 }
                 MaterialTheme(
@@ -387,7 +376,8 @@ fun MapListItemPreview() {
         title = "Water Utility",
         lastModified = "June 1 2023",
         shareType = "Public",
-        modifier = Modifier.size(width = 485.dp, height = 100.dp)
+        modifier = Modifier.size(width = 485.dp, height = 100.dp),
+        thumbnailUri = ""
     )
 }
 

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
@@ -1,11 +1,6 @@
 package com.arcgismaps.toolkit.featureformsapp.screens.browse
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.with
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -80,7 +75,6 @@ import java.util.Locale
  * Displays a list of PortalItems using the [mapListViewModel]. Provides a callback [onItemClick]
  * when an item is tapped.
  */
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun MapListScreen(
     modifier: Modifier = Modifier,
@@ -109,12 +103,9 @@ fun MapListScreen(
         )
         // use a cross fade animation to show a loading indicator when the data is loading
         // and transition to the list of portalItems once loaded
-        AnimatedContent(
+        Crossfade(
             targetState = uiState.isLoading,
             modifier = Modifier.padding(top = 88.dp),
-            transitionSpec = {
-                fadeIn(animationSpec = tween(1000)) with fadeOut()
-            },
             label = "list fade"
         ) { state ->
             when (state) {
@@ -138,17 +129,17 @@ fun MapListScreen(
                             uiState.data
                         ) { item ->
                             MapListItem(
-                                title = item.portalItem.title,
-                                lastModified = item.portalItem.modified?.format("MMM dd yyyy")
+                                title = item.title,
+                                lastModified = item.modified?.format("MMM dd yyyy")
                                     ?: "",
-                                shareType = item.portalItem.access.encoding.uppercase(Locale.getDefault()),
-                                thumbnail = item.portalItem.thumbnail,
+                                shareType = item.access.encoding.uppercase(Locale.getDefault()),
+                                thumbnail = item.thumbnail,
                                 placeholder = itemThumbnailPlaceholder,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .height(100.dp)
                             ) {
-                                onItemClick(item.portalItem.itemId)
+                                onItemClick(item.itemId)
                             }
                         }
                     }
@@ -243,7 +234,7 @@ fun MapListItemThumbnail(
                 placeholder = placeholder,
             ),
             modifier = modifier,
-            contentScale = contentScale
+            contentScale =contentScale
         )
     } ?: Image(
         painter = placeholder,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
@@ -241,7 +241,7 @@ fun AppSearchBar(
     username: String,
     modifier: Modifier = Modifier,
     onQueryChange: (String) -> Unit = {},
-    onRefresh: (Boolean) -> Unit = {},
+    onRefresh: () -> Unit = {},
     onSignOut: () -> Unit = {}
 ) {
     val focusManager = LocalFocusManager.current
@@ -322,21 +322,10 @@ fun AppSearchBar(
                             enabled = !isLoading,
                             onClick = {
                                 expanded = false
-                                onRefresh(false)
+                                onRefresh()
                             },
                             leadingIcon = {
                                 Icon(imageVector = Icons.Default.Refresh, contentDescription = null)
-                            }
-                        )
-                        DropdownMenuItem(
-                            text = { Text(text = "Clear Cache") },
-                            enabled = !isLoading,
-                            onClick = {
-                                expanded = false
-                                onRefresh(true)
-                            },
-                            leadingIcon = {
-                                Icon(imageVector = Icons.Default.Delete, contentDescription = null)
                             }
                         )
                         DropdownMenuItem(

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListScreen.kt
@@ -227,12 +227,15 @@ fun MapListItemThumbnail(
 ) {
     val scope = rememberCoroutineScope()
     loadableImage?.let {
-        AsyncImage(
-            imageLoader = ImageLoader(
+        val imageLoader = remember {
+            ImageLoader(
                 loadable = it,
                 scope = scope,
                 placeholder = placeholder,
-            ),
+            )
+        }
+        AsyncImage(
+            imageLoader = imageLoader,
             modifier = modifier,
             contentScale =contentScale
         )

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListViewModel.kt
@@ -66,7 +66,7 @@ class MapListViewModel @Inject constructor(
             // if the data is empty, refresh it
             // this is used to identify first launch
             if (portalItemRepository.getItemCount() == 0) {
-                refresh(false)
+                refresh()
             }
         }
     }
@@ -80,16 +80,15 @@ class MapListViewModel @Inject constructor(
     }
 
     /**
-     * Refreshes the data. [forceUpdate] clears the local cache.
+     * Refreshes the data.
      */
-    fun refresh(forceUpdate: Boolean) {
+    fun refresh() {
         if (!_isLoading.value) {
             viewModelScope.launch {
                 _isLoading.emit(true)
                 portalItemRepository.refresh(
                     portalSettings.getPortalUrl(),
-                    portalSettings.getPortalConnection(),
-                    forceUpdate
+                    portalSettings.getPortalConnection()
                 )
                 _isLoading.emit(false)
             }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/MapListViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arcgismaps.ArcGISEnvironment
-import com.arcgismaps.toolkit.featureformsapp.data.PortalItemData
+import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.toolkit.featureformsapp.data.PortalItemRepository
 import com.arcgismaps.toolkit.featureformsapp.data.PortalSettings
 import com.arcgismaps.toolkit.featureformsapp.navigation.NavigationRoute
@@ -22,7 +22,7 @@ import javax.inject.Inject
 data class MapListUIState(
     val isLoading: Boolean,
     val searchText: String,
-    val data: List<PortalItemData>
+    val data: List<PortalItem>
 )
 
 /**
@@ -51,8 +51,8 @@ class MapListViewModel @Inject constructor(
         ) { isLoading, searchText, portalItemData ->
             val data = portalItemData.filter {
                 searchText.isEmpty()
-                    || it.portalItem.title.uppercase().contains(searchText.uppercase())
-                    || it.portalItem.itemId.contains(searchText)
+                    || it.title.uppercase().contains(searchText.uppercase())
+                    || it.itemId.contains(searchText)
             }
             MapListUIState(isLoading, searchText, data)
         }.stateIn(


### PR DESCRIPTION
### Summary of changes

- Portal items and their thumbnail are now loaded in parallel reducing overall loading times on average from ~40s to ~10s (first load). 
- Added a new composable `AsyncImage` which uses a model class `ImageLoader` to load images asynchronously.
    - Thumbnails are now loaded directly using `PortalItem.thumbnail` and `AsyncImage` instead of using Coil to load images stored on disk.
    - Coil cannot be used to directly load the thumbnails from its urls when the PortalItem is private because it does have the authentication credentials to access those resources.
    - This is similar to the `AsyncImageView` of the swift toolkit [component](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Sources/ArcGISToolkit/Utility/AsyncImageView.swift).
    - One minor downside to this is the thumbnails are not loaded when the device is offline. But this could be fixed by adding a local cache layer to store thumbnails.
- Removed the option of a "clear cache". By default the local cache will be deleted when a "refresh" is performed.
- Cleaned up and optimized some code with added comments.
- Removed Coil dependency.