### PR TITLE
`Forms`: Common base state

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -51,6 +51,7 @@ import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.BaseGroupState
+import com.arcgismaps.toolkit.featureforms.components.base.FormElementState
 import com.arcgismaps.toolkit.featureforms.components.base.rememberBaseGroupState
 import com.arcgismaps.toolkit.featureforms.components.codedvalue.CodedValueFieldState
 import com.arcgismaps.toolkit.featureforms.components.codedvalue.rememberCodedValueFieldState
@@ -173,8 +174,7 @@ internal fun FeatureFormContent(
     }
     FeatureFormBody(
         form = form,
-        fieldStateMap = fieldStateMap,
-        groupStateMap = groupStateMap,
+        states = fieldStateMap + groupStateMap,
         modifier = modifier
     ) { state, id ->
         if (state is DateTimeFieldState) {
@@ -199,8 +199,7 @@ internal fun FeatureFormContent(
 @Composable
 private fun FeatureFormBody(
     form: FeatureForm,
-    fieldStateMap: Map<Int, BaseFieldState<*>>,
-    groupStateMap: Map<Int, BaseGroupState>,
+    states: Map<Int, FormElementState>,
     modifier: Modifier = Modifier,
     onFieldDialogRequest: ((BaseFieldState<*>, Int) -> Unit)? = null
 ) {
@@ -225,7 +224,7 @@ private fun FeatureFormBody(
             items(form.elements) { formElement ->
                 when (formElement) {
                     is FieldFormElement -> {
-                        val state = fieldStateMap[formElement.id]
+                        val state = states[formElement.id] as? BaseFieldState<*>
                         if (state != null) {
                             FieldElement(
                                 state = state,
@@ -237,10 +236,9 @@ private fun FeatureFormBody(
                     }
 
                     is GroupFormElement -> {
-                        val state = groupStateMap[formElement.id]
+                        val state = states[formElement.id] as? BaseGroupState
                         if (state != null) {
                             GroupElement(
-                                formElement,
                                 state,
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -292,7 +290,7 @@ internal fun rememberFieldStates(
     scope: CoroutineScope
 ): Map<Int, BaseFieldState<*>> {
     val stateMap = mutableMapOf<Int, BaseFieldState<*>>()
-    elements.forEach {  element ->
+    elements.forEach { element ->
         if (element is FieldFormElement) {
             val state = when (element.input) {
                 is TextBoxFormInput, is TextAreaFormInput -> {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -53,21 +53,15 @@ internal open class BaseFieldState<T>(
     initialValue: T = properties.value.value,
     scope: CoroutineScope,
     protected val onEditValue: (Any?) -> Unit,
+) : FormElementState(
+    label = properties.label,
+    description = properties.description,
+    isVisible = properties.visible
 ) {
-    /**
-     * Title for the field.
-     */
-    open val label: String = properties.label
-
     /**
      * Placeholder hint for the field.
      */
     open val placeholder: String = properties.placeholder
-    
-    /**
-     * Description text for the field.
-     */
-    val description: String = properties.description
 
     // a state flow to handle user input changes
     protected val _value = MutableStateFlow(initialValue)
@@ -89,11 +83,6 @@ internal open class BaseFieldState<T>(
      * Property that indicates if the field is required.
      */
     val isRequired: StateFlow<Boolean> = properties.required
-
-    /**
-     * Property that indicates if the field is visible.
-     */
-    val isVisible: StateFlow<Boolean> = properties.visible
    
     /**
      * Callback to update the current value of the FormTextFieldState to the given [input].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseGroupState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseGroupState.kt
@@ -47,7 +47,7 @@ internal class BaseGroupState(
         fun Saver(
             groupElement: GroupFormElement,
             fieldStates: Map<Int, BaseFieldState<*>>
-        ): Saver<BaseGroupState, Any> = Saver(
+        ): Saver<BaseGroupState, Boolean> = Saver(
             save = {
                 it.expanded.value
             },
@@ -56,7 +56,7 @@ internal class BaseGroupState(
                     label = groupElement.label,
                     description = groupElement.description,
                     isVisible = groupElement.isVisible,
-                    expanded = it as Boolean,
+                    expanded = it,
                     fieldStates = fieldStates
                 )
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseGroupState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseGroupState.kt
@@ -20,45 +20,43 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.mapping.featureforms.FormGroupState
 import com.arcgismaps.mapping.featureforms.GroupFormElement
-
-internal class GroupProperties(
-    val label: String,
-    val description: String,
-    val expanded: Boolean
-)
+import kotlinx.coroutines.flow.StateFlow
 
 internal class BaseGroupState(
-    properties: GroupProperties,
+    label: String,
+    description: String,
+    isVisible: StateFlow<Boolean>,
+    expanded: Boolean,
     val fieldStates: Map<Int, BaseFieldState<*>>
+) : FormElementState(
+    label = label,
+    description = description,
+    isVisible = isVisible
 ) {
-    val label = properties.label
+    private val _expanded = mutableStateOf(expanded)
+    val expanded: State<Boolean> = _expanded
 
-    val description = properties.description
-
-    private val _expanded = mutableStateOf(properties.expanded)
-    val expanded : State<Boolean> = _expanded
-
-    fun setExpanded(value : Boolean) {
+    fun setExpanded(value: Boolean) {
         _expanded.value = value
     }
 
     companion object {
-        fun Saver(fieldStates: Map<Int, BaseFieldState<*>>): Saver<BaseGroupState, Any> = listSaver(
+        fun Saver(
+            groupElement: GroupFormElement,
+            fieldStates: Map<Int, BaseFieldState<*>>
+        ): Saver<BaseGroupState, Any> = Saver(
             save = {
-                listOf(it.label, it.description, it.expanded.value)
+                it.expanded.value
             },
             restore = {
-                val properties = GroupProperties(
-                    label = it[0] as String,
-                    description = it[1] as String,
-                    expanded = it[2] as Boolean
-                )
                 BaseGroupState(
-                    properties = properties,
+                    label = groupElement.label,
+                    description = groupElement.description,
+                    isVisible = groupElement.isVisible,
+                    expanded = it as Boolean,
                     fieldStates = fieldStates
                 )
             }
@@ -71,14 +69,13 @@ internal fun rememberBaseGroupState(
     groupElement: GroupFormElement,
     fieldStates: Map<Int, BaseFieldState<*>>
 ): BaseGroupState = rememberSaveable(
-    saver = BaseGroupState.Saver(fieldStates)
+    saver = BaseGroupState.Saver(groupElement, fieldStates)
 ) {
     BaseGroupState(
-        properties = GroupProperties(
-            label = groupElement.label,
-            description = groupElement.description,
-            expanded = groupElement.initialState == FormGroupState.Expanded
-        ),
+        label = groupElement.label,
+        description = groupElement.description,
+        isVisible = groupElement.isVisible,
+        expanded = groupElement.initialState == FormGroupState.Expanded,
         fieldStates = fieldStates
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FormElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FormElementState.kt
@@ -17,9 +17,10 @@
 package com.arcgismaps.toolkit.featureforms.components.base
 
 import kotlinx.coroutines.flow.StateFlow
+import com.arcgismaps.mapping.featureforms.FormElement
 
 /**
- * Base state class for a [com.arcgismaps.mapping.featureforms.FormElement].
+ * Base state class for a [FormElement].
  *
  * @param label Title for the field.
  * @param description Description text for the field.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FormElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FormElementState.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.components.base
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Base state class for a [com.arcgismaps.mapping.featureforms.FormElement].
+ *
+ * @param label Title for the field.
+ * @param description Description text for the field.
+ * @param isVisible Property that indicates if the field is visible.
+ */
+public abstract class FormElementState(
+    public val label : String,
+    public val description: String,
+    public val isVisible : StateFlow<Boolean>
+)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/formelement/GroupElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/formelement/GroupElement.kt
@@ -43,19 +43,17 @@ import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.arcgismaps.mapping.featureforms.GroupFormElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.BaseGroupState
 
 @Composable
 internal fun GroupElement(
-    groupElement: GroupFormElement,
     state: BaseGroupState,
     modifier: Modifier = Modifier,
     colors: GroupElementColors = GroupElementDefaults.colors(),
     onDialogRequest: (BaseFieldState<*>, Int) -> Unit
 ) {
-    val visible by groupElement.isVisible.collectAsState()
+    val visible by state.isVisible.collectAsState()
     if (visible) {
         GroupElement(
             label = state.label,


### PR DESCRIPTION
### Summary of changes

Introduced a new `FormElementState` which is an abstract class that forms the state object for a `FormElement` type. Since in the SDK all the element types inherit from a `FormElement` this state class acts as a base class for any other derived `FormElement` state objects. This then creates the following inheritance heirarchy
   - FormElementState 
       - BaseFieldState
           - FormTextField  
           - .. other field element type states
       - BaseGroupState
       - RelationshipElement state (future)
       - AttachmentElement state (future)