### PR TITLE
SceneView current viewpoint camera

### DIFF
--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -31,8 +31,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.viewinterop.AndroidView
 import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.ArcGISScene
-import com.arcgismaps.mapping.view.Camera
 import com.arcgismaps.mapping.TimeExtent
+import com.arcgismaps.mapping.view.Camera
 import com.arcgismaps.mapping.view.DoubleTapEvent
 import com.arcgismaps.mapping.view.DownEvent
 import com.arcgismaps.mapping.view.GeoView

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.viewinterop.AndroidView
 import com.arcgismaps.mapping.ArcGISScene
+import com.arcgismaps.mapping.view.Camera
 import com.arcgismaps.mapping.view.DoubleTapEvent
 import com.arcgismaps.mapping.view.DownEvent
 import com.arcgismaps.mapping.view.LongPressEvent
@@ -58,6 +59,7 @@ import kotlinx.coroutines.launch
  * @param attributionState specifies the attribution bar's visibility, text changed and layout changed events
  * @param onNavigationChanged lambda invoked when the navigation status of the composable SceneView has changed
  * @param onInteractingChanged lambda invoked when the user starts and ends interacting with the composable SceneView
+ * @param onCurrentViewpointCameraChanged lambda invoked when the viewpoint Camera of the composable SceneView has changed
  * @param onRotate lambda invoked when a user performs a rotation gesture on the composable SceneView
  * @param onScale lambda invoked when a user performs a pinch gesture on the composable SceneView
  * @param onUp lambda invoked when the user removes all their pointers from the composable SceneView
@@ -81,6 +83,7 @@ public fun SceneView(
     attributionState: AttributionState = AttributionState(),
     onNavigationChanged: ((isNavigating: Boolean) -> Unit)? = null,
     onInteractingChanged: ((isInteracting: Boolean) -> Unit)? = null,
+    onCurrentViewpointCameraChanged: ((camera: Camera) -> Unit)? = null,
     onRotate: ((RotationChangeEvent) -> Unit)? = null,
     onScale: ((ScaleChangeEvent) -> Unit)? = null,
     onUp: ((UpEvent) -> Unit)? = null,
@@ -129,6 +132,7 @@ public fun SceneView(
         sceneView,
         onNavigationChanged,
         onInteractingChanged,
+        onCurrentViewpointCameraChanged,
         onRotate,
         onScale,
         onUp,
@@ -165,6 +169,7 @@ private fun SceneViewEventHandler(
     sceneView: SceneView,
     onNavigationChanged: ((isNavigating: Boolean) -> Unit)?,
     onInteractingChanged: ((isInteracting: Boolean) -> Unit)?,
+    onCurrentViewpointCameraChanged: ((camera: Camera) ->Unit)?,
     onRotate: ((RotationChangeEvent) -> Unit)?,
     onScale: ((ScaleChangeEvent) -> Unit)?,
     onUp: ((UpEvent) -> Unit)?,
@@ -177,6 +182,7 @@ private fun SceneViewEventHandler(
 ) {
     val currentOnNavigationChanged by rememberUpdatedState(onNavigationChanged)
     val currentOnInteractingChanged by rememberUpdatedState(onInteractingChanged)
+    val currentOnViewpointCameraChanged by rememberUpdatedState(onCurrentViewpointCameraChanged)
     val currentOnRotate by rememberUpdatedState(onRotate)
     val currentOnScale by rememberUpdatedState(onScale)
     val currentOnUp by rememberUpdatedState(onUp)
@@ -191,6 +197,11 @@ private fun SceneViewEventHandler(
         launch {
             sceneView.navigationChanged.collect {
                 currentOnNavigationChanged?.invoke(it)
+            }
+        }
+        launch {
+            sceneView.viewpointChanged.collect {
+                currentOnViewpointCameraChanged?.invoke(sceneView.getCurrentViewpointCamera())
             }
         }
         launch(Dispatchers.Main.immediate) {

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -169,7 +169,7 @@ private fun SceneViewEventHandler(
     sceneView: SceneView,
     onNavigationChanged: ((isNavigating: Boolean) -> Unit)?,
     onInteractingChanged: ((isInteracting: Boolean) -> Unit)?,
-    onCurrentViewpointCameraChanged: ((camera: Camera) ->Unit)?,
+    onCurrentViewpointCameraChanged: ((camera: Camera) -> Unit)?,
     onRotate: ((RotationChangeEvent) -> Unit)?,
     onScale: ((ScaleChangeEvent) -> Unit)?,
     onUp: ((UpEvent) -> Unit)?,

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -69,7 +69,7 @@ import kotlinx.coroutines.launch
  * @param onSpatialReferenceChanged lambda invoked when the spatial reference of the composable SceneView has changed
  * @param onLayerViewStateChanged lambda invoked when the composable SceneView's layer view state is changed
  * @param onInteractingChanged lambda invoked when the user starts and ends interacting with the composable SceneView
- * @param onCurrentViewpointCameraChanged lambda invoked when the viewpoint Camera of the composable SceneView has changed
+ * @param onCurrentViewpointCameraChanged lambda invoked when the viewpoint camera of the composable SceneView has changed
  * @param onRotate lambda invoked when a user performs a rotation gesture on the composable SceneView
  * @param onScale lambda invoked when a user performs a pinch gesture on the composable SceneView
  * @param onUp lambda invoked when the user removes all their pointers from the composable SceneView

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneViewProxy.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneViewProxy.kt
@@ -18,6 +18,7 @@
 package com.arcgismaps.toolkit.geocompose
 
 import com.arcgismaps.mapping.view.Camera
+import com.arcgismaps.mapping.view.SceneView
 
 /**
  * Used to perform operations on a composable [SceneView].
@@ -38,9 +39,21 @@ public class SceneViewProxy : GeoViewProxy("SceneView") {
      *
      * @since 200.4.0
      */
-    private var sceneView: com.arcgismaps.mapping.view.SceneView? = null
+    private var _sceneView: SceneView? = null
         set(value) {
             setGeoView(value)
+            field = value
+        }
+
+    /**
+     * Retrieve the camera displaying the current viewpoint, or return null if none is available.
+     *
+     * @return a [Camera]
+     * @since 200.4.0
+     */
+    public val currentViewpointCamera: Camera?
+        get() {
+            return this._sceneView?.getCurrentViewpointCamera()
         }
 
     /**
@@ -49,17 +62,7 @@ public class SceneViewProxy : GeoViewProxy("SceneView") {
      *
      * @since 200.4.0
      */
-    internal fun setSceneView(sceneView: com.arcgismaps.mapping.view.SceneView?) {
-        this.sceneView = sceneView
-    }
-
-    /**
-     * Retrieve the camera displaying the current viewpoint, or return null if none is available.
-     *
-     * @return a [Camera]
-     * @since 200.4.0
-     */
-    public fun getCurrentViewpointCameraOrNull(): Camera? {
-      return this.sceneView?.getCurrentViewpointCamera()
+    internal fun setSceneView(sceneView: SceneView?) {
+        this._sceneView = sceneView
     }
 }

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneViewProxy.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneViewProxy.kt
@@ -17,9 +17,6 @@
 
 package com.arcgismaps.toolkit.geocompose
 
-import com.arcgismaps.mapping.view.Camera
-import com.arcgismaps.mapping.view.SceneView
-
 /**
  * Used to perform operations on a composable [SceneView].
  *
@@ -39,21 +36,9 @@ public class SceneViewProxy : GeoViewProxy("SceneView") {
      *
      * @since 200.4.0
      */
-    private var _sceneView: SceneView? = null
+    private var sceneView: com.arcgismaps.mapping.view.SceneView? = null
         set(value) {
             setGeoView(value)
-            field = value
-        }
-
-    /**
-     * Retrieve the camera displaying the current viewpoint, or return null if none is available.
-     *
-     * @return a [Camera]
-     * @since 200.4.0
-     */
-    public val currentViewpointCamera: Camera?
-        get() {
-            return this._sceneView?.getCurrentViewpointCamera()
         }
 
     /**
@@ -62,7 +47,7 @@ public class SceneViewProxy : GeoViewProxy("SceneView") {
      *
      * @since 200.4.0
      */
-    internal fun setSceneView(sceneView: SceneView?) {
-        this._sceneView = sceneView
+    internal fun setSceneView(sceneView: com.arcgismaps.mapping.view.SceneView?) {
+        this.sceneView = sceneView
     }
 }

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneViewProxy.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneViewProxy.kt
@@ -17,6 +17,8 @@
 
 package com.arcgismaps.toolkit.geocompose
 
+import com.arcgismaps.mapping.view.Camera
+
 /**
  * Used to perform operations on a composable [SceneView].
  *
@@ -49,5 +51,15 @@ public class SceneViewProxy : GeoViewProxy("SceneView") {
      */
     internal fun setSceneView(sceneView: com.arcgismaps.mapping.view.SceneView?) {
         this.sceneView = sceneView
+    }
+
+    /**
+     * Retrieve the camera displaying the current viewpoint, or return null if none is available.
+     *
+     * @return a [Camera]
+     * @since 200.4.0
+     */
+    public fun getCurrentViewpointCameraOrNull(): Camera? {
+      return this.sceneView?.getCurrentViewpointCamera()
     }
 }


### PR DESCRIPTION
- Adds the lambda `onCurrentViewpointCameraChanged: ((camera: Camera) -> Unit)? = null` to the Composable SceneView
- Does the ad hoc testing in the local SceneView App to check the callback:
```
 onCurrentViewpointCameraChanged = { camera ->
                  ....
                }
```