### PR TITLE
The mapView property needs to be assigned specifically in MapViewProxy class

### DIFF
--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapViewProxy.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapViewProxy.kt
@@ -44,6 +44,7 @@ public class MapViewProxy : GeoViewProxy("MapView") {
     private var mapView: com.arcgismaps.mapping.view.MapView? = null
         set(value) {
             setGeoView(value)
+            field = value
         }
 
     /**

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneViewProxy.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneViewProxy.kt
@@ -39,6 +39,7 @@ public class SceneViewProxy : GeoViewProxy("SceneView") {
     private var sceneView: com.arcgismaps.mapping.view.SceneView? = null
         set(value) {
             setGeoView(value)
+            field = value
         }
 
     /**


### PR DESCRIPTION
The mapView property needs to be assigned in the mapViewProxy class
The sceneView property needs to be assigned in the sceneViewProxy class