### PR TITLE
SceneView: add CameraController param

### DIFF
--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -32,9 +32,11 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.ArcGISScene
 import com.arcgismaps.mapping.TimeExtent
+import com.arcgismaps.mapping.view.CameraController
 import com.arcgismaps.mapping.view.DoubleTapEvent
 import com.arcgismaps.mapping.view.DownEvent
 import com.arcgismaps.mapping.view.GeoView
+import com.arcgismaps.mapping.view.GlobeCameraController
 import com.arcgismaps.mapping.view.LongPressEvent
 import com.arcgismaps.mapping.view.PanChangeEvent
 import com.arcgismaps.mapping.view.RotationChangeEvent
@@ -62,6 +64,7 @@ import kotlinx.coroutines.launch
  * @param viewLabelProperties the [ViewLabelProperties] used by the composable SceneView
  * @param selectionProperties the [SelectionProperties] used by the composable SceneView
  * @param attributionState specifies the attribution bar's visibility, text changed and layout changed events
+ * @param cameraController the [CameraController] to manage the position, orientation, and movement of the camera
  * @param timeExtent the [TimeExtent] used by the composable SceneView
  * @param onTimeExtentChanged lambda invoked when the composable SceneView's [TimeExtent] is changed
  * @param onNavigationChanged lambda invoked when the navigation status of the composable SceneView has changed
@@ -91,6 +94,7 @@ public fun SceneView(
     viewLabelProperties: ViewLabelProperties = ViewLabelProperties(),
     selectionProperties: SelectionProperties = SelectionProperties(),
     attributionState: AttributionState = AttributionState(),
+    cameraController: CameraController = GlobeCameraController(),
     timeExtent: TimeExtent? = null,
     onTimeExtentChanged: ((TimeExtent?) -> Unit)? = null,
     onNavigationChanged: ((isNavigating: Boolean) -> Unit)? = null,
@@ -120,6 +124,7 @@ public fun SceneView(
             it.labeling = viewLabelProperties
             it.selectionProperties = selectionProperties
             it.setTimeExtent(timeExtent)
+            it.cameraController = cameraController
         })
 
     DisposableEffect(Unit) {


### PR DESCRIPTION
Adds the `cameraController` parameter.

Note that this interacts with the viewpoint set on the SceneView via `SceneViewpointOperation`, but it works the same as `setViewpoint` methods on the view-based SceneView. I considered adding extra doc to explain what will happen, but I think the doc on `OrbitLocationCameraController` and `OrbitGeoElementCameraController` do a good enough job of explaining that setting the viewpoint when they are active won't work, and I confirmed that that's the case here with ad hoc tests.