### PR TITLE
Update OAuthUserSignInActivity launch mode to singleTask. 

### DIFF
--- a/microapps/AuthenticationApp/app/src/main/AndroidManifest.xml
+++ b/microapps/AuthenticationApp/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
             android:name="com.arcgismaps.toolkit.authentication.OAuthUserSignInActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
             android:exported="true"
-            android:launchMode="singleTop" >
+            android:launchMode="singleTask" >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/toolkit/authentication/README.md
+++ b/toolkit/authentication/README.md
@@ -47,7 +47,7 @@ You will also need to declare the `OAuthUserSignInActivity` in your app's manife
 	android:name="com.arcgismaps.toolkit.authentication.OAuthUserSignInActivity"
 	android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
 	android:exported="true"
-	android:launchMode="singleTop" >
+	android:launchMode="singleTask" >
 	<intent-filter>
 		<action android:name="android.intent.action.VIEW" />
 
@@ -143,7 +143,7 @@ override fun onResume() {
 }
 ```
 
-Please note that your app's activity must have a `launchMode` of `singleTop` for OAuth authentication to work.
+Please note that your app's activity must have a `launchMode` of `singleTask` for OAuth authentication to work.
 
 ### Launch OAuth Prompts in Incognito Mode
 

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthUserSignInActivity.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthUserSignInActivity.kt
@@ -45,14 +45,14 @@ private const val RESULT_CODE_CANCELED = 2
  * The most common use case is that completing an OAuth challenge by signing in using the CustomTabs
  * browser should redirect back to this activity immediately and allow the `OAuthAuthenticator` to
  * immediately handle the completion of the challenge. In this case, the activity should be declared
- * in the manifest using `launchMode="singleTop"` and an `intent-filter` should be specified:
+ * in the manifest using `launchMode="singleTask"` and an `intent-filter` should be specified:
  *
  * ```
  * <activity
  * android:name="com.arcgismaps.toolkit.authentication.OAuthUserSignInActivity"
  * android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
  * android:exported="true"
- * android:launchMode="singleTop" >
+ * android:launchMode="singleTask" >
  *   <intent-filter>
  *     <action android:name="android.intent.action.VIEW" />
  *


### PR DESCRIPTION
Fixes issues with FireFox not redirecting back to `OAuthUserSignInActivity` by changing the launch mode from `singleTop` to `singleTask`

Here's the doc on `singleTask`:
> The system creates the activity at the root of a new task or locates the activity on an existing task with the same affinity. If an instance of the activity already exists, the system routes the intent to the existing instance through a call to its [onNewIntent()](https://developer.android.com/reference/android/app/Activity#onNewIntent(android.content.Intent)) method, rather than creating a new instance. Meanwhile all of the other activities on top of it are destroyed.

Since Activities launched in the same app have affinity to each other, the `OAuthUserSignInActivity` will not create a new task and instead use the same task where it is launched. 