### PR TITLE
SceneView: ImageOverlays

### DIFF
--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/AnalysisOverlayCollection.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/AnalysisOverlayCollection.kt
@@ -17,11 +17,8 @@
 
 package com.arcgismaps.toolkit.geocompose
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import com.arcgismaps.mapping.view.AnalysisOverlay
-import com.arcgismaps.mapping.view.SceneView
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -101,9 +98,9 @@ public class AnalysisOverlayCollection : Iterable<AnalysisOverlay> {
      *
      * @since 200.4.0
      */
-    internal sealed class ChangedEvent() {
+    internal sealed class ChangedEvent {
         class Added(val element: AnalysisOverlay) : ChangedEvent()
         class Removed(val element: AnalysisOverlay) : ChangedEvent()
-        object Cleared : ChangedEvent()
+        data object Cleared : ChangedEvent()
     }
 }

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/GraphicsOverlayCollection.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/GraphicsOverlayCollection.kt
@@ -102,10 +102,10 @@ public class GraphicsOverlayCollection : Iterable<GraphicsOverlay> {
      *
      * @since 200.4.0
      */
-    internal sealed class ChangedEvent() {
+    internal sealed class ChangedEvent {
         class Added(val element: GraphicsOverlay) : ChangedEvent()
         class Removed(val element: GraphicsOverlay) : ChangedEvent()
-        object Cleared : ChangedEvent()
+        data object Cleared : ChangedEvent()
     }
 }
 

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
@@ -20,7 +20,6 @@ package com.arcgismaps.toolkit.geocompose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.remember
 import com.arcgismaps.mapping.view.ImageOverlay
 import com.arcgismaps.mapping.view.SceneView
 import kotlinx.coroutines.channels.BufferOverflow
@@ -29,7 +28,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
 /**
- * A collection class to encapsulate the [ImageOverlay] list used by the [com.arcgismaps.toolkit.geocompose.MapView]
+ * A collection class to encapsulate the [ImageOverlay] list used by the [com.arcgismaps.toolkit.geocompose.SceneView]
  *
  * @since 200.4.0
  */
@@ -97,7 +96,7 @@ public class ImageOverlayCollection : Iterable<ImageOverlay> {
     }
 
     /**
-     * Sealed class used to notify the compose MapView to update the GraphicOverlays on the
+     * Sealed class used to notify the compose SceneView to update the ImageOverlays on the
      * type of [ChangedEvent].
      *
      * @since 200.4.0
@@ -109,9 +108,8 @@ public class ImageOverlayCollection : Iterable<ImageOverlay> {
     }
 }
 
-
 /**
- * Update the view-based [geoView]'s imageOverlays property to reflect changes made to the
+ * Update the view-based [SceneView]'s imageOverlays property to reflect changes made to the
  * [imageOverlayCollection] based on the type of [ImageOverlayCollection.ChangedEvent]
  *
  * @since 200.4.0
@@ -122,7 +120,7 @@ internal fun ImageOverlaysUpdater(
     sceneView: SceneView
 ) {
     LaunchedEffect(imageOverlayCollection) {
-        // sync up the GeoView with the new graphics overlays
+        // sync up the GeoView with the new image overlays
         sceneView.imageOverlays.clear()
         imageOverlayCollection.forEach {
             sceneView.imageOverlays.add(it)

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
@@ -1,0 +1,164 @@
+/*
+ *  Copyright 2023 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.arcgismaps.toolkit.geocompose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import com.arcgismaps.mapping.view.ImageOverlay
+import com.arcgismaps.mapping.view.SceneView
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * A collection class to encapsulate the [ImageOverlay] list used by the [com.arcgismaps.toolkit.geocompose.MapView]
+ *
+ * @since 200.4.0
+ */
+@Stable
+public class ImageOverlayCollection : Iterable<ImageOverlay> {
+
+    private val imageOverlays = mutableListOf<ImageOverlay>()
+
+    private val _changed: MutableSharedFlow<ChangedEvent> = MutableSharedFlow(
+        extraBufferCapacity = Int.MAX_VALUE,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    /**
+     * [SharedFlow] used to emit changes made to the [imageOverlays] list
+     */
+    internal val changed: SharedFlow<ChangedEvent> = _changed.asSharedFlow()
+
+    override fun iterator(): Iterator<ImageOverlay> {
+        return imageOverlays.iterator()
+    }
+
+    /**
+     * Add a [imageOverlay] to this ImageOverlayCollection.
+     *
+     * @return if the add operation succeeds, return true.
+     * @since 200.4.0
+     */
+    public fun add(imageOverlay: ImageOverlay): Boolean {
+        return if (imageOverlays.add(imageOverlay)) {
+            _changed.tryEmit(ChangedEvent.Added(imageOverlay))
+            true
+        } else false
+    }
+
+    /**
+     * Remove a [imageOverlay] from this ImageOverlayCollection.
+     *
+     * @return if the remove operation succeeds, return true.
+     * @since 200.4.0
+     */
+    public fun remove(imageOverlay: ImageOverlay): Boolean {
+        return if (imageOverlays.remove(imageOverlay)) {
+            _changed.tryEmit(ChangedEvent.Removed(imageOverlay))
+            true
+        } else false
+    }
+
+    /**
+     * Returns the number of graphics overlays in this ImageOverlayCollection.
+     *
+     * @since 200.4.0
+     */
+    public val size: Int
+        get() = imageOverlays.size
+
+    /**
+     * Clears all graphics overlays from this ImageOverlayCollection.
+     *
+     * @since 200.4.0
+     */
+    public fun clear() {
+        imageOverlays.clear()
+        _changed.tryEmit(ChangedEvent.Cleared)
+    }
+
+    /**
+     * Sealed class used to notify the compose MapView to update the GraphicOverlays on the
+     * type of [ChangedEvent].
+     *
+     * @since 200.4.0
+     */
+    internal sealed class ChangedEvent() {
+        class Added(val element: ImageOverlay) : ChangedEvent()
+        class Removed(val element: ImageOverlay) : ChangedEvent()
+        object Cleared : ChangedEvent()
+    }
+}
+
+
+/**
+ * Update the view-based [geoView]'s imageOverlays property to reflect changes made to the
+ * [imageOverlayCollection] based on the type of [ImageOverlayCollection.ChangedEvent]
+ *
+ * @since 200.4.0
+ */
+@Composable
+internal fun ImageOverlaysUpdater(
+    imageOverlayCollection: ImageOverlayCollection,
+    sceneView: SceneView
+) {
+    LaunchedEffect(imageOverlayCollection) {
+        // sync up the GeoView with the new graphics overlays
+        sceneView.imageOverlays.clear()
+        imageOverlayCollection.forEach {
+            sceneView.imageOverlays.add(it)
+        }
+        // start observing imageOverlays for subsequent changes
+        imageOverlayCollection.changed.collect { changedEvent ->
+            when (changedEvent) {
+                // On ImageOverlay added:
+                is ImageOverlayCollection.ChangedEvent.Added ->
+                    sceneView.imageOverlays.add(changedEvent.element)
+
+                // On ImageOverlay removed:
+                is ImageOverlayCollection.ChangedEvent.Removed ->
+                    sceneView.imageOverlays.remove(changedEvent.element)
+
+                // On ImageOverlays cleared:
+                is ImageOverlayCollection.ChangedEvent.Cleared ->
+                    sceneView.imageOverlays.clear()
+            }
+        }
+    }
+}
+
+/**
+ * Create and [remember] a [ImageOverlayCollection].
+ * [init] will be called when the [ImageOverlayCollection] is first created to configure its
+ * initial state.
+ *
+ * @param key invalidates the remembered ImageOverlayCollection if different from the previous composition
+ * @param init called when the [ImageOverlayCollection] is created to configure its initial state
+ * @since 200.4.0
+ */
+@Composable
+public inline fun rememberImageOverlayCollection(
+    key: Any? = null,
+    crossinline init: ImageOverlayCollection.() -> Unit = {}
+): ImageOverlayCollection = remember(key) {
+    ImageOverlayCollection().apply(init)
+}

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
@@ -107,39 +107,3 @@ public class ImageOverlayCollection : Iterable<ImageOverlay> {
         object Cleared : ChangedEvent()
     }
 }
-
-/**
- * Update the view-based [SceneView]'s imageOverlays property to reflect changes made to the
- * [imageOverlayCollection] based on the type of [ImageOverlayCollection.ChangedEvent]
- *
- * @since 200.4.0
- */
-@Composable
-internal fun ImageOverlaysUpdater(
-    imageOverlayCollection: ImageOverlayCollection,
-    sceneView: SceneView
-) {
-    LaunchedEffect(imageOverlayCollection) {
-        // sync up the GeoView with the new image overlays
-        sceneView.imageOverlays.clear()
-        imageOverlayCollection.forEach {
-            sceneView.imageOverlays.add(it)
-        }
-        // start observing imageOverlays for subsequent changes
-        imageOverlayCollection.changed.collect { changedEvent ->
-            when (changedEvent) {
-                // On ImageOverlay added:
-                is ImageOverlayCollection.ChangedEvent.Added ->
-                    sceneView.imageOverlays.add(changedEvent.element)
-
-                // On ImageOverlay removed:
-                is ImageOverlayCollection.ChangedEvent.Removed ->
-                    sceneView.imageOverlays.remove(changedEvent.element)
-
-                // On ImageOverlays cleared:
-                is ImageOverlayCollection.ChangedEvent.Cleared ->
-                    sceneView.imageOverlays.clear()
-            }
-        }
-    }
-}

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
@@ -17,11 +17,8 @@
 
 package com.arcgismaps.toolkit.geocompose
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import com.arcgismaps.mapping.view.ImageOverlay
-import com.arcgismaps.mapping.view.SceneView
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -101,9 +98,9 @@ public class ImageOverlayCollection : Iterable<ImageOverlay> {
      *
      * @since 200.4.0
      */
-    internal sealed class ChangedEvent() {
+    internal sealed class ChangedEvent {
         class Added(val element: ImageOverlay) : ChangedEvent()
         class Removed(val element: ImageOverlay) : ChangedEvent()
-        object Cleared : ChangedEvent()
+        data object Cleared : ChangedEvent()
     }
 }

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/ImageOverlayCollection.kt
@@ -145,20 +145,3 @@ internal fun ImageOverlaysUpdater(
         }
     }
 }
-
-/**
- * Create and [remember] a [ImageOverlayCollection].
- * [init] will be called when the [ImageOverlayCollection] is first created to configure its
- * initial state.
- *
- * @param key invalidates the remembered ImageOverlayCollection if different from the previous composition
- * @param init called when the [ImageOverlayCollection] is created to configure its initial state
- * @since 200.4.0
- */
-@Composable
-public inline fun rememberImageOverlayCollection(
-    key: Any? = null,
-    crossinline init: ImageOverlayCollection.() -> Unit = {}
-): ImageOverlayCollection = remember(key) {
-    ImageOverlayCollection().apply(init)
-}

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -68,7 +68,7 @@ import java.time.Instant
  * @param selectionProperties the [SelectionProperties] used by the composable SceneView
  * @param attributionState specifies the attribution bar's visibility, text changed and layout changed events
  * @param cameraController the [CameraController] to manage the position, orientation, and movement of the camera
- * @param imageOverlays a collection of overlays for displaying images in the SceneView
+ * @param imageOverlays a collection of overlays for displaying images in the composable SceneView
  * @param timeExtent the [TimeExtent] used by the composable SceneView
  * @param sunTime the position of the sun in the scene view based on a specific date and time
  * @param sunLighting the type of ambient sunlight and shadows in the scene view

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -219,7 +219,7 @@ internal fun ImageOverlaysUpdater(
     sceneView: SceneView
 ) {
     LaunchedEffect(imageOverlayCollection) {
-        // sync up the GeoView with the new image overlays
+        // sync up the SceneView with the new image overlays
         sceneView.imageOverlays.clear()
         imageOverlayCollection.forEach {
             sceneView.imageOverlays.add(it)

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.launch
  * @param viewLabelProperties the [ViewLabelProperties] used by the composable SceneView
  * @param selectionProperties the [SelectionProperties] used by the composable SceneView
  * @param attributionState specifies the attribution bar's visibility, text changed and layout changed events
+ * @param imageOverlays a collection of overlays for displaying images in the SceneView
  * @param timeExtent the [TimeExtent] used by the composable SceneView
  * @param onTimeExtentChanged lambda invoked when the composable SceneView's [TimeExtent] is changed
  * @param onNavigationChanged lambda invoked when the navigation status of the composable SceneView has changed
@@ -91,6 +92,7 @@ public fun SceneView(
     viewLabelProperties: ViewLabelProperties = ViewLabelProperties(),
     selectionProperties: SelectionProperties = SelectionProperties(),
     attributionState: AttributionState = AttributionState(),
+    imageOverlays: ImageOverlayCollection = rememberImageOverlayCollection(),
     timeExtent: TimeExtent? = null,
     onTimeExtentChanged: ((TimeExtent?) -> Unit)? = null,
     onNavigationChanged: ((isNavigating: Boolean) -> Unit)? = null,
@@ -140,6 +142,7 @@ public fun SceneView(
     ViewpointUpdater(sceneView, viewpointOperation)
 
     GraphicsOverlaysUpdater(graphicsOverlays, sceneView)
+    ImageOverlaysUpdater(imageOverlays, sceneView)
 
     AttributionStateHandler(sceneView, attributionState)
     ViewpointChangedStateHandler(sceneView, viewpointChangedState)

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -291,3 +291,21 @@ private fun SceneViewEventHandler(
         }
     }
 }
+
+
+/**
+ * Create and [remember] a [ImageOverlayCollection].
+ * [init] will be called when the [ImageOverlayCollection] is first created to configure its
+ * initial state.
+ *
+ * @param key invalidates the remembered ImageOverlayCollection if different from the previous composition
+ * @param init called when the [ImageOverlayCollection] is created to configure its initial state
+ * @since 200.4.0
+ */
+@Composable
+public inline fun rememberImageOverlayCollection(
+    key: Any? = null,
+    crossinline init: ImageOverlayCollection.() -> Unit = {}
+): ImageOverlayCollection = remember(key) {
+    ImageOverlayCollection().apply(init)
+}

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -200,6 +200,42 @@ private fun ViewpointUpdater(
 }
 
 /**
+ * Update the view-based [SceneView]'s imageOverlays property to reflect changes made to the
+ * [imageOverlayCollection] based on the type of [ImageOverlayCollection.ChangedEvent]
+ *
+ * @since 200.4.0
+ */
+@Composable
+internal fun ImageOverlaysUpdater(
+    imageOverlayCollection: ImageOverlayCollection,
+    sceneView: SceneView
+) {
+    LaunchedEffect(imageOverlayCollection) {
+        // sync up the GeoView with the new image overlays
+        sceneView.imageOverlays.clear()
+        imageOverlayCollection.forEach {
+            sceneView.imageOverlays.add(it)
+        }
+        // start observing imageOverlays for subsequent changes
+        imageOverlayCollection.changed.collect { changedEvent ->
+            when (changedEvent) {
+                // On ImageOverlay added:
+                is ImageOverlayCollection.ChangedEvent.Added ->
+                    sceneView.imageOverlays.add(changedEvent.element)
+
+                // On ImageOverlay removed:
+                is ImageOverlayCollection.ChangedEvent.Removed ->
+                    sceneView.imageOverlays.remove(changedEvent.element)
+
+                // On ImageOverlays cleared:
+                is ImageOverlayCollection.ChangedEvent.Cleared ->
+                    sceneView.imageOverlays.clear()
+            }
+        }
+    }
+}
+
+/**
  * Sets up the callbacks for all the view-based [sceneView] events.
  */
 @Composable


### PR DESCRIPTION
Adds `imageOverlays` param and associated `ImageOverlaysCollection` to SceneView.

<details>
<summary>This code snippet will help with ad-hoc testing</summary>

```kotlin
 val imageOverlayCollection = rememberImageOverlayCollection()
    val point = Point(22.321736, 44.697703, SpatialReference.wgs84())
    val buffered = GeometryEngine.bufferOrNull(point, 30.0)
    val envelope = buffered?.extent
    val imageFrame = ImageFrame("https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/SNice.svg/1200px-SNice.svg.png", envelope!!)
    val imageOverlay = ImageOverlay(imageFrame)
    imageOverlayCollection.add(imageOverlay)
```

</details>