### PR TITLE
`Forms`: Refactor Validation

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/ComboBoxFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/ComboBoxFieldTests.kt
@@ -52,7 +52,7 @@ import org.junit.Rule
 import org.junit.Test
 
 class ComboBoxFieldTests {
-    private val descriptionSemanticLabel = "description"
+    private val descriptionSemanticLabel = "helper"
     private val clearTextSemanticLabel = "Clear text button"
     private val optionsIconSemanticLabel = "field icon"
     private val comboBoxDialogListSemanticLabel = "ComboBoxDialogLazyColumn"

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldNumericTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldNumericTests.kt
@@ -17,7 +17,6 @@
 package com.arcgismaps.toolkit.featureforms
 
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -103,12 +102,11 @@ class FormTextFieldNumericTests {
                 state = FormTextFieldState(
                     textFieldProperties,
                     scope = scope,
-                    context = LocalContext.current,
                     onEditValue = {
                         featureForm.editValue(integerField, it)
                         scope.launch { featureForm.evaluateExpressions() }
                     },
-                    validate = {integerField.getValidationErrors()}
+                    defaultValidator = {integerField.getValidationErrors()}
                 )
             )
         }
@@ -149,12 +147,11 @@ class FormTextFieldNumericTests {
                 state = FormTextFieldState(
                     textFieldProperties,
                     scope = scope,
-                    context = LocalContext.current,
                     onEditValue = {
                         featureForm.editValue(floatingPointField, it)
                         scope.launch { featureForm.evaluateExpressions() }
                     },
-                    validate = {floatingPointField.getValidationErrors()}
+                    defaultValidator = {floatingPointField.getValidationErrors()}
                 )
             )
         }

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldRangeNumericTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldRangeNumericTests.kt
@@ -17,7 +17,6 @@
 package com.arcgismaps.toolkit.featureforms
 
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -96,12 +95,11 @@ class FormTextFieldRangeNumericTests {
                 state = FormTextFieldState(
                     textFieldProperties,
                     scope = scope,
-                    context = LocalContext.current,
                     onEditValue = {
                         featureForm.editValue(integerField, it)
                         scope.launch { featureForm.evaluateExpressions() }
                     },
-                    validate = {integerField.getValidationErrors()}
+                    defaultValidator = {integerField.getValidationErrors()}
                 )
             )
         }

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
@@ -20,7 +20,6 @@ package com.arcgismaps.toolkit.featureforms
 
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotFocused
@@ -108,12 +107,11 @@ class FormTextFieldTests {
                 state = FormTextFieldState(
                     textFieldProperties,
                     scope = scope,
-                    context = LocalContext.current,
                     onEditValue = {
                         featureForm.editValue(field, it)
                         scope.launch { featureForm.evaluateExpressions() }
                     },
-                    validate = {field.getValidationErrors()}
+                    defaultValidator = {field.getValidationErrors()}
                 )
             )
         }

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
@@ -56,7 +56,6 @@ import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FormTextFieldTests {
     private val labelSemanticLabel = "label"
     private val helperSemanticLabel = "helper"

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -248,7 +248,6 @@ internal fun rememberStates(
 internal fun rememberFieldState(
     element: FieldFormElement,
     form: FeatureForm,
-    //context: Context,
     scope: CoroutineScope
 ): BaseFieldState<out Any?>? {
     return when (element.input) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -1,6 +1,5 @@
 package com.arcgismaps.toolkit.featureforms
 
-import android.content.Context
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -29,7 +28,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -44,8 +43,8 @@ import com.arcgismaps.mapping.featureforms.SwitchFormInput
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
-import com.arcgismaps.toolkit.featureforms.components.base.MutableFormStateCollection
 import com.arcgismaps.toolkit.featureforms.components.base.FormStateCollection
+import com.arcgismaps.toolkit.featureforms.components.base.MutableFormStateCollection
 import com.arcgismaps.toolkit.featureforms.components.base.getState
 import com.arcgismaps.toolkit.featureforms.components.base.rememberBaseGroupState
 import com.arcgismaps.toolkit.featureforms.components.codedvalue.rememberCodedValueFieldState
@@ -131,9 +130,8 @@ internal fun FeatureFormContent(
     form: FeatureForm,
     modifier: Modifier = Modifier
 ) {
-    val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val states = rememberStates(form = form, context = context, scope = scope)
+    val states = rememberStates(form = form, scope = scope)
     FeatureFormBody(
         form = form,
         states = states,
@@ -193,7 +191,6 @@ private fun FeatureFormBody(
  * provided FeatureForm. These state objects are returned as part of a [FormStateCollection].
  *
  * @param form the [FeatureForm] to create the states for.
- * @param context a [Context].
  * @param scope a [CoroutineScope] to run collectors and calculations on.
  *
  * @return returns the [FormStateCollection] created.
@@ -201,14 +198,13 @@ private fun FeatureFormBody(
 @Composable
 internal fun rememberStates(
     form: FeatureForm,
-    context: Context,
     scope: CoroutineScope
 ): FormStateCollection {
     val states = MutableFormStateCollection()
     form.elements.forEach { element ->
         when (element) {
             is FieldFormElement -> {
-                val state = rememberFieldState(element, form, context, scope)
+                val state = rememberFieldState(element, form, scope)
                 if (state != null) {
                     states.add(element, state)
                 }
@@ -221,7 +217,6 @@ internal fun rememberStates(
                         val state = rememberFieldState(
                             element = it,
                             form = form,
-                            context = context,
                             scope = scope
                         )
                         if (state != null) {
@@ -245,7 +240,6 @@ internal fun rememberStates(
  *
  * @param element the [FieldFormElement] to create the state for.
  * @param form the [FeatureForm] the [element] is part of.
- * @param context a [Context].
  * @param scope a [CoroutineScope] to run collectors and calculations on.
  *
  * @return returns the [BaseFieldState] created.
@@ -254,7 +248,7 @@ internal fun rememberStates(
 internal fun rememberFieldState(
     element: FieldFormElement,
     form: FeatureForm,
-    context: Context,
+    //context: Context,
     scope: CoroutineScope
 ): BaseFieldState<out Any?>? {
     return when (element.input) {
@@ -274,7 +268,6 @@ internal fun rememberFieldState(
                 minLength = minLength,
                 maxLength = maxLength,
                 form = form,
-                context = context,
                 scope = scope
             )
         }
@@ -304,7 +297,7 @@ internal fun rememberFieldState(
                 field = element,
                 form = form,
                 scope = scope,
-                noValueString = context.getString(R.string.no_value)
+                noValueString = stringResource(R.string.no_value)
             )
         }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -169,29 +169,34 @@ internal open class BaseFieldState<T>(
 
     private fun filter(errors: List<ValidationErrorState>): ValidationErrorState {
         Log.e("TAG", "filtering: $errors with wasfocused:$wasFocused")
-        return if (errors.isNotEmpty()) {
-            if (!isEditable.value) {
-                ValidationErrorState.NoError
-            } else {
-                if (wasFocused) {
-                    if (!isFocused.value) {
-                        if (errors.any { it is ValidationErrorState.Required }) {
-                            ValidationErrorState.Required
-                        } else {
-                            errors.first()
-                        }
+        // if editable
+        return if (errors.isNotEmpty() && isEditable.value) {
+            // if it has been focused
+            if (wasFocused) {
+                // if not in focus show any required errors
+                if (!isFocused.value) {
+                    if (errors.any { it is ValidationErrorState.Required }) {
+                        ValidationErrorState.Required
                     } else {
-                        if (errors.any { it !is ValidationErrorState.Required }) {
-                            errors.first()
-                        } else {
-                            ValidationErrorState.NoError
-                        }
+                        errors.first()
                     }
                 } else {
-                    ValidationErrorState.NoError
+                    // if focused and empty, don't show the "Required" error or numeric parse errors
+                    if (_mergedValue.value is String) {
+
+                    }
+                    if (errors.any { it !is ValidationErrorState.Required }) {
+                        errors.first()
+                    } else {
+                        ValidationErrorState.NoError
+                    }
                 }
+            } else {
+                // never been focused
+                ValidationErrorState.NoError
             }
         } else {
+            // not editable
             ValidationErrorState.NoError
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -59,6 +59,8 @@ internal data class Value<T>(
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
  * is called on [BaseFieldState.onValueChanged].
+ * @param defaultValidator the default validator that returns the list of validation errors. This
+ * is called in [BaseFieldState.validate].
  */
 internal open class BaseFieldState<T>(
     properties: FieldProperties<T>,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -170,14 +170,26 @@ internal open class BaseFieldState<T>(
     private fun filter(errors: List<ValidationErrorState>): ValidationErrorState {
         Log.e("TAG", "filtering: $errors with wasfocused:$wasFocused")
         return if (errors.isNotEmpty()) {
-            if (wasFocused) {
-                if (errors.any { it is ValidationErrorState.Required }) {
-                    ValidationErrorState.Required
+            if (!isEditable.value) {
+                ValidationErrorState.NoError
+            } else {
+                if (wasFocused) {
+                    if (!isFocused.value) {
+                        if (errors.any { it is ValidationErrorState.Required }) {
+                            ValidationErrorState.Required
+                        } else {
+                            errors.first()
+                        }
+                    } else {
+                        if (errors.any { it !is ValidationErrorState.Required }) {
+                            errors.first()
+                        } else {
+                            ValidationErrorState.NoError
+                        }
+                    }
                 } else {
                     ValidationErrorState.NoError
                 }
-            } else {
-                ValidationErrorState.NoError
             }
         } else {
             ValidationErrorState.NoError

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -81,12 +81,14 @@ internal open class BaseFieldState<T>(
     /**
      * A mutable state flow to handle user input changes.
      */
+    @Suppress("PropertyName")
     protected val _value = MutableStateFlow(initialValue)
 
     /**
      * A state flow that combines the user input [_value] and calculated property callbacks.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Suppress("PropertyName")
     protected val _mergedValue: StateFlow<T> = flowOf(_value, properties.value)
         .flattenMerge()
         .stateIn(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -87,7 +87,7 @@ internal open class BaseFieldState<T>(
      * A state flow that combines the user input [_value] and calculated property callbacks.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    protected val _mergedValue: StateFlow<T> = flowOf(_value, properties.value.drop(1))
+    protected val _mergedValue: StateFlow<T> = flowOf(_value, properties.value)
         .flattenMerge()
         .stateIn(
             scope = scope,
@@ -121,7 +121,9 @@ internal open class BaseFieldState<T>(
      */
     val isRequired: StateFlow<Boolean> = properties.required
 
-
+    /**
+     * A mutable state flow to handle current focus state.
+     */
     private val _isFocused: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     /**
@@ -133,27 +135,29 @@ internal open class BaseFieldState<T>(
     protected var wasFocused = false
 
     init {
+        // ignore the first values for all the flows since validate() is open and must
+        // NOT be called during initialization due to any derived class initialization order
         scope.launch {
             // validate when focus changes
-            isFocused.collect {
+            isFocused.drop(1).collect {
                 updateValidation()
             }
         }
         scope.launch {
             // validate when required property changes
-            isRequired.collect {
+            isRequired.drop(1).collect {
                 updateValidation()
             }
         }
         scope.launch {
             // validate when the editable property changes
-            isEditable.collect {
+            isEditable.drop(1).collect {
                 updateValidation()
             }
         }
         scope.launch {
             // validate when the value changes
-            _mergedValue.collect {
+            _mergedValue.drop(1).collect {
                 updateValidation()
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -149,6 +149,9 @@ internal open class BaseFieldState<T>(
      * Callback to update the current value of the FormTextFieldState to the given [input].
      */
     open fun onValueChanged(input: T) {
+        // infer that a value change event comes from a user interaction and hence treat it as a
+        // focus event
+        wasFocused = true
         onEditValue(input)
         _value.value = input
     }
@@ -182,9 +185,9 @@ internal open class BaseFieldState<T>(
                     }
                 } else {
                     // if focused and empty, don't show the "Required" error or numeric parse errors
-                    if (_mergedValue.value is String) {
-
-                    }
+//                    if (_mergedValue.value is String) {
+//
+//                    }
                     if (errors.any { it !is ValidationErrorState.Required }) {
                         errors.first()
                     } else {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FieldValidation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FieldValidation.kt
@@ -20,20 +20,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.arcgismaps.toolkit.featureforms.R
 
-internal sealed class ValidationErrorState {
+internal sealed class ValidationErrorState(
+    private vararg val formatArgs: Any
+) {
     object NoError : ValidationErrorState()
     object Required : ValidationErrorState()
-    object MinMaxCharConstraint : ValidationErrorState()
-    object ExactCharConstraint : ValidationErrorState()
-    object MaxCharConstraint : ValidationErrorState()
-    object MinNumericConstraint : ValidationErrorState()
-    object MaxNumericConstraint : ValidationErrorState()
-    object MinMaxNumericConstraint : ValidationErrorState()
+    class MinMaxCharConstraint(min: Int, max: Int) : ValidationErrorState(min, max)
+    class ExactCharConstraint(length: Int) : ValidationErrorState(length)
+    class MaxCharConstraint(max: Int) : ValidationErrorState(max)
+    class MinNumericConstraint(min: String) : ValidationErrorState(min)
+    class MaxNumericConstraint(max: String) : ValidationErrorState(max)
+    class MinMaxNumericConstraint(min : String, max: String) : ValidationErrorState(min, max)
     object NotANumber : ValidationErrorState()
     object NotAWholeNumber : ValidationErrorState()
 
     @Composable
-    open fun getString(vararg formatArgs: Any): String {
+    open fun getString(): String {
         return when (this) {
             is NoError -> {
                 ""
@@ -44,27 +46,27 @@ internal sealed class ValidationErrorState {
             }
 
             is MinMaxCharConstraint -> {
-                stringResource(id = R.string.enter_min_to_max_chars, formatArgs)
+                stringResource(id = R.string.enter_min_to_max_chars, *formatArgs)
             }
 
             is ExactCharConstraint -> {
-                stringResource(id = R.string.enter_n_chars, formatArgs)
+                stringResource(id = R.string.enter_n_chars, *formatArgs)
             }
 
             is MaxCharConstraint -> {
-                stringResource(id = R.string.maximum_n_chars, formatArgs)
+                stringResource(id = R.string.maximum_n_chars, *formatArgs)
             }
 
             is MinNumericConstraint -> {
-                stringResource(id = R.string.less_than_min_value, formatArgs)
+                stringResource(id = R.string.less_than_min_value, *formatArgs)
             }
 
             is MaxNumericConstraint -> {
-                stringResource(id = R.string.exceeds_max_value, formatArgs)
+                stringResource(id = R.string.exceeds_max_value, *formatArgs)
             }
 
             is MinMaxNumericConstraint -> {
-                stringResource(id = R.string.numeric_range_helper_text, formatArgs)
+                stringResource(id = R.string.numeric_range_helper_text, *formatArgs)
             }
 
             is NotANumber -> {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FieldValidation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FieldValidation.kt
@@ -16,15 +16,64 @@
 
 package com.arcgismaps.toolkit.featureforms.components.base
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.arcgismaps.toolkit.featureforms.R
+
 internal sealed class ValidationErrorState {
-    object NoError: ValidationErrorState()
-    object Required: ValidationErrorState()
-    object MinMaxCharConstraint: ValidationErrorState()
-    object ExactCharConstraint: ValidationErrorState()
-    object MaxCharConstraint: ValidationErrorState()
-    object MinNumericConstraint: ValidationErrorState()
-    object MaxNumericConstraint: ValidationErrorState()
-    object MinMaxNumericConstraint: ValidationErrorState()
-    object NotANumber: ValidationErrorState()
-    object NotAWholeNumber: ValidationErrorState()
+    object NoError : ValidationErrorState()
+    object Required : ValidationErrorState()
+    object MinMaxCharConstraint : ValidationErrorState()
+    object ExactCharConstraint : ValidationErrorState()
+    object MaxCharConstraint : ValidationErrorState()
+    object MinNumericConstraint : ValidationErrorState()
+    object MaxNumericConstraint : ValidationErrorState()
+    object MinMaxNumericConstraint : ValidationErrorState()
+    object NotANumber : ValidationErrorState()
+    object NotAWholeNumber : ValidationErrorState()
+
+    @Composable
+    open fun getString(vararg formatArgs: Any): String {
+        return when (this) {
+            is NoError -> {
+                ""
+            }
+
+            is Required -> {
+                stringResource(id = R.string.required)
+            }
+
+            is MinMaxCharConstraint -> {
+                stringResource(id = R.string.enter_min_to_max_chars, formatArgs)
+            }
+
+            is ExactCharConstraint -> {
+                stringResource(id = R.string.enter_n_chars, formatArgs)
+            }
+
+            is MaxCharConstraint -> {
+                stringResource(id = R.string.maximum_n_chars, formatArgs)
+            }
+
+            is MinNumericConstraint -> {
+                stringResource(id = R.string.less_than_min_value, formatArgs)
+            }
+
+            is MaxNumericConstraint -> {
+                stringResource(id = R.string.exceeds_max_value, formatArgs)
+            }
+
+            is MinMaxNumericConstraint -> {
+                stringResource(id = R.string.numeric_range_helper_text, formatArgs)
+            }
+
+            is NotANumber -> {
+                stringResource(id = R.string.value_must_be_a_number)
+            }
+
+            is NotAWholeNumber -> {
+                stringResource(id = R.string.value_must_be_a_whole_number)
+            }
+        }
+    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -109,6 +109,7 @@ internal open class CodedValueFieldState(
     }
     
     override fun onValueChanged(input: String) {
+        wasFocused = true
         val code = codedValues.firstOrNull {
             it.name == input
         }?.code

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -61,6 +61,8 @@ internal open class CodedValueFieldProperties(
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
  * is called on [CodedValueFieldState.onValueChanged].
+ * @param defaultValidator the default validator that returns the list of validation errors. This
+ * is called in [CodedValueFieldState.validate].
  */
 @Stable
 internal open class CodedValueFieldState(
@@ -68,13 +70,13 @@ internal open class CodedValueFieldState(
     initialValue: String = properties.value.value,
     scope: CoroutineScope,
     onEditValue: ((Any?) -> Unit),
-    validate: () -> List<Throwable>
+    defaultValidator: () -> List<Throwable>
 ) : BaseFieldState<String>(
     properties = properties,
     scope = scope,
     initialValue = initialValue,
     onEditValue = onEditValue,
-    defaultValidator = validate
+    defaultValidator = defaultValidator
 ) {
     /**
      * The list of coded values associated with this field.
@@ -152,7 +154,7 @@ internal open class CodedValueFieldState(
                         form.editValue(formElement, newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
-                    validate = formElement::getValidationErrors
+                    defaultValidator = formElement::getValidationErrors
                 ).apply {
                     onFocusChanged(list[1] as Boolean)
                 }
@@ -189,6 +191,6 @@ internal fun rememberCodedValueFieldState(
             form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         },
-        validate = field::getValidationErrors
+        defaultValidator = field::getValidationErrors
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -365,7 +365,7 @@ private fun ComboBoxPreview() {
         ),
         scope = scope,
         onEditValue = {},
-        validate = { emptyList() }
+        defaultValidator = { emptyList() }
     )
     ComboBoxField(state = state)
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -130,7 +130,8 @@ internal fun ComboBoxField(
             if (value.error is ValidationErrorState.Required) {
                 Text(
                     text = value.error.getString(),
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.semantics { contentDescription = "helper" }
                 )
             } else {
                 Text(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -110,14 +110,15 @@ internal fun ComboBoxField(
         state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
     } else ""
 
+    val (supportingText, supportingTextColor) = if (value.error is ValidationErrorState.NoError) {
+        Pair(state.description, Color.Unspecified)
+    } else {
+        Pair(value.error.getString(), MaterialTheme.colorScheme.error)
+    }
+
     BaseTextField(
         text = state.getCodedValueNameOrNull(value.data) ?: value.data,
-        onValueChange = {
-            state.onValueChanged(it)
-            // consider a "clear" operation to be a focused state even though the clear icon
-            // is not part of the field's focus target
-            if (it.isEmpty()) state.onFocusChanged(true)
-        },
+        onValueChange = state::onValueChanged,
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
@@ -126,24 +127,14 @@ internal fun ComboBoxField(
         singleLine = true,
         trailingIcon = Icons.Outlined.List,
         supportingText = {
-            // show the validation error if it exists
-            if (value.error is ValidationErrorState.Required) {
-                Text(
-                    text = value.error.getString(),
-                    color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.semantics { contentDescription = "helper" }
-                )
-            } else {
-                Text(
-                    text = state.description,
-                    modifier = Modifier.semantics { contentDescription = "description" },
-                )
-            }
+            Text(
+                text = supportingText,
+                color = supportingTextColor,
+                modifier = Modifier.semantics { contentDescription = "helper" }
+            )
         },
         interactionSource = interactionSource,
-        onFocusChange = {
-            state.onFocusChanged(it)
-        }
+        onFocusChange = state::onFocusChanged
     )
 
     LaunchedEffect(interactionSource) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -17,7 +17,6 @@
 package com.arcgismaps.toolkit.featureforms.components.codedvalue
 
 import android.content.res.Configuration
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -109,7 +108,7 @@ internal fun ComboBoxField(
     } else if (state.showNoValueOption == FormInputNoValueOption.Show) {
         state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
     } else ""
-
+    // show if any errors are present as the supporting text with the error color
     val (supportingText, supportingTextColor) = if (value.error is ValidationErrorState.NoError) {
         Pair(state.description, Color.Unspecified)
     } else {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
@@ -55,7 +55,7 @@ internal fun RadioButtonField(
     RadioButtonField(
         label = state.label,
         description = state.description,
-        value = value,
+        value = value.data,
         editable = editable,
         required = required,
         codedValues = state.codedValues.associateBy({ it.code }, { it.name }),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -35,12 +35,14 @@ internal class RadioButtonFieldState(
     properties: RadioButtonFieldProperties,
     initialValue: String = properties.value.value,
     scope: CoroutineScope,
-    onEditValue: ((Any?) -> Unit)
+    onEditValue: ((Any?) -> Unit),
+    validate: () -> List<Throwable>
 ) : CodedValueFieldState(
     properties = properties,
     initialValue = initialValue,
     scope = scope,
-    onEditValue = onEditValue
+    onEditValue = onEditValue,
+    validate = validate
 ) {
 
     /**
@@ -48,11 +50,11 @@ internal class RadioButtonFieldState(
      * trigger a fallback to a ComboBox. If the [value] is empty then this returns false.
      */
     fun shouldFallback(): Boolean {
-        return if (value.value.isEmpty()) {
+        return if (value.value.data.isEmpty()) {
             false
         } else {
             !codedValues.any {
-                it.name == value.value
+                it.name == value.value.data
             }
         }
     }
@@ -69,7 +71,7 @@ internal class RadioButtonFieldState(
         ): Saver<RadioButtonFieldState, Any> = listSaver(
             save = {
                 listOf(
-                    it.value.value
+                    it.value.value.data
                 )
             },
             restore = { list ->
@@ -93,7 +95,8 @@ internal class RadioButtonFieldState(
                     onEditValue = { newValue ->
                         form.editValue(formElement, newValue)
                         scope.launch { form.evaluateExpressions() }
-                    }
+                    },
+                    validate = formElement::getValidationErrors
                 )
             }
         )
@@ -127,6 +130,7 @@ internal fun rememberRadioButtonFieldState(
         onEditValue = {
             form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
-        }
+        },
+        validate = field::getValidationErrors
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -36,13 +36,13 @@ internal class RadioButtonFieldState(
     initialValue: String = properties.value.value,
     scope: CoroutineScope,
     onEditValue: ((Any?) -> Unit),
-    validate: () -> List<Throwable>
+    defaultValidator: () -> List<Throwable>
 ) : CodedValueFieldState(
     properties = properties,
     initialValue = initialValue,
     scope = scope,
     onEditValue = onEditValue,
-    validate = validate
+    defaultValidator = defaultValidator
 ) {
 
     /**
@@ -96,7 +96,7 @@ internal class RadioButtonFieldState(
                         form.editValue(formElement, newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
-                    validate = formElement::getValidationErrors
+                    defaultValidator = formElement::getValidationErrors
                 )
             }
         )
@@ -131,6 +131,6 @@ internal fun rememberRadioButtonFieldState(
             form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         },
-        validate = field::getValidationErrors
+        defaultValidator = field::getValidationErrors
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
@@ -35,7 +35,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
 @Composable
 internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier) {
     val codeName by state.value.collectAsState()
-    val checkedState = codeName == state.onValue.name
+    val checkedState = codeName.data == state.onValue.name
     val value = if (checkedState) state.onValue.name else state.offValue.name
     val isEditable by state.isEditable.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -73,6 +73,8 @@ internal class SwitchFieldProperties(
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
  * is called on [SwitchFieldState.onValueChanged].
+ * @param defaultValidator the default validator that returns the list of validation errors. This
+ * is called in [SwitchFieldState.validate].
  */
 @Stable
 internal class SwitchFieldState(
@@ -80,13 +82,13 @@ internal class SwitchFieldState(
     val initialValue: String = properties.value.value,
     scope: CoroutineScope,
     onEditValue: ((Any?) -> Unit),
-    validate: () -> List<Throwable>
+    defaultValidator: () -> List<Throwable>
 ) : CodedValueFieldState(
     properties = properties,
     scope = scope,
     initialValue = initialValue,
     onEditValue = onEditValue,
-    validate = validate
+    defaultValidator = defaultValidator
 ) {
     /**
      * The CodedValue that represents the "on" state of the Switch.
@@ -146,7 +148,7 @@ internal class SwitchFieldState(
                         )
                         scope.launch { form.evaluateExpressions() }
                     },
-                    validate = formElement::getValidationErrors
+                    defaultValidator = formElement::getValidationErrors
                 )
             }
         )
@@ -190,6 +192,6 @@ internal fun rememberSwitchFieldState(
             form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         },
-        validate = field::getValidationErrors
+        defaultValidator = field::getValidationErrors
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -79,12 +79,14 @@ internal class SwitchFieldState(
     properties: SwitchFieldProperties,
     val initialValue: String = properties.value.value,
     scope: CoroutineScope,
-    onEditValue: ((Any?) -> Unit)
+    onEditValue: ((Any?) -> Unit),
+    validate: () -> List<Throwable>
 ) : CodedValueFieldState(
     properties = properties,
     scope = scope,
     initialValue = initialValue,
-    onEditValue = onEditValue
+    onEditValue = onEditValue,
+    validate = validate
 ) {
     /**
      * The CodedValue that represents the "on" state of the Switch.
@@ -110,7 +112,7 @@ internal class SwitchFieldState(
         ): Saver<SwitchFieldState, Any> = listSaver(
             save = {
                 listOf(
-                    it.value.value,
+                    it.value.value.data,
                     it.fallback
                 )
             },
@@ -143,7 +145,8 @@ internal class SwitchFieldState(
                             if (codedValueName == input.onValue.name) input.onValue.code else input.offValue.code
                         )
                         scope.launch { form.evaluateExpressions() }
-                    }
+                    },
+                    validate = formElement::getValidationErrors
                 )
             }
         )
@@ -186,6 +189,7 @@ internal fun rememberSwitchFieldState(
         onEditValue = {
             form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
-        }
+        },
+        validate = field::getValidationErrors
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -127,7 +127,7 @@ private fun DateTimeFieldPreview() {
             ),
             scope = scope,
             onEditValue = {},
-            validate = { emptyList() }
+            defaultValidator = { emptyList() }
         )
         DateTimeField(state = state)
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -18,7 +18,6 @@
 
 package com.arcgismaps.toolkit.featureforms.components.datetime
 
-import android.util.Log
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.material.icons.Icons
@@ -60,6 +59,7 @@ internal fun DateTimeField(
     } else {
         state.label
     }
+    // show if any errors are present as the supporting text with the error color
     val (supportingText, supportingTextColor) = if (value.error is ValidationErrorState.NoError) {
         Pair(state.description, Color.Unspecified)
     } else {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -54,7 +54,6 @@ internal fun DateTimeField(
     val isRequired by state.isRequired.collectAsState()
     val instant by state.value.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }
-    // to check if the field was ever focused by the user
     val label = if (isRequired) {
         "${state.label} *"
     } else {
@@ -85,7 +84,8 @@ internal fun DateTimeField(
             if (instant.error is ValidationErrorState.Required) {
                 Text(
                     text = instant.error.getString(),
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.semantics { contentDescription = "helper" }
                 )
             } else {
                 Text(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -59,19 +59,21 @@ internal class DateTimeFieldProperties(
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
  * is called on [FormTextFieldState.onValueChanged].
+ * @param defaultValidator the default validator that returns the list of validation errors. This
+ * is called in [DateTimeFieldState.validate].
  */
 internal class DateTimeFieldState(
     properties: DateTimeFieldProperties,
     initialValue: Instant? = properties.value.value,
     scope: CoroutineScope,
     onEditValue: (Any?) -> Unit,
-    validate: () -> List<Throwable>
+    defaultValidator: () -> List<Throwable>
 ) : BaseFieldState<Instant?>(
     properties = properties,
     initialValue = initialValue,
     scope = scope,
     onEditValue = onEditValue,
-    defaultValidator = validate
+    defaultValidator = defaultValidator
 ) {
     val minEpochMillis: Instant? = properties.minEpochMillis
 
@@ -109,7 +111,7 @@ internal class DateTimeFieldState(
                         form.editValue(field, it)
                         scope.launch { form.evaluateExpressions() }
                     },
-                    validate = {
+                    defaultValidator = {
                         field.getValidationErrors()
                     }
                 ).apply {
@@ -153,7 +155,7 @@ internal fun rememberDateTimeFieldState(
             form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         },
-        validate = {
+        defaultValidator = {
             field.getValidationErrors()
         }
     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -49,11 +49,11 @@ internal fun FormTextField(
         }
     }
     val supportingText by state.supportingText
-    val contentLength = if (state.minLength > 0 || state.maxLength > 0) "${text.length}" else ""
+    val contentLength = if (state.minLength > 0 || state.maxLength > 0) "${text.data.length}" else ""
     val supportingTextIsErrorMessage by state.supportingTextIsErrorMessage
 
     BaseTextField(
-        text = text,
+        text = text.data,
         onValueChange = {
             state.onValueChanged(it)
         },

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
 import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
+import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState
 import com.arcgismaps.toolkit.featureforms.utils.isNumeric
 
 @Composable
@@ -37,7 +38,7 @@ internal fun FormTextField(
     state: FormTextFieldState,
     modifier: Modifier = Modifier,
 ) {
-    val text by state.value.collectAsState()
+    val value by state.value.collectAsState()
     val isEditable by state.isEditable.collectAsState()
     val isRequired by state.isRequired.collectAsState()
     val isFocused by state.isFocused.collectAsState()
@@ -48,12 +49,14 @@ internal fun FormTextField(
             state.label
         }
     }
-    val supportingText by state.supportingText
-    val contentLength = if (state.minLength > 0 || state.maxLength > 0) "${text.data.length}" else ""
-    val supportingTextIsErrorMessage by state.supportingTextIsErrorMessage
+    //val supportingText by state.supportingText
+    val contentLength =
+        if (state.minLength > 0 || state.maxLength > 0) "${value.data.length}" else ""
+    //val errorText = state.getErrorMessage(value.error)
+    //val supportingTextIsErrorMessage by state.supportingTextIsErrorMessage
 
     BaseTextField(
-        text = text.data,
+        text = value.data,
         onValueChange = {
             state.onValueChanged(it)
         },
@@ -64,15 +67,22 @@ internal fun FormTextField(
         singleLine = state.singleLine,
         keyboardType = if (state.fieldType.isNumeric) KeyboardType.Number else KeyboardType.Ascii,
         supportingText = {
-            val textColor = if (supportingTextIsErrorMessage) MaterialTheme.colorScheme.error
-            else MaterialTheme.colorScheme.onSurface
+            val textColor =
+                if (value.error is ValidationErrorState.NoError) MaterialTheme.colorScheme.onSurface
+                else MaterialTheme.colorScheme.error
             Row {
-                if (supportingText.isNotEmpty()) {
+                // show the validation error if it exists
+                if (value.error is ValidationErrorState.NoError) {
                     Text(
-                        text = supportingText,
+                        text = state.description,
+                        modifier = Modifier.semantics { contentDescription = "description" },
+                    )
+                } else {
+                    Text(
+                        text = value.error.getString(),
+                        color = textColor,
                         modifier = Modifier
-                            .semantics { contentDescription = "helper" },
-                        color = textColor
+                            .semantics { contentDescription = "helper" }
                     )
                 }
                 if (isFocused && isEditable) {
@@ -90,3 +100,18 @@ internal fun FormTextField(
         }
     )
 }
+
+//@Composable
+//private fun (FormTextFieldState).getErrorMessage(error: ValidationErrorState): String {
+//    return when (error) {
+//        is ValidationErrorState.Required -> {
+//            error.getString()
+//        }
+//
+//        is
+//
+//        else -> {
+//            description
+//        }
+//    }
+//}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -49,16 +49,21 @@ internal fun FormTextField(
             state.label
         }
     }
-    //val supportingText by state.supportingText
     val contentLength =
         if (state.minLength > 0 || state.maxLength > 0) "${value.data.length}" else ""
-    //val errorText = state.getErrorMessage(value.error)
-    //val supportingTextIsErrorMessage by state.supportingTextIsErrorMessage
+    val supportingTextColor = if (value.error is ValidationErrorState.NoError) {
+        MaterialTheme.colorScheme.onSurface
+    } else {
+        MaterialTheme.colorScheme.error
+    }
 
     BaseTextField(
         text = value.data,
         onValueChange = {
             state.onValueChanged(it)
+            // consider a "clear" operation to be a focused state even though the clear icon
+            // is not part of the field's focus target
+            if (it.isEmpty()) state.onFocusChanged(true)
         },
         modifier = modifier.fillMaxWidth(),
         isEditable = isEditable,
@@ -67,9 +72,6 @@ internal fun FormTextField(
         singleLine = state.singleLine,
         keyboardType = if (state.fieldType.isNumeric) KeyboardType.Number else KeyboardType.Ascii,
         supportingText = {
-            val textColor =
-                if (value.error is ValidationErrorState.NoError) MaterialTheme.colorScheme.onSurface
-                else MaterialTheme.colorScheme.error
             Row {
                 // show the validation error if it exists
                 if (value.error is ValidationErrorState.NoError) {
@@ -80,17 +82,17 @@ internal fun FormTextField(
                 } else {
                     Text(
                         text = value.error.getString(),
-                        color = textColor,
-                        modifier = Modifier
-                            .semantics { contentDescription = "helper" }
+                        color = supportingTextColor,
+                        modifier = Modifier.semantics { contentDescription = "helper" }
                     )
                 }
+                // show character count
                 if (isFocused && isEditable) {
                     Spacer(modifier = Modifier.weight(1f))
                     Text(
                         text = contentLength,
                         modifier = Modifier.semantics { contentDescription = "char count" },
-                        color = textColor
+                        color = supportingTextColor
                     )
                 }
             }
@@ -100,18 +102,3 @@ internal fun FormTextField(
         }
     )
 }
-
-//@Composable
-//private fun (FormTextFieldState).getErrorMessage(error: ValidationErrorState): String {
-//    return when (error) {
-//        is ValidationErrorState.Required -> {
-//            error.getString()
-//        }
-//
-//        is
-//
-//        else -> {
-//            description
-//        }
-//    }
-//}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -50,8 +50,12 @@ internal fun FormTextField(
             state.label
         }
     }
-    val contentLength =
-        if (state.minLength > 0 || state.maxLength > 0) "${value.data.length}" else ""
+    val contentLength = if (state.minLength > 0 || state.maxLength > 0) {
+        "${value.data.length}"
+    } else {
+        ""
+    }
+    // show if any errors are present as the supporting text with the error color
     val (supportingText, supportingTextColor) = if (value.error is ValidationErrorState.NoError) {
         Pair(state.description, Color.Unspecified)
     } else {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.components.text
 
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.saveable.Saver
@@ -180,7 +179,6 @@ internal class FormTextFieldState(
     override fun validate(): List<ValidationErrorState> {
         val currentValue = _mergedValue.value
         val coreErrors = defaultValidator()
-        Log.e("TAG", "validate: $coreErrors")
         val errors = mutableListOf<ValidationErrorState>()
         errors += super.validate()
 
@@ -283,7 +281,6 @@ internal fun rememberFormTextFieldState(
 ): FormTextFieldState = rememberSaveable(
     saver = FormTextFieldState.Saver(field, form, scope)
 ) {
-    Log.e("TAG", "rememberFormTextFieldState: ${form.fieldType(field)}")
     FormTextFieldState(
         properties = TextFieldProperties(
             label = field.label,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -64,6 +64,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
+import kotlin.math.min
 
 internal class TextFieldProperties(
     label: String,
@@ -116,17 +117,17 @@ internal class FormTextFieldState(
     // fetch the maxLength based on the featureFormElement.inputType
     val maxLength = properties.maxLength
     
-    private var hasBeenFocused: Boolean = false
+    //private var hasBeenFocused: Boolean = false
     
     // supporting text will depend on multiple other states. If there is an error, it will display
     // error message. Otherwise description is displayed, unless it is empty in which case
     // the helper text is displayed when the field is focused.
-    private val _supportingText: MutableState<String> = mutableStateOf(description)
-    val supportingText: State<String> = _supportingText
+//    private val _supportingText: MutableState<String> = mutableStateOf(description)
+//    val supportingText: State<String> = _supportingText
     
-    private val _hasError = mutableStateOf(false)
-    private val _supportingTextIsErrorMessage = mutableStateOf(false)
-    val supportingTextIsErrorMessage: State<Boolean> = _supportingTextIsErrorMessage
+//    private val _hasError = mutableStateOf(false)
+//    private val _supportingTextIsErrorMessage = mutableStateOf(false)
+//    val supportingTextIsErrorMessage: State<Boolean> = _supportingTextIsErrorMessage
     /**
      * The domain of the element's field.
      */
@@ -137,105 +138,105 @@ internal class FormTextFieldState(
      */
     val fieldType: FieldType = properties.fieldType
     
-    private val errorMessages: MutableMap<ValidationErrorState, String> by lazy {
-        val min = if (domain is RangeDomain) {
-            (domain.minValue as? Number)?.format()
-        } else {
-            ""
-        }
-        
-        val max = if (domain is RangeDomain) {
-            (domain.maxValue as? Number)?.format()
-        } else {
-            ""
-        }
-        
-        mutableMapOf(
-            Required to context.getString(R.string.required),
-            MaxCharConstraint to context.getString(R.string.maximum_n_chars, if (maxLength > 0) maxLength else 254),
-            ExactCharConstraint to context.getString(R.string.enter_n_chars, minLength),
-            MinMaxCharConstraint to context.getString(R.string.enter_min_to_max_chars, minLength, maxLength),
-            MinNumericConstraint to context.getString(R.string.less_than_min_value, min),
-            MaxNumericConstraint to context.getString(R.string.exceeds_max_value, max),
-            MinMaxNumericConstraint to context.getString(R.string.numeric_range_helper_text, min, max),
-            NotANumber to context.getString(R.string.value_must_be_a_number),
-            NotAWholeNumber to context.getString(R.string.value_must_be_a_whole_number)
-        )
-    }
+//    private val errorMessages: MutableMap<ValidationErrorState, String> by lazy {
+//        val min = if (domain is RangeDomain) {
+//            (domain.minValue as? Number)?.format()
+//        } else {
+//            ""
+//        }
+//
+//        val max = if (domain is RangeDomain) {
+//            (domain.maxValue as? Number)?.format()
+//        } else {
+//            ""
+//        }
+//
+//        mutableMapOf(
+//            Required to context.getString(R.string.required),
+//            MaxCharConstraint to context.getString(R.string.maximum_n_chars, if (maxLength > 0) maxLength else 254),
+//            ExactCharConstraint to context.getString(R.string.enter_n_chars, minLength),
+//            MinMaxCharConstraint(minLength, maxLength) to context.getString(R.string.enter_min_to_max_chars, minLength, maxLength),
+//            MinNumericConstraint to context.getString(R.string.less_than_min_value, min),
+//            MaxNumericConstraint to context.getString(R.string.exceeds_max_value, max),
+//            MinMaxNumericConstraint to context.getString(R.string.numeric_range_helper_text, min, max),
+//            NotANumber to context.getString(R.string.value_must_be_a_number),
+//            NotAWholeNumber to context.getString(R.string.value_must_be_a_whole_number)
+//        )
+//    }
     
     // build helper text
-    private val helperText =
-        if (fieldType.isNumeric) {
-            if (domain != null && domain is RangeDomain) {
-                val min = domain.minValue
-                val max = domain.maxValue
-                // to format the range of either integer or floating point
-                // values without a lot of logic, they are formatted as strings.
-                if (min is Number && max is Number) {
-                    context.getString(R.string.numeric_range_helper_text, min.format(), max.format())
-                } else if (min is Number) {
-                    context.getString(R.string.less_than_min_value, min.format())
-                } else if (max is Number) {
-                    context.getString(R.string.exceeds_max_value, max.format())
-                } else {
-                    // not likely to happen.
-                    ""
-                }
-            } else {
-                ""
-            }
-        } else {
-            if (minLength > 0 && maxLength > 0) {
-                if (minLength == maxLength) {
-                    context.getString(R.string.enter_n_chars, minLength)
-                } else {
-                    context.getString(R.string.enter_min_to_max_chars, minLength, maxLength)
-                }
-            } else if (maxLength > 0) {
-                context.getString(R.string.maximum_n_chars, maxLength)
-            } else {
-                context.getString(R.string.maximum_n_chars, 254)
-            }
-        }
+//    private val helperText =
+//        if (fieldType.isNumeric) {
+//            if (domain != null && domain is RangeDomain) {
+//                val min = domain.minValue
+//                val max = domain.maxValue
+//                // to format the range of either integer or floating point
+//                // values without a lot of logic, they are formatted as strings.
+//                if (min is Number && max is Number) {
+//                    context.getString(R.string.numeric_range_helper_text, min.format(), max.format())
+//                } else if (min is Number) {
+//                    context.getString(R.string.less_than_min_value, min.format())
+//                } else if (max is Number) {
+//                    context.getString(R.string.exceeds_max_value, max.format())
+//                } else {
+//                    // not likely to happen.
+//                    ""
+//                }
+//            } else {
+//                ""
+//            }
+//        } else {
+//            if (minLength > 0 && maxLength > 0) {
+//                if (minLength == maxLength) {
+//                    context.getString(R.string.enter_n_chars, minLength)
+//                } else {
+//                    context.getString(R.string.enter_min_to_max_chars, minLength, maxLength)
+//                }
+//            } else if (maxLength > 0) {
+//                context.getString(R.string.maximum_n_chars, maxLength)
+//            } else {
+//                context.getString(R.string.maximum_n_chars, 254)
+//            }
+//        }
     
-    init {
-        scope.launch {
-            value.drop(1).collect { newValue ->
-                updateValidation(newValue.data)
-            }
-        }
-        scope.launch {
-            isRequired.drop(1).collect {
-                updateValidation(value.value.data)
-            }
-        }
-        scope.launch {
-            isFocused.drop(1).collect {
-                if (it) {
-                    hasBeenFocused = true
-                }
-                updateValidation(value.value.data)
-            }
-        }
-    }
+//    init {
+//        scope.launch {
+//            value.drop(1).collect { newValue ->
+//                updateValidation(newValue.data)
+//            }
+//        }
+//        scope.launch {
+//            isRequired.drop(1).collect {
+//                updateValidation(value.value.data)
+//            }
+//        }
+//        scope.launch {
+//            isFocused.drop(1).collect {
+//                if (it) {
+//                    hasBeenFocused = true
+//                }
+//                updateValidation(value.value.data)
+//            }
+//        }
+//    }
     
-    private fun updateValidation(value: String) {
-        val errors = validate(value)
-        val errorToDisplay = errorMessageToDisplay(value, errors)
-        _supportingTextIsErrorMessage.value = errorToDisplay != NoError
-        _supportingText.value = if (errorToDisplay != NoError) {
-            errorMessages[errorToDisplay] ?: throw IllegalStateException("validation error must have a message")
-        } else {
-            description.ifEmpty {
-                if (isFocused.value && isEditable.value) {
-                    helperText
-                } else {
-                    ""
-                }
-            }
-        }
-        _hasError.value = errors.isNotEmpty()
-    }
+//    private fun updateValidation(value: String) {
+//        val errors = validate(value)
+//        val errorToDisplay = errorMessageToDisplay(value, errors)
+////        _supportingTextIsErrorMessage.value = errorToDisplay != NoError
+////        _supportingText.value = if (errorToDisplay != NoError) {
+////            errorMessages[errorToDisplay] ?: throw IllegalStateException("validation error must have a message")
+////        } else {
+////            description.ifEmpty {
+////                if (isFocused.value && isEditable.value) {
+////                    helperText
+////                } else {
+////                    ""
+////                }
+////            }
+////        }
+////        _hasError.value = errors.isNotEmpty()
+//    }
     
     private fun validateNumericRange(numberVal: Int): ValidationErrorState {
         require(fieldType.isIntegerType)
@@ -245,19 +246,19 @@ internal class FormTextFieldState(
                 if (numberVal in min..max) {
                     NoError
                 } else {
-                    MinMaxNumericConstraint
+                    MinMaxNumericConstraint(min.toString(), max.toString())
                 }
             } else if (min != null) {
                 if (min <= numberVal) {
                     NoError
                 } else {
-                    MinNumericConstraint
+                    MinNumericConstraint(min.toString())
                 }
             } else if (max != null) {
                 if (numberVal <= max) {
                     NoError
                 } else {
-                    MaxNumericConstraint
+                    MaxNumericConstraint(max.toString())
                 }
             } else {
                 NoError
@@ -275,19 +276,19 @@ internal class FormTextFieldState(
                 if (numberVal in min..max) {
                     NoError
                 } else {
-                    MinMaxNumericConstraint
+                    MinMaxNumericConstraint(min.toString(), max.toString())
                 }
             } else if (min != null) {
                 if (min <= numberVal) {
                     NoError
                 } else {
-                    MinNumericConstraint
+                    MinNumericConstraint(min.toString())
                 }
             } else if (max != null) {
                 if (numberVal <= max) {
                     NoError
                 } else {
-                    MaxNumericConstraint
+                    MaxNumericConstraint(max.toString())
                 }
             } else {
                 NoError
@@ -297,37 +298,37 @@ internal class FormTextFieldState(
         }
     }
     
-    private fun errorMessageToDisplay(
-        value: String,
-        validationErrors: List<ValidationErrorState>
-    ): ValidationErrorState =
-        if (validationErrors.isEmpty() || !isEditable.value) {
-            NoError
-        } else if (isFocused.value) {
-            if (value.isEmpty()) {
-                // if focused and empty, don't show the "Required" error or numeric parse errors
-                validationErrors.firstOrNull { it != Required && it != NotANumber && it != NotAWholeNumber } ?: NoError
-            } else {
-                // if non empty, focused, show any error other than required (the Required error shouldn't be in the list)
-                validationErrors.first()
-            }
-        } else if (hasBeenFocused) {
-            if (value.isEmpty()) {
-                if (validationErrors.contains(Required)) {
-                    // show any non required and non parse error before showing a Required error
-                    validationErrors.firstOrNull { it != Required && it != NotANumber && it != NotAWholeNumber  } ?: Required
-                } else {
-                    // don't show parse errors when empty and not required (and when required, show required as above)
-                    validationErrors.firstOrNull { it != NotANumber && it != NotAWholeNumber  } ?: NoError
-                }
-            } else {
-                // if non empty, unfocused, show any error other than required (the Required error shouldn't be in the list)
-                validationErrors.first()
-            }
-        } else {
-            // never been focused
-            NoError
-        }
+//    private fun errorMessageToDisplay(
+//        value: String,
+//        validationErrors: List<ValidationErrorState>
+//    ): ValidationErrorState =
+//        if (validationErrors.isEmpty() || !isEditable.value) {
+//            NoError
+//        } else if (isFocused.value) {
+//            if (value.isEmpty()) {
+//                // if focused and empty, don't show the "Required" error or numeric parse errors
+//                validationErrors.firstOrNull { it != Required && it != NotANumber && it != NotAWholeNumber } ?: NoError
+//            } else {
+//                // if non empty, focused, show any error other than required (the Required error shouldn't be in the list)
+//                validationErrors.first()
+//            }
+//        } else if (hasBeenFocused) {
+//            if (value.isEmpty()) {
+//                if (validationErrors.contains(Required)) {
+//                    // show any non required and non parse error before showing a Required error
+//                    validationErrors.firstOrNull { it != Required && it != NotANumber && it != NotAWholeNumber  } ?: Required
+//                } else {
+//                    // don't show parse errors when empty and not required (and when required, show required as above)
+//                    validationErrors.firstOrNull { it != NotANumber && it != NotAWholeNumber  } ?: NoError
+//                }
+//            } else {
+//                // if non empty, unfocused, show any error other than required (the Required error shouldn't be in the list)
+//                validationErrors.first()
+//            }
+//        } else {
+//            // never been focused
+//            NoError
+//        }
 
     override fun validate(value: String): List<ValidationErrorState> {
         val errors = defaultValidator()
@@ -343,12 +344,12 @@ internal class FormTextFieldState(
             ) {
                 if (minLength > 0 && maxLength > 0) {
                     if (minLength == maxLength) {
-                        ret += ExactCharConstraint
+                        ret += ExactCharConstraint(minLength)
                     } else {
-                        ret += MinMaxCharConstraint
+                        ret += MinMaxCharConstraint(minLength, maxLength)
                     }
                 } else {
-                    ret += MaxCharConstraint
+                    ret += MaxCharConstraint(maxLength)
                 }
             }
         } else {
@@ -388,7 +389,7 @@ internal class FormTextFieldState(
             save = {
                 listOf(
                     it.value.value.data,
-                    it.hasBeenFocused
+                    it.wasFocused
                 )
             },
             restore = { list ->
@@ -419,8 +420,7 @@ internal class FormTextFieldState(
                     validate = { formElement.getValidationErrors() }
                 ).apply {
                     // focus is lost on rotation. https://devtopia.esri.com/runtime/apollo/issues/230
-                    hasBeenFocused = list[1] as Boolean
-                    updateValidation(list[0] as String)
+                    onFocusChanged(list[1] as Boolean)
                 }
             }
         )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -116,18 +116,7 @@ internal class FormTextFieldState(
     
     // fetch the maxLength based on the featureFormElement.inputType
     val maxLength = properties.maxLength
-    
-    //private var hasBeenFocused: Boolean = false
-    
-    // supporting text will depend on multiple other states. If there is an error, it will display
-    // error message. Otherwise description is displayed, unless it is empty in which case
-    // the helper text is displayed when the field is focused.
-//    private val _supportingText: MutableState<String> = mutableStateOf(description)
-//    val supportingText: State<String> = _supportingText
-    
-//    private val _hasError = mutableStateOf(false)
-//    private val _supportingTextIsErrorMessage = mutableStateOf(false)
-//    val supportingTextIsErrorMessage: State<Boolean> = _supportingTextIsErrorMessage
+
     /**
      * The domain of the element's field.
      */
@@ -137,32 +126,6 @@ internal class FormTextFieldState(
      * The FieldType of the element's field.
      */
     val fieldType: FieldType = properties.fieldType
-    
-//    private val errorMessages: MutableMap<ValidationErrorState, String> by lazy {
-//        val min = if (domain is RangeDomain) {
-//            (domain.minValue as? Number)?.format()
-//        } else {
-//            ""
-//        }
-//
-//        val max = if (domain is RangeDomain) {
-//            (domain.maxValue as? Number)?.format()
-//        } else {
-//            ""
-//        }
-//
-//        mutableMapOf(
-//            Required to context.getString(R.string.required),
-//            MaxCharConstraint to context.getString(R.string.maximum_n_chars, if (maxLength > 0) maxLength else 254),
-//            ExactCharConstraint to context.getString(R.string.enter_n_chars, minLength),
-//            MinMaxCharConstraint(minLength, maxLength) to context.getString(R.string.enter_min_to_max_chars, minLength, maxLength),
-//            MinNumericConstraint to context.getString(R.string.less_than_min_value, min),
-//            MaxNumericConstraint to context.getString(R.string.exceeds_max_value, max),
-//            MinMaxNumericConstraint to context.getString(R.string.numeric_range_helper_text, min, max),
-//            NotANumber to context.getString(R.string.value_must_be_a_number),
-//            NotAWholeNumber to context.getString(R.string.value_must_be_a_whole_number)
-//        )
-//    }
     
     // build helper text
 //    private val helperText =
@@ -198,27 +161,7 @@ internal class FormTextFieldState(
 //                context.getString(R.string.maximum_n_chars, 254)
 //            }
 //        }
-    
-//    init {
-//        scope.launch {
-//            value.drop(1).collect { newValue ->
-//                updateValidation(newValue.data)
-//            }
-//        }
-//        scope.launch {
-//            isRequired.drop(1).collect {
-//                updateValidation(value.value.data)
-//            }
-//        }
-//        scope.launch {
-//            isFocused.drop(1).collect {
-//                if (it) {
-//                    hasBeenFocused = true
-//                }
-//                updateValidation(value.value.data)
-//            }
-//        }
-//    }
+
     
 //    private fun updateValidation(value: String) {
 //        val errors = validate(value)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -42,6 +42,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.
 import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.NoError
 import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.NotANumber
 import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.NotAWholeNumber
+import com.arcgismaps.toolkit.featureforms.components.datetime.DateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.utils.asDoubleTuple
 import com.arcgismaps.toolkit.featureforms.utils.asLongTuple
 import com.arcgismaps.toolkit.featureforms.utils.domain
@@ -80,21 +81,22 @@ internal class TextFieldProperties(
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
  * is called on [FormTextFieldState.onValueChanged].
+ * @param defaultValidator the default validator that returns the list of validation errors. This
+ * is called in [FormTextFieldState.validate].
  */
 @Stable
 internal class FormTextFieldState(
     properties: TextFieldProperties,
     initialValue: String = properties.value.value,
     scope: CoroutineScope,
-    //private val context: Context,
     onEditValue: (Any?) -> Unit,
-    validate: () -> List<Throwable>
+    defaultValidator: () -> List<Throwable>
 ) : BaseFieldState<String>(
     properties = properties,
     initialValue = initialValue,
     scope = scope,
     onEditValue = onEditValue,
-    defaultValidator = validate
+    defaultValidator = defaultValidator
 ) {
     // indicates singleLine only if TextBoxFeatureFormInput
     val singleLine = properties.singleLine
@@ -261,7 +263,7 @@ internal class FormTextFieldState(
                         form.editValue(formElement, newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
-                    validate = { formElement.getValidationErrors() }
+                    defaultValidator = { formElement.getValidationErrors() }
                 ).apply {
                     // focus is lost on rotation. https://devtopia.esri.com/runtime/apollo/issues/230
                     onFocusChanged(list[1] as Boolean)
@@ -302,7 +304,7 @@ internal fun rememberFormTextFieldState(
             form.editValue(field, it)
             scope.launch { form.evaluateExpressions() }
         },
-        validate = { field.getValidationErrors() }
+        defaultValidator = { field.getValidationErrors() }
     )
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -102,7 +102,7 @@ internal fun FeatureFormDialog() {
         is DialogType.ComboBoxDialog -> {
             val state = (dialogType as DialogType.ComboBoxDialog).state
             ComboBoxDialog(
-                initialValue = state.value.collectAsState().value,
+                initialValue = state.value.collectAsState().value.data,
                 values = state.codedValues.associateBy({ it.code }, { it.name }),
                 label = state.label,
                 description = state.description,
@@ -135,7 +135,7 @@ internal fun FeatureFormDialog() {
                 pickerStyle,
                 state.minEpochMillis,
                 state.maxEpochMillis,
-                state.value.collectAsState().value,
+                state.value.collectAsState().value.data,
                 state.label,
                 state.description,
                 DateTimePickerInput.Date

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -154,7 +154,12 @@ internal fun FeatureFormDialog() {
             )
         }
 
-        else -> {}
+        else -> {
+            // clear focus from the originating tapped field
+            if (dialogType == null) {
+                ClearFocus(true)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Summary of changes

The changes are based on the new validation design.

- BaseFieldState introduces two new methods to facilitate the design.
  - open fun validate() : List< ValidationErrorState>
      - This method uses the default validation logic `field::getValidationErrors` to generate a list of `ValidationErrorState` for the compose UI to consume. Child classes can override this to provide a more concise list of errors according to their data type.
  - private fun filter(errors : List< ValidationErrorState>) : ValidationErrorState : 
      - This method takes all the errors for a field value and only produces one validation error based on the "Field Validation UI Messaging Algorithm". Since this algorithm is the single source of truth, this method is final.

- Additionally, the value flows are broken down into `_value` (provides user input), `_mergedValue`(combines _value and onValueChanged events) and finally the actual `value` as a `Value(val data: T, val error: ValidationErrorState)` object. This separation of data is needed to accurately model the data and the error into a single object. `_validationError` provides the errors in this case.

- To preserve validation errors when the device orientation changes, the `wasFocused` property is included in the Savers of all the state classes. Then when the state classes are restored the focus flag is also restored and hence any validation errors will be once again visible.

- Only the `FormTextField`, `DateTimeField` and `ComboBoxField` are effected in terms of validation since the other input types do not show any validation errors.

- The `FeatureFormDialog` now clears focus from the tapped field since losing focus is needed to display the "required" errors.

- The `FormTextFieldState` does not need a reference to a `Context` anymore since fetching resource strings are now part of the `ValidationErrorState` class which provides a compose accessible method `getString()`.