### PR TITLE
SceneView: ambient light color

### DIFF
--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -77,7 +77,7 @@ import java.time.Instant
  * @param onTimeExtentChanged lambda invoked when the composable SceneView's [TimeExtent] is changed
  * @param sunTime the position of the sun in the scene view based on a specific date and time
  * @param sunLighting the type of ambient sunlight and shadows in the scene view
- * @param ambientLightColor the color of the composable SceneView's ambient light.
+ * @param ambientLightColor the color of the composable SceneView's ambient light
  * @param onNavigationChanged lambda invoked when the navigation status of the composable SceneView has changed
  * @param onSpatialReferenceChanged lambda invoked when the spatial reference of the composable SceneView has changed
  * @param onLayerViewStateChanged lambda invoked when the composable SceneView's layer view state is changed

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.semantics.contentDescription
@@ -68,6 +70,7 @@ import kotlinx.coroutines.launch
  * @param cameraController the [CameraController] to manage the position, orientation, and movement of the camera
  * @param timeExtent the [TimeExtent] used by the composable SceneView
  * @param onTimeExtentChanged lambda invoked when the composable SceneView's [TimeExtent] is changed
+ * @param ambientLightColor the color of the scene view's ambient light.
  * @param onNavigationChanged lambda invoked when the navigation status of the composable SceneView has changed
  * @param onSpatialReferenceChanged lambda invoked when the spatial reference of the composable SceneView has changed
  * @param onLayerViewStateChanged lambda invoked when the composable SceneView's layer view state is changed
@@ -99,6 +102,7 @@ public fun SceneView(
     cameraController: CameraController = GlobeCameraController(),
     timeExtent: TimeExtent? = null,
     onTimeExtentChanged: ((TimeExtent?) -> Unit)? = null,
+    ambientLightColor: Color = Color(220, 220, 220, 255),
     onNavigationChanged: ((isNavigating: Boolean) -> Unit)? = null,
     onSpatialReferenceChanged: ((spatialReference: SpatialReference?) -> Unit)? = null,
     onLayerViewStateChanged: ((GeoView.GeoViewLayerViewStateChanged) -> Unit)? = null,
@@ -128,6 +132,7 @@ public fun SceneView(
             it.selectionProperties = selectionProperties
             it.setTimeExtent(timeExtent)
             it.cameraController = cameraController
+            it.ambientLightColor = com.arcgismaps.Color(ambientLightColor.toArgb())
         })
 
     DisposableEffect(Unit) {

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -74,7 +74,7 @@ import java.time.Instant
  * @param sunTime the position of the sun in the scene view based on a specific date and time
  * @param sunLighting the type of ambient sunlight and shadows in the scene view
  * @param onTimeExtentChanged lambda invoked when the composable SceneView's [TimeExtent] is changed
- * @param ambientLightColor the color of the scene view's ambient light.
+ * @param ambientLightColor the color of the composable SceneView's ambient light.
  * @param onNavigationChanged lambda invoked when the navigation status of the composable SceneView has changed
  * @param onSpatialReferenceChanged lambda invoked when the spatial reference of the composable SceneView has changed
  * @param onLayerViewStateChanged lambda invoked when the composable SceneView's layer view state is changed


### PR DESCRIPTION
Adds the `ambientLightColor` parameter to `SceneView`, using compose color as the type.

Note that this will only work if `sunLighting` is set to `LightingMode.Light` or `LightAndShadows`, which is not yet merged in.