### PR TITLE
Feature Editor: Update geometry editor symbology

### DIFF
--- a/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
+++ b/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
@@ -192,7 +192,7 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
     else feature.featureTable?.geometryType == GeometryType.Polygon
 
     val renderer = (feature.featureTable?.layer as? FeatureLayer)?.renderer
-    val featureSymbol = renderer?.getSymbol(feature, true)
+    val featureSymbol = renderer?.getSymbol(feature, true) ?: return
 
     if (isGeometryPoint) {
         geometryEditor.tool.style.apply {

--- a/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
+++ b/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
@@ -207,8 +207,8 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
             val vertexOutlineSymbol = SimpleLineSymbol(SimpleLineSymbolStyle.Solid, color = Color.black)
             when (featureSymbol) {
                 is SimpleLineSymbol -> {
-                    val vertexSize = max(featureSymbol.width, 3f) * 3
-                    val midVertexSize = max(featureSymbol.width, 3f) * 2
+                    val vertexSize = max(featureSymbol.width, 1f) * 5
+                    val midVertexSize = max(featureSymbol.width, 1f) * 4
 
                     val vertex = SimpleMarkerSymbol(
                         color = featureSymbol.color.opaque,
@@ -241,8 +241,8 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
                     val strokeSymbolLayer = featureSymbol.symbolLayers.filterIsInstance<StrokeSymbolLayer>().firstOrNull()
                     if (strokeSymbolLayer != null) {
                         val symbolStrokeWidth = strokeSymbolLayer.width.toFloat()
-                        val vertexSize = max(symbolStrokeWidth, 3f) * 3
-                        val midVertexSize = max(symbolStrokeWidth, 3f) * 2
+                        val vertexSize = max(symbolStrokeWidth, 1f) * 5
+                        val midVertexSize = max(symbolStrokeWidth, 1f) * 4
 
                         val vertex = SimpleMarkerSymbol(
                             color = featureSymbol.color.opaque,
@@ -288,8 +288,8 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
                     featureSymbol.outline?.let {
                         outlineColor = it.color
                         outlineWidth = it.width
-                        vertexSize = max(outlineWidth, 3f) * 3
-                        midVertexSize = max(outlineWidth, 3f) * 2
+                        vertexSize = max(outlineWidth, 1f) * 5
+                        midVertexSize = max(outlineWidth, 1f) * 4
                     }
 
                     // Color can be null (no fill)
@@ -325,8 +325,8 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
                     val strokeSymbolLayer = featureSymbol.symbolLayers.filterIsInstance<StrokeSymbolLayer>().firstOrNull()
                     if (strokeSymbolLayer != null) {
                         val symbolStrokeWidth = strokeSymbolLayer.width.toFloat()
-                        val vertexSize = max(symbolStrokeWidth, 3f) * 3
-                        val midVertexSize = max(symbolStrokeWidth, 3f) * 2
+                        val vertexSize = max(symbolStrokeWidth, 1f) * 5
+                        val midVertexSize = max(symbolStrokeWidth, 1f) * 4
 
                         val vertex = SimpleMarkerSymbol(
                             color = featureSymbol.color.opaque ,

--- a/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
+++ b/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
@@ -240,39 +240,43 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
                     vertexTextSymbol = null
                 }
                 is MultilayerPolylineSymbol -> {
+                    var vertexSize = (vertexSymbol as? SimpleMarkerSymbol)?.size ?: 5f
+                    var midVertexSize = (midVertexSymbol as? SimpleMarkerSymbol)?.size ?: 4f
+                    var strokeWidth = (lineSymbol as? SimpleLineSymbol)?.width ?: 3f
+
                     // Find the first stroke symbol layer in the list of layers, if any.
                     val strokeSymbolLayer = featureSymbol.symbolLayers.filterIsInstance<StrokeSymbolLayer>().firstOrNull()
                     if (strokeSymbolLayer != null) {
-                        val symbolStrokeWidth = strokeSymbolLayer.width.toFloat()
-                        val vertexSize = max(symbolStrokeWidth, 1f) * 5
-                        val midVertexSize = max(symbolStrokeWidth, 1f) * 4
-
-                        val vertex = SimpleMarkerSymbol(
-                            color = featureSymbol.color.opaque,
-                            style = SimpleMarkerSymbolStyle.Circle,
-                            size = vertexSize
-                        )
-                        vertex.outline = vertexOutlineSymbol
-                        val midVertex = SimpleMarkerSymbol(
-                            color = Color.white,
-                            style = SimpleMarkerSymbolStyle.Circle,
-                            size = midVertexSize
-                        )
-                        midVertex.outline = vertexOutlineSymbol
-
-                        vertexSymbol = vertex
-                        selectedVertexSymbol = vertex
-                        feedbackVertexSymbol = vertex
-                        midVertexSymbol = midVertex
-                        selectedMidVertexSymbol = midVertex
-                        feedbackLineSymbol = SimpleLineSymbol(
-                            SimpleLineSymbolStyle.Dash,
-                            color = featureSymbol.color.opaque,
-                            width = symbolStrokeWidth
-                        )
-                        lineSymbol = featureSymbol
-                        vertexTextSymbol = null
+                        strokeWidth = strokeSymbolLayer.width.toFloat()
+                        vertexSize = max(strokeWidth, 1f) * 5
+                        midVertexSize = max(strokeWidth, 1f) * 4
                     }
+
+                    val vertex = SimpleMarkerSymbol(
+                        color = featureSymbol.color.opaque,
+                        style = SimpleMarkerSymbolStyle.Circle,
+                        size = vertexSize
+                    )
+                    vertex.outline = vertexOutlineSymbol
+                    val midVertex = SimpleMarkerSymbol(
+                        color = Color.white,
+                        style = SimpleMarkerSymbolStyle.Circle,
+                        size = midVertexSize
+                    )
+                    midVertex.outline = vertexOutlineSymbol
+
+                    vertexSymbol = vertex
+                    selectedVertexSymbol = vertex
+                    feedbackVertexSymbol = vertex
+                    midVertexSymbol = midVertex
+                    selectedMidVertexSymbol = midVertex
+                    feedbackLineSymbol = SimpleLineSymbol(
+                        SimpleLineSymbolStyle.Dash,
+                        color = featureSymbol.color.opaque,
+                        width = strokeWidth
+                    )
+                    lineSymbol = featureSymbol
+                    vertexTextSymbol = null
                 }
                 else -> {} // Use default symbology
             }
@@ -284,12 +288,12 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
                 is SimpleFillSymbol -> {
                     // Defaults when outline is null
                     var vertexSize = (vertexSymbol as? SimpleMarkerSymbol)?.size ?: 5f
-                    var midVertexSize = vertexSize / 2
+                    var midVertexSize = (midVertexSymbol as? SimpleMarkerSymbol)?.size ?: 4f
+                    var outlineWidth = (lineSymbol as? SimpleLineSymbol)?.width ?: 3f
                     var outlineColor = Color.white
-                    var outlineWidth = (feedbackLineSymbol as? SimpleLineSymbol)?.width ?: 3f
 
                     featureSymbol.outline?.let {
-                        outlineColor = it.color
+                        outlineColor = it.color.opaque
                         outlineWidth = it.width
                         vertexSize = max(outlineWidth, 1f) * 5
                         midVertexSize = max(outlineWidth, 1f) * 4
@@ -324,40 +328,44 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
                     vertexTextSymbol = null
                 }
                 is MultilayerPolygonSymbol -> {
+                    var vertexSize = (vertexSymbol as? SimpleMarkerSymbol)?.size ?: 5f
+                    var midVertexSize = (midVertexSymbol as? SimpleMarkerSymbol)?.size ?: 4f
+                    var symbolStrokeWidth = (lineSymbol as? SimpleLineSymbol)?.width ?: 3f
+
                     // Find the first stroke symbol layer in the list of layers, if any.
                     val strokeSymbolLayer = featureSymbol.symbolLayers.filterIsInstance<StrokeSymbolLayer>().firstOrNull()
                     if (strokeSymbolLayer != null) {
-                        val symbolStrokeWidth = strokeSymbolLayer.width.toFloat()
-                        val vertexSize = max(symbolStrokeWidth, 1f) * 5
-                        val midVertexSize = max(symbolStrokeWidth, 1f) * 4
-
-                        val vertex = SimpleMarkerSymbol(
-                            color = featureSymbol.color.opaque ,
-                            style = SimpleMarkerSymbolStyle.Circle,
-                            size = vertexSize
-                        )
-                        vertex.outline = vertexOutlineSymbol
-                        val midVertex = SimpleMarkerSymbol(
-                            color = Color.white,
-                            style = SimpleMarkerSymbolStyle.Circle,
-                            size = midVertexSize
-                        )
-                        midVertex.outline = vertexOutlineSymbol
-
-                        vertexSymbol = vertex
-                        selectedVertexSymbol = vertex
-                        feedbackVertexSymbol = vertex
-                        midVertexSymbol = midVertex
-                        selectedMidVertexSymbol = midVertex
-                        feedbackLineSymbol = SimpleLineSymbol(
-                            SimpleLineSymbolStyle.Dash,
-                            color = featureSymbol.color.opaque,
-                            width = symbolStrokeWidth
-                        )
-                        lineSymbol = featureSymbol // Could be null (no outline)
-                        fillSymbol = featureSymbol
-                        vertexTextSymbol = null
+                        symbolStrokeWidth = strokeSymbolLayer.width.toFloat()
+                        vertexSize = max(symbolStrokeWidth, 1f) * 5
+                        midVertexSize = max(symbolStrokeWidth, 1f) * 4
                     }
+
+                    val vertex = SimpleMarkerSymbol(
+                        color = featureSymbol.color.opaque,
+                        style = SimpleMarkerSymbolStyle.Circle,
+                        size = vertexSize
+                    )
+                    vertex.outline = vertexOutlineSymbol
+                    val midVertex = SimpleMarkerSymbol(
+                        color = Color.white,
+                        style = SimpleMarkerSymbolStyle.Circle,
+                        size = midVertexSize
+                    )
+                    midVertex.outline = vertexOutlineSymbol
+
+                    vertexSymbol = vertex
+                    selectedVertexSymbol = vertex
+                    feedbackVertexSymbol = vertex
+                    midVertexSymbol = midVertex
+                    selectedMidVertexSymbol = midVertex
+                    feedbackLineSymbol = SimpleLineSymbol(
+                        SimpleLineSymbolStyle.Dash,
+                        color = featureSymbol.color.opaque,
+                        width = symbolStrokeWidth
+                    )
+                    lineSymbol = featureSymbol // Could be null (no outline)
+                    fillSymbol = featureSymbol
+                    vertexTextSymbol = null
                 }
                 is PictureMarkerSymbol -> {
                     val midVertex = SimpleMarkerSymbol(

--- a/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
+++ b/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
@@ -211,14 +211,12 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
 
                     val vertex = SimpleMarkerSymbol(color = featureSymbol.color, style = SimpleMarkerSymbolStyle.Circle, size = vertexWidth)
                     vertex.outline = vertexOutlineSymbol
-                    val selectedVertex = SimpleMarkerSymbol(color = Color.white, style = SimpleMarkerSymbolStyle.Circle, size = vertexWidth)
-                    selectedVertex.outline = vertexOutlineSymbol
                     val midVertex = SimpleMarkerSymbol(color = Color.white, style = SimpleMarkerSymbolStyle.Circle, size = midVertexWidth)
                     midVertex.outline = vertexOutlineSymbol
 
                     vertexSymbol = vertex
-                    selectedVertexSymbol = selectedVertex
-                    feedbackVertexSymbol = selectedVertex
+                    selectedVertexSymbol = vertex
+                    feedbackVertexSymbol = vertex
                     midVertexSymbol = midVertex
                     selectedMidVertexSymbol = midVertex
                     feedbackLineSymbol = SimpleLineSymbol(SimpleLineSymbolStyle.Dash, color = featureSymbol.color, width = featureSymbol.width)
@@ -233,14 +231,12 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
 
                     val vertex = SimpleMarkerSymbol(color = featureSymbol.color, style = SimpleMarkerSymbolStyle.Circle, size = vertexSize)
                     vertex.outline = vertexOutlineSymbol
-                    val selectedVertex = SimpleMarkerSymbol(color = Color.white, style = SimpleMarkerSymbolStyle.Circle, size = vertexSize)
-                    selectedVertex.outline = vertexOutlineSymbol
                     val midVertex = SimpleMarkerSymbol(color = Color.white, style = SimpleMarkerSymbolStyle.Circle, size = midVertexSize)
                     midVertex.outline = vertexOutlineSymbol
 
                     vertexSymbol = vertex
-                    selectedVertexSymbol = selectedVertex
-                    feedbackVertexSymbol = selectedVertex
+                    selectedVertexSymbol = vertex
+                    feedbackVertexSymbol = vertex
                     midVertexSymbol = midVertex
                     selectedMidVertexSymbol = midVertex
                     feedbackLineSymbol = SimpleLineSymbol(SimpleLineSymbolStyle.Dash, color = featureSymbol.color, width = symbolStrokeWidth)
@@ -271,14 +267,12 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
                     // Color can be null (no fill)
                     val vertex = SimpleMarkerSymbol(color = featureSymbol.color, style = SimpleMarkerSymbolStyle.Circle, size = vertexSize)
                     vertex.outline = vertexOutlineSymbol
-                    val selectedVertex = SimpleMarkerSymbol(color = Color.white , style = SimpleMarkerSymbolStyle.Circle, size = vertexSize)
-                    selectedVertex.outline = vertexOutlineSymbol
                     val midVertex = SimpleMarkerSymbol(color = Color.white, style = SimpleMarkerSymbolStyle.Circle, size = midVertexSize)
                     midVertex.outline = vertexOutlineSymbol
 
                     vertexSymbol = vertex
-                    selectedVertexSymbol = selectedVertex
-                    feedbackVertexSymbol = selectedVertex
+                    selectedVertexSymbol = vertex
+                    feedbackVertexSymbol = vertex
                     midVertexSymbol = midVertex
                     selectedMidVertexSymbol = midVertex
                     feedbackLineSymbol = SimpleLineSymbol(SimpleLineSymbolStyle.Dash, color = outlineColor, width = outlineWidth)
@@ -294,14 +288,12 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
 
                     val vertex = SimpleMarkerSymbol(color = opaqueFillColor, style = SimpleMarkerSymbolStyle.Circle, size = vertexSize)
                     vertex.outline = vertexOutlineSymbol
-                    val selectedVertex = SimpleMarkerSymbol(color = Color.white , style = SimpleMarkerSymbolStyle.Circle, size = vertexSize)
-                    selectedVertex.outline = vertexOutlineSymbol
                     val midVertex = SimpleMarkerSymbol(color = Color.white, style = SimpleMarkerSymbolStyle.Circle, size = midVertexSize)
                     midVertex.outline = vertexOutlineSymbol
 
                     vertexSymbol = vertex
-                    selectedVertexSymbol = selectedVertex
-                    feedbackVertexSymbol = selectedVertex
+                    selectedVertexSymbol = vertex
+                    feedbackVertexSymbol = vertex
                     midVertexSymbol = midVertex
                     selectedMidVertexSymbol = midVertex
                     feedbackLineSymbol = SimpleLineSymbol(SimpleLineSymbolStyle.Dash, color = opaqueFillColor, width = symbolStrokeWidth)
@@ -310,14 +302,12 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
                     vertexTextSymbol = null
                 }
                 is PictureMarkerSymbol -> {
-                    val selectedVertex = SimpleMarkerSymbol(color = Color.white, style = SimpleMarkerSymbolStyle.Circle, size = featureSymbol.toMultilayerSymbol().size)
-                    selectedVertex.outline = vertexOutlineSymbol
                     val midVertex = SimpleMarkerSymbol(color = Color.white, style = SimpleMarkerSymbolStyle.Circle, size = featureSymbol.toMultilayerSymbol().size/3)
                     midVertex.outline = vertexOutlineSymbol
 
                     vertexSymbol = featureSymbol
-                    selectedVertexSymbol = selectedVertex
-                    feedbackVertexSymbol= selectedVertex
+                    selectedVertexSymbol = featureSymbol
+                    feedbackVertexSymbol= featureSymbol
                     midVertexSymbol = midVertex
                     selectedMidVertexSymbol = midVertex
                     feedbackLineSymbol = SimpleLineSymbol(SimpleLineSymbolStyle.Dash, featureSymbol.toMultilayerSymbol().color, width = featureSymbol.toMultilayerSymbol().size/5)

--- a/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
+++ b/toolkit/featureeditor/src/main/java/com/arcgismaps/toolkit/featureeditor/FeatureEditor.kt
@@ -183,6 +183,11 @@ public class FeatureEditor(
 }
 
 private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: ArcGISFeature, geometry: Geometry?) {
+    // Get the feature symbol from the renderer or return if null.
+    val renderer = (feature.featureTable?.layer as? FeatureLayer)?.renderer
+    val featureSymbol = renderer?.getSymbol(feature, true) ?: return
+
+    // Determine the geometry of the feature.
     val isGeometryPoint =  if (geometry?.let { !it.isEmpty } == true) geometry is Point || geometry is Multipoint
     else feature.featureTable?.geometryType == GeometryType.Point || feature.featureTable?.geometryType == GeometryType.Multipoint
 
@@ -192,9 +197,7 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
     val isGeometryPolygon = if (geometry?.let { !it.isEmpty } == true) geometry is Polygon
     else feature.featureTable?.geometryType == GeometryType.Polygon
 
-    val renderer = (feature.featureTable?.layer as? FeatureLayer)?.renderer
-    val featureSymbol = renderer?.getSymbol(feature, true) ?: return
-
+    // Apply symbology to the editor for the geometry types.
     if (isGeometryPoint) {
         geometryEditor.tool.style.apply {
             vertexSymbol = featureSymbol
@@ -280,7 +283,7 @@ private fun updateGeometryEditorStyle(geometryEditor: GeometryEditor, feature: A
             when (featureSymbol) {
                 is SimpleFillSymbol -> {
                     // Defaults when outline is null
-                    var vertexSize = (vertexSymbol as? SimpleMarkerSymbol)?.size ?: 3f
+                    var vertexSize = (vertexSymbol as? SimpleMarkerSymbol)?.size ?: 5f
                     var midVertexSize = vertexSize / 2
                     var outlineColor = Color.white
                     var outlineWidth = (feedbackLineSymbol as? SimpleLineSymbol)?.width ?: 3f


### PR DESCRIPTION
**Issue(s)**
[2062](https://devtopia.esri.com/runtime/bistromath/issues/2062)

**Description of change**
Create helper method that applies feature symbology to the geometry editor when the feature is being edited. 

To test with data that doesn't have a feature form definition, remove the feature form non-null requirement in the `FeatureEditorAppState.onSingleTapConfirmed()` and `FeatureEditor.start()`. If the feature geometry is not allowed to be edited, comment the appropriate line when the feature editor is initialised, see [issue](https://devtopia.esri.com/runtime/bistromath/issues/2191). 

**Testing**
Manual testing with a variety of web maps linked in the issue.

