### PR TITLE
`Forms`: Submit Form Validation

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
@@ -397,9 +397,14 @@ fun LoginOptions(
 
 fun Modifier.verticalScrollbar(
     state: LazyListState,
-    width: Dp = 5.dp
+    width: Dp = 5.dp,
+    autoHide : Boolean = false,
 ): Modifier = composed {
-    val targetAlpha = if (state.isScrollInProgress) 1f else 0f
+    val targetAlpha = if (autoHide) {
+        if (state.isScrollInProgress) 1f else 0f
+    } else {
+        1f
+    }
     val duration = if (state.isScrollInProgress) 150 else 500
     val color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
 

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
@@ -397,14 +397,9 @@ fun LoginOptions(
 
 fun Modifier.verticalScrollbar(
     state: LazyListState,
-    width: Dp = 5.dp,
-    autoHide : Boolean = false,
+    width: Dp = 5.dp
 ): Modifier = composed {
-    val targetAlpha = if (autoHide) {
-        if (state.isScrollInProgress) 1f else 0f
-    } else {
-        1f
-    }
+    val targetAlpha = if (state.isScrollInProgress) 1f else 0f
     val duration = if (state.isScrollInProgress) 150 else 500
     val color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
 

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -164,7 +164,7 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
         }
     }
     if (uiState is UIState.Committing) {
-        SubmitForm(uiState = (uiState as UIState.Committing)) {
+        SubmitForm(errors = (uiState as UIState.Committing).errors) {
             mapViewModel.cancelCommit()
         }
     }
@@ -214,8 +214,7 @@ fun TopFormBar(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SubmitForm(uiState: UIState.Committing, onDismissRequest: () -> Unit) {
-    val errors = uiState.errors
+private fun SubmitForm(errors : List<ErrorInfo>, onDismissRequest: () -> Unit) {
     if (errors.isEmpty()) {
         // show a progress dialog if no errors are present
         AlertDialog(
@@ -265,7 +264,7 @@ private fun SubmitForm(uiState: UIState.Committing, onDismissRequest: () -> Unit
                 Card(
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Column(modifier = Modifier.padding(25.dp)) {
+                    Column(modifier = Modifier.padding(15.dp)) {
                         Text(
                             text = stringResource(R.string.attributes_failed, errors.count()),
                             color = MaterialTheme.colorScheme.error

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -209,7 +209,10 @@ private fun SubmitForm(errors: List<String>, onDismissRequest: () -> Unit) {
             onDismissRequest = onDismissRequest,
             modifier = Modifier.heightIn(max = 600.dp),
             confirmButton = {
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
                     Button(onClick = onDismissRequest) {
                         Text(text = "View")
                     }
@@ -237,10 +240,12 @@ private fun SubmitForm(errors: List<String>, onDismissRequest: () -> Unit) {
                             text = "${errors.count()} attributes failed.",
                             color = MaterialTheme.colorScheme.error
                         )
+                        Spacer(modifier = Modifier.height(10.dp))
                         LazyColumn(
                             modifier = Modifier,
                             //.verticalScrollbar(lazyListState, autoHide = false),
-                            state = lazyListState
+                            state = lazyListState,
+                            verticalArrangement = Arrangement.spacedBy(10.dp)
                         ) {
                             items(errors.count()) {
                                 Text(text = errors[it], color = MaterialTheme.colorScheme.error)
@@ -262,9 +267,13 @@ fun TopFormBarPreview() {
 @Preview
 @Composable
 fun SubmitFormPreview() {
-    SubmitForm(errors = listOf("1", "1", "1", "1", "1")) {
-
-    }
+    SubmitForm(
+        errors = listOf(
+            "field is required",
+            "field has a min constraint",
+            "field is required"
+        )
+    ) { }
 }
 
 fun getWindowSize(context: Context): WindowSizeClass {

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -79,12 +79,12 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             is UIState.Committing -> {
                 Pair(
                     (uiState as UIState.Committing).featureForm,
-                    ValidationErrorVisibility.OnlyAfterFocus
+                    ValidationErrorVisibility.Automatic
                 )
             }
 
             else -> {
-                Pair(null, ValidationErrorVisibility.OnlyAfterFocus)
+                Pair(null, ValidationErrorVisibility.Automatic)
             }
         }
     }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -51,6 +51,7 @@ import androidx.window.core.layout.WindowSizeClass
 import androidx.window.layout.WindowMetricsCalculator
 import com.arcgismaps.toolkit.composablemap.ComposableMap
 import com.arcgismaps.toolkit.featureforms.FeatureForm
+import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureformsapp.R
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.BottomSheetMaxWidth
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetExpansionHeight
@@ -67,19 +68,19 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
     val uiState by mapViewModel.uiState
     val context = LocalContext.current
     val windowSize = getWindowSize(context)
-    Log.e("TAG", "MapScreen: $uiState")
-    val featureForm = remember(uiState) {
+    val (featureForm, errorVisibility) = remember(uiState) {
         when (uiState) {
             is UIState.Editing -> {
-                (uiState as UIState.Editing).featureForm
+                val state = (uiState as UIState.Editing)
+                Pair(state.featureForm, state.validationErrorVisibility)
             }
 
             is UIState.Committing -> {
-                (uiState as UIState.Committing).featureForm
+                Pair((uiState as UIState.Committing).featureForm, ValidationErrorVisibility.OnlyAfterFocus)
             }
 
             else -> {
-                null
+                Pair(null, ValidationErrorVisibility.OnlyAfterFocus)
             }
         }
     }
@@ -145,7 +146,8 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                     if (featureForm != null) {
                         FeatureForm(
                             featureForm = featureForm,
-                            modifier = Modifier.fillMaxSize()
+                            modifier = Modifier.fillMaxSize(),
+                            validationErrorVisibility = errorVisibility
                         )
                     }
                 }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -40,7 +40,7 @@ sealed class UIState {
      */
     data class Editing(
         val featureForm: FeatureForm,
-        val validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.OnlyAfterFocus
+        val validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.Automatic
     ) : UIState()
 
     /**
@@ -145,7 +145,7 @@ class MapViewModel @Inject constructor(
         // ValidationErrorVisibility.Always
         _uiState.value = UIState.Editing(
             previousState.featureForm,
-            validationErrorVisibility = ValidationErrorVisibility.Always
+            validationErrorVisibility = ValidationErrorVisibility.Visible
         )
         return Result.success(Unit)
     }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -18,6 +18,7 @@ import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.view.MapView
 import com.arcgismaps.mapping.view.SingleTapConfirmedEvent
 import com.arcgismaps.toolkit.composablemap.MapState
+import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureformsapp.data.PortalItemRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -36,7 +37,7 @@ sealed class UIState {
     /**
      * In editing state with the [featureForm].
      */
-    data class Editing(val featureForm: FeatureForm) : UIState()
+    data class Editing(val featureForm: FeatureForm, val validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.OnlyAfterFocus) : UIState()
 
     data class Committing(val featureForm: FeatureForm, val errors: List<String>) :
         UIState()
@@ -111,7 +112,7 @@ class MapViewModel @Inject constructor(
         val previousState = (_uiState.value as? UIState.Committing) ?: return Result.failure(
             IllegalStateException("Not in committing state")
         )
-        _uiState.value = UIState.Editing(previousState.featureForm)
+        _uiState.value = UIState.Editing(previousState.featureForm, validationErrorVisibility = ValidationErrorVisibility.Always)
         return Result.success(Unit)
     }
 

--- a/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
+++ b/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
@@ -17,4 +17,15 @@
     <string name="sign_in_with_default_credentials">Sign in using built-in Credentials</string>
     <string name="sign_in_with_enterprise">Sign in with ArcGIS Enterprise</string>
     <string name="skin_sign_in">Skip sign in</string>
+    <string name="maximum_character_length_exceeded">Maximum character length exceeded</string>
+    <string name="date_less_than_minimum">Date less than minimum</string>
+    <string name="value_must_be_of_correct_type">Value must be of correct type.</string>
+    <string name="date_exceeds_maximum">Date exceeds maximum</string>
+    <string name="exceeds_maximum_value">Exceeds maximum value</string>
+    <string name="minimum_character_length_not_met">Minimum character length not met</string>
+    <string name="less_than_minimum_value">Less than minimum value</string>
+    <string name="value_must_not_be_empty">Value must not be empty</string>
+    <string name="value_must_be_within_domain">Value must be within domain</string>
+    <string name="required">Required</string>
+    <string name="unknown_error">Unknown Error</string>
 </resources>

--- a/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
+++ b/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
@@ -1,14 +1,6 @@
 <resources>
     <string name="app_name">FeatureFormsApp</string>
     <string name="edit_feature">Edit Feature</string>
-    <string name="map_url_orig">https://runtimecoretest.maps.arcgis.com/home/item.html?id=df0f27f83eee41b0afe4b6216f80b541</string>
-    <string name="map_url_text_box_area">https://runtimecoretest.maps.arcgis.com/home/item.html?id=454422bdf7e24fb0ba4ffe0a22f6bf37</string>
-    <string name="map_url_visibility">https://runtimecoretest.maps.arcgis.com/home/item.html?id=c606b1f345044d71881f99d00583f8f7</string>
-    <string name="map_url_editable">https://runtimecoretest.maps.arcgis.com/home/item.html?id=622c4674d6f64114a1de2e0b8382fcf3</string>
-    <string name="map_url_length_default_value">https://runtimecoretest.maps.arcgis.com/home/item.html?id=a81d90609e4549479d1f214f28335af2</string>
-    <string name="map_url_range_domain_combo">https://runtimecoretest.maps.arcgis.com/home/item.html?id=bb4c5e81740e4e7296943988c78a7ea6</string>
-    <string name="map_url_all_text_state">https://runtimecoretest.maps.arcgis.com/home/item.html?id=5d69e2301ad14ec8a73b568dfc29450a</string>
-    <string name="map_url_redlands_hydrants">https://runtimecoretest.maps.arcgis.com/home/item.html?id=0f6864ddc35241649e5ad2ee61a3abe4</string>
     <string name="agol_portal_url">https://www.arcgis.com</string>
     <string name="login">Login</string>
     <string name="cancel">Cancel</string>

--- a/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
+++ b/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
@@ -28,4 +28,8 @@
     <string name="value_must_be_within_domain">Value must be within domain</string>
     <string name="required">Required</string>
     <string name="unknown_error">Unknown Error</string>
+    <string name="the_form_has_errors">The Form has errors</string>
+    <string name="errors_must_be_fixed_to_submit_this_form">Errors must be fixed to submit this form</string>
+    <string name="attributes_failed">%1$s attributes failed.</string>
+    <string name="view">View</string>
 </resources>

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -61,8 +61,21 @@ import com.arcgismaps.toolkit.featureforms.utils.FeatureFormDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 
+/**
+ * The "property" determines the behavior of when the validation errors are visible.
+ */
 public sealed class ValidationErrorVisibility {
+
+    /**
+     * Indicates that the validation errors are only visible for editable fields that have
+     * received focus.
+     */
     public object OnlyAfterFocus : ValidationErrorVisibility()
+
+    /**
+     * Indicates the validation is run for all the editable fields regardless of their focus state,
+     * and any errors are shown.
+     */
     public object Always : ValidationErrorVisibility()
 }
 
@@ -74,6 +87,9 @@ public sealed class ValidationErrorVisibility {
  * @param featureForm The [FeatureForm] configuration.
  * @param modifier The [Modifier] to be applied to layout corresponding to the content of this
  * FeatureForm.
+ * @param validationErrorVisibility The [ValidationErrorVisibility] that determines the behavior of
+ * when the validation errors are visible. Default is [ValidationErrorVisibility.OnlyAfterFocus] which
+ * indicates errors are only visible once the respective field gains focus.
  *
  * @since 200.2.0
  */

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -108,7 +108,7 @@ public fun FeatureForm(
     FeatureFormBody(form = featureForm, states = states, modifier = modifier)
     FeatureFormDialog()
     LaunchedEffect(featureForm) {
-        // ensure expressions are evaluated before state objects are created.
+        // ensure expressions are evaluated
         featureForm.evaluateExpressions()
         // add an artificial delay of 300ms to avoid the slight flicker if the
         // expressions are evaluated quickly

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -43,6 +45,7 @@ import com.arcgismaps.mapping.featureforms.SwitchFormInput
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
+import com.arcgismaps.toolkit.featureforms.components.base.BaseGroupState
 import com.arcgismaps.toolkit.featureforms.components.base.FormStateCollection
 import com.arcgismaps.toolkit.featureforms.components.base.MutableFormStateCollection
 import com.arcgismaps.toolkit.featureforms.components.base.getState
@@ -78,7 +81,7 @@ public sealed class ValidationErrorVisibility {
 public fun FeatureForm(
     featureForm: FeatureForm,
     modifier: Modifier = Modifier,
-    validationErrorVisibility : ValidationErrorVisibility = ValidationErrorVisibility.OnlyAfterFocus
+    validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.OnlyAfterFocus
 ) {
     var initialEvaluation by rememberSaveable(featureForm) { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
@@ -98,10 +101,14 @@ public fun FeatureForm(
     }
     LaunchedEffect(validationErrorVisibility) {
         if (validationErrorVisibility == ValidationErrorVisibility.Always) {
-            states.forEach {
-                if (it.formElement is FieldFormElement) {
-                    val state = it.getState<BaseFieldState<Any>>()
-                    state.onFocusChanged(true)
+            states.forEach { entry ->
+                if (entry.formElement is FieldFormElement) {
+                    entry.getState<BaseFieldState<*>>().forceValidation()
+                }
+                if (entry.formElement is GroupFormElement) {
+                    entry.getState<BaseGroupState>().fieldStates.forEach { childEntry ->
+                        childEntry.getState<BaseFieldState<*>>().forceValidation()
+                    }
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -70,13 +70,13 @@ public sealed class ValidationErrorVisibility {
      * Indicates that the validation errors are only visible for editable fields that have
      * received focus.
      */
-    public object OnlyAfterFocus : ValidationErrorVisibility()
+    public object Automatic : ValidationErrorVisibility()
 
     /**
      * Indicates the validation is run for all the editable fields regardless of their focus state,
      * and any errors are shown.
      */
-    public object Always : ValidationErrorVisibility()
+    public object Visible : ValidationErrorVisibility()
 }
 
 /**
@@ -88,7 +88,7 @@ public sealed class ValidationErrorVisibility {
  * @param modifier The [Modifier] to be applied to layout corresponding to the content of this
  * FeatureForm.
  * @param validationErrorVisibility The [ValidationErrorVisibility] that determines the behavior of
- * when the validation errors are visible. Default is [ValidationErrorVisibility.OnlyAfterFocus] which
+ * when the validation errors are visible. Default is [ValidationErrorVisibility.Automatic] which
  * indicates errors are only visible once the respective field gains focus.
  *
  * @since 200.2.0
@@ -97,7 +97,7 @@ public sealed class ValidationErrorVisibility {
 public fun FeatureForm(
     featureForm: FeatureForm,
     modifier: Modifier = Modifier,
-    validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.OnlyAfterFocus
+    validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.Automatic
 ) {
     var initialEvaluation by rememberSaveable(featureForm) { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
@@ -118,7 +118,7 @@ public fun FeatureForm(
     // launch a new side effect in a launched effect when validationErrorVisibility changes
     LaunchedEffect(validationErrorVisibility) {
         // if it set to always show errors force each field to validate itself and show any errors
-        if (validationErrorVisibility == ValidationErrorVisibility.Always) {
+        if (validationErrorVisibility == ValidationErrorVisibility.Visible) {
             states.forEach { entry ->
                 // validate all fields
                 if (entry.formElement is FieldFormElement) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -66,13 +66,17 @@ import kotlinx.coroutines.delay
  * @param featureForm The [FeatureForm] configuration.
  * @param modifier The [Modifier] to be applied to layout corresponding to the content of this
  * FeatureForm.
+ * @param forceValidation Default behavior for when "property" is "x" validation errors are visible for fields that receive focus.
+ *
+ * When set to "x" runs validates on the values of fields that were never focused and shows the errors if any.
  *
  * @since 200.2.0
  */
 @Composable
 public fun FeatureForm(
     featureForm: FeatureForm,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    forceValidation : Boolean = false
 ) {
     var initialEvaluation by rememberSaveable(featureForm) { mutableStateOf(false) }
     InitializingExpressions(modifier) {
@@ -86,6 +90,7 @@ public fun FeatureForm(
         // expressions are evaluated quickly
         delay(300)
         initialEvaluation = true
+        featureForm.getValidationErrors()
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -115,12 +115,16 @@ public fun FeatureForm(
         delay(300)
         initialEvaluation = true
     }
+    // launch a new side effect in a launched effect when validationErrorVisibility changes
     LaunchedEffect(validationErrorVisibility) {
+        // if it set to always show errors force each field to validate itself and show any errors
         if (validationErrorVisibility == ValidationErrorVisibility.Always) {
             states.forEach { entry ->
+                // validate all fields
                 if (entry.formElement is FieldFormElement) {
                     entry.getState<BaseFieldState<*>>().forceValidation()
                 }
+                // validate any fields that are within a group
                 if (entry.formElement is GroupFormElement) {
                     entry.getState<BaseGroupState>().fieldStates.forEach { childEntry ->
                         childEntry.getState<BaseFieldState<*>>().forceValidation()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -263,8 +263,20 @@ internal abstract class BaseFieldState<T>(
     open fun validate(): List<ValidationErrorState> {
         val errors = defaultValidator()
         return buildList {
-            if (errors.any { it is FeatureFormValidationException.RequiredException }) {
-                add(ValidationErrorState.Required)
+            errors.forEach {
+                when(it) {
+                    is FeatureFormValidationException.RequiredException -> {
+                        add(ValidationErrorState.Required)
+                    }
+
+                    is FeatureFormValidationException.OutOfDomainException -> {
+                        add(ValidationErrorState.NotInCodedValueDomain)
+                    }
+
+                    is FeatureFormValidationException.NullNotAllowedException -> {
+                        add(ValidationErrorState.NullNotAllowed)
+                    }
+                }
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -147,6 +147,16 @@ internal abstract class BaseFieldState<T>(
     }
 
     /**
+     * Forces the validation of this field irrespective of the current focus state [isFocused] and
+     * generates any validation errors via the [value] property. Avoid calling this method in any
+     * open/abstract class constructors since it indirectly invokes open members.
+     */
+    fun forceValidation() {
+        wasFocused = true
+        updateValidation()
+    }
+
+    /**
      * Runs and updates the validation using [validate] and [filterErrors]. Avoid calling this
      * method in any open/abstract class constructors since it directly invokes open members.
      */

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FieldValidation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FieldValidation.kt
@@ -30,9 +30,11 @@ internal sealed class ValidationErrorState(
     class MaxCharConstraint(max: Int) : ValidationErrorState(max)
     class MinNumericConstraint(min: String) : ValidationErrorState(min)
     class MaxNumericConstraint(max: String) : ValidationErrorState(max)
-    class MinMaxNumericConstraint(min : String, max: String) : ValidationErrorState(min, max)
+    class MinMaxNumericConstraint(min: String, max: String) : ValidationErrorState(min, max)
     object NotANumber : ValidationErrorState()
     object NotAWholeNumber : ValidationErrorState()
+    object NotInCodedValueDomain : ValidationErrorState()
+    object NullNotAllowed : ValidationErrorState()
 
     @Composable
     open fun getString(): String {
@@ -75,6 +77,14 @@ internal sealed class ValidationErrorState(
 
             is NotAWholeNumber -> {
                 stringResource(id = R.string.value_must_be_a_whole_number)
+            }
+
+            NotInCodedValueDomain -> {
+                stringResource(R.string.value_must_be_within_domain)
+            }
+
+            NullNotAllowed -> {
+                stringResource(R.string.value_must_not_be_empty)
             }
         }
     }

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -34,4 +34,6 @@
     <string name="exceeds_max_value">Exceeds maximum value %1$s</string>
     <string name="value_must_be_a_whole_number">Value must be a whole number</string>
     <string name="value_must_be_a_number">Value must be a number</string>
+    <string name="value_must_be_within_domain">Value must be within domain</string>
+    <string name="value_must_not_be_empty">Value must not be empty</string>
 </resources>


### PR DESCRIPTION
### Summary of changes

- Added the usage of `FeatureForm::getValidationErrors()` during form submission in the microapp to show any validation errors (for editable fields). If any errors are present, an `AlertDialog` displays the errors preventing the user from submitting the form. If no errors are present a progress dialog is displayed until saving the edits is complete.
- `FeatureForm` composable now accepts a new parameter of `ValidationErrorVisibility` which can be used to set the behavior for when the validation errors become visible on each field.