### PR TITLE
`Forms` : Added discardEdits API and UI

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -22,7 +24,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -51,6 +56,7 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
     val uiState by mapViewModel.uiState
     val context = LocalContext.current
     val windowSize = getWindowSize(context)
+    var showDiscardEditsDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -62,7 +68,7 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                 title = mapViewModel.portalItem.title,
                 editingMode = uiState is UIState.Editing,
                 onClose = {
-                    scope.launch { mapViewModel.rollbackEdits() }
+                    showDiscardEditsDialog = true
                 },
                 onSave = {
                     scope.launch {
@@ -130,6 +136,40 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             }
         }
     }
+    if (showDiscardEditsDialog) {
+        DiscardEditsDialog(
+            onConfirm = {
+                mapViewModel.rollbackEdits()
+                showDiscardEditsDialog = false
+            },
+            onCancel = {
+                showDiscardEditsDialog = false
+            }
+        )
+    }
+}
+
+@Composable
+fun DiscardEditsDialog(onConfirm: () -> Unit, onCancel: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onCancel,
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text(text = stringResource(R.string.discard))
+            }
+        },
+        dismissButton = {
+            Button(onClick = onCancel) {
+                Text(text = stringResource(R.string.cancel))
+            }
+        },
+        title = {
+            Text(text = stringResource(R.string.discard_edits))
+        },
+        text = {
+            Text(text = stringResource(R.string.all_changes_will_be_lost))
+        }
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -93,11 +93,9 @@ class MapViewModel @Inject constructor(
             }
     }
 
-    suspend fun rollbackEdits(): Result<Unit> {
+    fun rollbackEdits(): Result<Unit> {
         (_uiState.value as? UIState.Editing)?.let {
-            val feature = it.featureForm.feature
-            (feature.featureTable as? ServiceFeatureTable)?.undoLocalEdits()
-            feature.refresh()
+            it.featureForm.discardEdits()
             _uiState.value = UIState.NotEditing
             return Result.success(Unit)
         } ?: return Result.failure(IllegalStateException("Not in editing state"))

--- a/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
+++ b/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
@@ -17,4 +17,7 @@
     <string name="sign_in_with_default_credentials">Sign in using built-in Credentials</string>
     <string name="sign_in_with_enterprise">Sign in with ArcGIS Enterprise</string>
     <string name="skin_sign_in">Skip sign in</string>
+    <string name="discard">Discard</string>
+    <string name="discard_edits">Discard Edits?</string>
+    <string name="all_changes_will_be_lost">All changes made will be lost.</string>
 </resources>

--- a/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
+++ b/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
@@ -19,5 +19,5 @@
     <string name="skin_sign_in">Skip sign in</string>
     <string name="discard">Discard</string>
     <string name="discard_edits">Discard Edits?</string>
-    <string name="all_changes_will_be_lost">All changes made will be lost.</string>
+    <string name="all_changes_will_be_lost">All changes made within the form will be lost.</string>
 </resources>

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview


### PR DESCRIPTION
### Summary of changes

- Microapp now uses the api `FeatureForm.discardEdits()` instead of custom code.
- A confirmation dialog is displayed when the user clicks on the "cross" icon to discard the current edits to the feature.
- Fixes `369` where the form reloads when a feature form is being edited and the user taps on another feature.