### PR TITLE
bump sdk from 4085 to 4122

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,6 +54,6 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.4.0
-sdkBuildNumber=4085
+sdkBuildNumber=4122
 
 


### PR DESCRIPTION
in preparation for holistic testing events.