### PR TITLE
`Forms`: Make FormElementState internal

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FormElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FormElementState.kt
@@ -26,8 +26,8 @@ import com.arcgismaps.mapping.featureforms.FormElement
  * @param description Description text for the field.
  * @param isVisible Property that indicates if the field is visible.
  */
-public abstract class FormElementState(
-    public val label : String,
-    public val description: String,
-    public val isVisible : StateFlow<Boolean>
+internal abstract class FormElementState(
+    val label : String,
+    val description: String,
+    val isVisible : StateFlow<Boolean>
 )


### PR DESCRIPTION
### Summary 

- Makes `FormElementState` internal since it is not intended not to be public at the moment.