### PR TITLE
`Forms` : Update disabled fields style

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldNumericTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldNumericTests.kt
@@ -29,16 +29,10 @@ import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FeatureFormDefinition
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
-import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
-import com.arcgismaps.toolkit.featureforms.utils.editValue
-import com.arcgismaps.toolkit.featureforms.utils.fieldType
-import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import junit.framework.TestCase
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.BeforeClass
 import org.junit.Rule
@@ -84,31 +78,8 @@ class FormTextFieldNumericTests {
     fun testEnterNonNumericValueIntegerField() = runTest {
         composeTestRule.setContent {
             val scope = rememberCoroutineScope()
-            val textFieldProperties = TextFieldProperties(
-                label = integerField.label,
-                placeholder = integerField.hint,
-                description = integerField.description,
-                value = integerField.valueFlow(scope),
-                editable = integerField.isEditable,
-                required = integerField.isRequired,
-                singleLine = integerField.input is TextBoxFormInput,
-                domain = integerField.domain,
-                fieldType = featureForm.fieldType(integerField),
-                minLength = (integerField.input as TextBoxFormInput).minLength.toInt(),
-                maxLength = (integerField.input as TextBoxFormInput).maxLength.toInt(),
-                visible = integerField.isVisible
-            )
-            FormTextField(
-                state = FormTextFieldState(
-                    textFieldProperties,
-                    scope = scope,
-                    onEditValue = {
-                        featureForm.editValue(integerField, it)
-                        scope.launch { featureForm.evaluateExpressions() }
-                    },
-                    defaultValidator = {integerField.getValidationErrors()}
-                )
-            )
+            val state = rememberFieldState(element = integerField, form = featureForm, scope = scope) as FormTextFieldState
+            FormTextField(state = state)
         }
         val outlinedTextField = composeTestRule.onNodeWithContentDescription(outlinedTextFieldSemanticLabel)
         val text = "lorem ipsum"
@@ -128,31 +99,8 @@ class FormTextFieldNumericTests {
     fun testEnterNonNumericValueFloatingPointField() = runTest {
         composeTestRule.setContent {
             val scope = rememberCoroutineScope()
-            val textFieldProperties = TextFieldProperties(
-                label = floatingPointField.label,
-                placeholder = floatingPointField.hint,
-                description = floatingPointField.description,
-                value = floatingPointField.valueFlow(scope),
-                editable = floatingPointField.isEditable,
-                required = floatingPointField.isRequired,
-                singleLine = floatingPointField.input is TextBoxFormInput,
-                domain = floatingPointField.domain,
-                fieldType = featureForm.fieldType(floatingPointField),
-                minLength = (floatingPointField.input as TextBoxFormInput).minLength.toInt(),
-                maxLength = (floatingPointField.input as TextBoxFormInput).maxLength.toInt(),
-                visible = floatingPointField.isVisible
-            )
-            FormTextField(
-                state = FormTextFieldState(
-                    textFieldProperties,
-                    scope = scope,
-                    onEditValue = {
-                        featureForm.editValue(floatingPointField, it)
-                        scope.launch { featureForm.evaluateExpressions() }
-                    },
-                    defaultValidator = {floatingPointField.getValidationErrors()}
-                )
-            )
+            val state = rememberFieldState(element = floatingPointField, form = featureForm, scope = scope) as FormTextFieldState
+            FormTextField(state = state)
         }
         val outlinedTextField = composeTestRule.onNodeWithContentDescription(outlinedTextFieldSemanticLabel)
         val text = "lorem ipsum"

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldRangeNumericTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldRangeNumericTests.kt
@@ -29,16 +29,10 @@ import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FeatureFormDefinition
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextField
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
-import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
-import com.arcgismaps.toolkit.featureforms.utils.editValue
-import com.arcgismaps.toolkit.featureforms.utils.fieldType
-import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import junit.framework.TestCase
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.BeforeClass
 import org.junit.Rule
@@ -77,31 +71,8 @@ class FormTextFieldRangeNumericTests {
     fun testEnterNumericValueOutOfRange() = runTest {
         composeTestRule.setContent {
             val scope = rememberCoroutineScope()
-            val textFieldProperties = TextFieldProperties(
-                label = integerField.label,
-                placeholder = integerField.hint,
-                description = integerField.description,
-                value = integerField.valueFlow(scope),
-                editable = integerField.isEditable,
-                required = integerField.isRequired,
-                singleLine = integerField.input is TextBoxFormInput,
-                domain = integerField.domain,
-                fieldType = featureForm.fieldType(integerField),
-                minLength = (integerField.input as TextBoxFormInput).minLength.toInt(),
-                maxLength = (integerField.input as TextBoxFormInput).maxLength.toInt(),
-                visible = integerField.isVisible
-            )
-            FormTextField(
-                state = FormTextFieldState(
-                    textFieldProperties,
-                    scope = scope,
-                    onEditValue = {
-                        featureForm.editValue(integerField, it)
-                        scope.launch { featureForm.evaluateExpressions() }
-                    },
-                    defaultValidator = {integerField.getValidationErrors()}
-                )
-            )
+            val state = rememberFieldState(element = integerField, form = featureForm, scope = scope) as FormTextFieldState
+            FormTextField(state = state)
         }
         val outlinedTextField = composeTestRule.onNodeWithContentDescription(outlinedTextFieldSemanticLabel)
         val text = "9"

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
-import androidx.compose.ui.test.printToLog
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.data.QueryParameters
@@ -180,7 +179,6 @@ class FormTextFieldTests {
     @Test
     fun testEnteredValueUnfocusedState() {
         val outlinedTextField = composeTestRule.onNodeWithContentDescription(outlinedTextFieldSemanticLabel, useUnmergedTree = true)
-        outlinedTextField.printToLog("TAG")
         val text = "lorem ipsum"
         outlinedTextField.performTextInput(text)
         outlinedTextField.assertIsFocused()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
@@ -250,7 +250,6 @@ internal fun BaseTextField(
                                 .clickable {
                                     clearFocus = true
                                 }
-                                .semantics { contentDescription = "supporting text" }
                         ) {
                             supportingText?.invoke(this)
                         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
@@ -16,19 +16,30 @@
 
 package com.arcgismaps.toolkit.featureforms.components.base
 
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 
 @Composable
-internal fun baseTextFieldColors(isEditable: Boolean, isEmpty: Boolean, isPlaceholderEmpty: Boolean): TextFieldColors {
+internal fun baseTextFieldColors(
+    isEditable: Boolean,
+    isEmpty: Boolean,
+    isPlaceholderEmpty: Boolean,
+    interactionSource: InteractionSource
+): TextFieldColors {
+    val focused by interactionSource.collectIsFocusedAsState()
     val textColor = BaseTextFieldColors.textColor(
         isEditable = isEditable,
         isEmpty = isEmpty,
-        isPlaceHolderEmpty = isPlaceholderEmpty
+        isPlaceHolderEmpty = isPlaceholderEmpty,
+        focused
     )
+
     val borderColor = BaseTextFieldColors.borderColor(
         isEditable = isEditable
     )
@@ -36,12 +47,13 @@ internal fun baseTextFieldColors(isEditable: Boolean, isEmpty: Boolean, isPlaceh
         isEditable = isEditable
     )
     return OutlinedTextFieldDefaults.colors(
-        focusedTextColor = textColor,
-        unfocusedTextColor = textColor,
+        focusedTextColor = if (focused) textColor else textColor.copy(0.5f),
+        unfocusedTextColor = textColor.copy(0.5f),
         focusedBorderColor = borderColor,
         focusedLabelColor = labelColor
     )
 }
+
 /**
  * Color properties of a base text field.
  */
@@ -52,22 +64,22 @@ internal object BaseTextFieldColors {
             MaterialTheme.colorScheme.primary
         else
             MaterialTheme.colorScheme.secondary.copy(alpha = 0.8f)
-    
+
     @Composable
     fun labelColor(isEditable: Boolean) =
         if (isEditable)
             MaterialTheme.colorScheme.primary
         else
             MaterialTheme.colorScheme.secondary.copy(alpha = 0.8f)
-    
+
     @Composable
-    fun textColor(isEditable: Boolean, isEmpty: Boolean, isPlaceHolderEmpty: Boolean): Color {
+    fun textColor(isEditable: Boolean, isEmpty: Boolean, isPlaceHolderEmpty: Boolean, isFocused: Boolean): Color {
         val color = if (isEmpty && !isPlaceHolderEmpty) {
             Color.Gray
         } else {
             MaterialTheme.colorScheme.secondary
         }
-        
+
         return if (isEditable) color else color.copy(alpha = 0.6f)
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
@@ -23,7 +23,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
 /**
- *  Color properties of a base text field.
+ *  Color properties of a base text field. Since non editable fields are rendered as read-only
+ *  text fields, the colors actually match disabled fields.
+ *
  *  Taken from the material 3 design :https://m3.material.io/components/text-fields/specs.
  */
 @Composable

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
@@ -16,70 +16,57 @@
 
 package com.arcgismaps.toolkit.featureforms.components.base
 
-import androidx.compose.foundation.interaction.InteractionSource
-import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 
+/**
+ *  Color properties of a base text field.
+ *  Taken from the material 3 design :https://m3.material.io/components/text-fields/specs.
+ */
 @Composable
 internal fun baseTextFieldColors(
     isEditable: Boolean,
-    isEmpty: Boolean,
-    isPlaceholderEmpty: Boolean,
-    interactionSource: InteractionSource
 ): TextFieldColors {
-    val focused by interactionSource.collectIsFocusedAsState()
-    val textColor = BaseTextFieldColors.textColor(
-        isEditable = isEditable,
-        isEmpty = isEmpty,
-        isPlaceHolderEmpty = isPlaceholderEmpty,
-        focused
-    )
-
-    val borderColor = BaseTextFieldColors.borderColor(
-        isEditable = isEditable
-    )
-    val labelColor = BaseTextFieldColors.labelColor(
-        isEditable = isEditable
-    )
-    return OutlinedTextFieldDefaults.colors(
-        focusedTextColor = if (focused) textColor else textColor.copy(0.5f),
-        unfocusedTextColor = textColor.copy(0.5f),
-        focusedBorderColor = borderColor,
-        focusedLabelColor = labelColor
-    )
+    return if (isEditable) {
+        OutlinedTextFieldDefaults.colors()
+    } else {
+        // non editable field colors are similar to disabled field colors.
+        val disabledColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+        val outlineColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+        OutlinedTextFieldDefaults.colors(
+            focusedLabelColor = disabledColor,
+            unfocusedLabelColor = disabledColor,
+            focusedSupportingTextColor = disabledColor,
+            unfocusedSupportingTextColor = disabledColor,
+            focusedTextColor = disabledColor,
+            unfocusedTextColor = disabledColor,
+            focusedBorderColor = outlineColor,
+            unfocusedBorderColor = outlineColor,
+        )
+    }
 }
 
 /**
- * Color properties of a base text field.
+ * Specifies the text color based on if the field is editable or a placeholder is being shown.
  */
-internal object BaseTextFieldColors {
-    @Composable
-    fun borderColor(isEditable: Boolean) =
-        if (isEditable)
-            MaterialTheme.colorScheme.primary
-        else
-            MaterialTheme.colorScheme.secondary.copy(alpha = 0.8f)
-
-    @Composable
-    fun labelColor(isEditable: Boolean) =
-        if (isEditable)
-            MaterialTheme.colorScheme.primary
-        else
-            MaterialTheme.colorScheme.secondary.copy(alpha = 0.8f)
-
-    @Composable
-    fun textColor(isEditable: Boolean, isEmpty: Boolean, isPlaceHolderEmpty: Boolean, isFocused: Boolean): Color {
-        val color = if (isEmpty && !isPlaceHolderEmpty) {
-            Color.Gray
-        } else {
-            MaterialTheme.colorScheme.secondary
-        }
-
-        return if (isEditable) color else color.copy(alpha = 0.6f)
+@Composable
+internal fun defaultTextColor(
+    isEditable: Boolean,
+    isEmpty: Boolean,
+    isPlaceholderEmpty: Boolean,
+) : Color {
+    val baseColor = MaterialTheme.colorScheme.onSurface
+    return if ((isEmpty && !isPlaceholderEmpty)) {
+        // if placeholder is visible, make it lighter than the actual input text color
+        baseColor.copy(alpha = 0.6f)
+    } else if (!isEditable) {
+        // if disabled
+        baseColor.copy(alpha = 0.38f)
+    } else {
+        // input text color
+        baseColor
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -87,7 +87,7 @@ internal fun DateTimeField(
                 text = supportingText,
                 color = supportingTextColor,
                 modifier = Modifier.semantics {
-                    contentDescription = "helper"
+                    contentDescription = "supporting text"
                 }
             )
         },


### PR DESCRIPTION
### Summary of changes

- Non editable fields are rendered as read-only fields but with the colors of disabled fields. This is so that the users can copy the text from a non-editable field but to establish a visual distinction they are presented as disabled fields.
- The color and alpha values are taken from the text field [material 3 design](https://m3.material.io/components/text-fields/specs#e4964192-72ad-414f-85b4-4b4357abb83c).
- Placeholder text is also rendered with a lighter alpha compared to the input text.