### PR TITLE
Add version to API ref

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,10 @@ plugins {
 
 buildscript {
     dependencies {
+        // there doesn't appear to be a better way to provide this to subprojects.
+        // this is what lets us put the version number dropdown list in the generated dokka.
+        // it is a "dokka plugin" which is not a gradle plugin, it needs to be on the classpath
+        // before any dependent subproject uses its symbols to configure a dokka task.
         classpath(libs.dokka.versioning)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,3 +25,9 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.dokka) apply false
 }
+
+buildscript {
+    dependencies {
+        classpath(libs.dokka.versioning)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
+dokka-versioning = { group = "org.jetbrains.dokka", name = "versioning-plugin", version.ref = "dokka" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }

--- a/kdoc/build.gradle.kts
+++ b/kdoc/build.gradle.kts
@@ -54,6 +54,9 @@ tasks {
     //./gradlew :documentation:dokkaHtml
     // doc output will be under `documentation/build/dokka/html`.
     dokkaHtml {
+        pluginConfiguration<org.jetbrains.dokka.versioning.VersioningPlugin, org.jetbrains.dokka.versioning.VersioningConfiguration> {
+            version = versionNumber
+        }
         moduleName.set("arcgis-maps-kotlin-toolkit")
         dokkaSourceSets {
             configureEach {
@@ -93,6 +96,9 @@ android {
 }
 
 dependencies {
+    // Puts the version in the KDoc
+    dokkaPlugin(libs.dokka.versioning)
+
     project.afterEvaluate {
        releasedModules.forEach { proj ->
            proj.configurations.forEach { config ->


### PR DESCRIPTION
### Description

PR to add the Dokka versioning plugin to the Toolkit project, to be able to display the ArcGIS version on the KDoc.

![image](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/assets/14892474/1c0bfbcc-e1dc-4605-9d27-f1cd746a6567)


### Testing

Run the gradle command: `./gradlew :kdoc:dokkaHtml`