### PR TITLE
Compose doc improvements

### DIFF
--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/MapView.kt
@@ -102,6 +102,11 @@ import kotlinx.coroutines.launch
  * @param onTwoPointerTap lambda invoked when a user taps two pointers on the composable MapView
  * @param onPan lambda invoked when a user drags a pointer or pointers across composable MapView
  * @param onDrawStatusChanged lambda invoked when the draw status of the composable MapView is changed
+ * @sample com.arcgismaps.toolkit.geocompose.samples.MapViewSample
+ * @see
+ * - <a href="https://developers.arcgis.com/kotlin/maps-2d/tutorials/display-a-map/">Display a map tutorial</a>
+ * - <a href="https://developers.arcgis.com/kotlin/maps-2d/tutorials/display-a-web-map/">Display a web map tutorial</a>
+ * - <a href="https://developers.arcgis.com/kotlin/maps-2d/tutorials/add-a-point-line-and-polygon/">Add a point, line, and polygon tutorial</a>
  * @since 200.4.0
  */
 @Composable

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/SceneView.kt
@@ -100,6 +100,10 @@ import java.time.Instant
  * @param onTwoPointerTap lambda invoked when a user taps two pointers on the composable SceneView
  * @param onPan lambda invoked when a user drags a pointer or pointers across composable SceneView
  * @param onDrawStatusChanged lambda invoked when the draw status of the composable SceneView is changed
+ * @sample com.arcgismaps.toolkit.geocompose.samples.SceneViewSample
+ * @see
+ * - <a href="https://developers.arcgis.com/kotlin/scenes-3d/tutorials/display-a-scene/">Display a scene tutorial</a>
+ * - <a href="https://developers.arcgis.com/kotlin/scenes-3d/tutorials/display-a-web-scene/">Display a web scene tutorial</a>
  * @since 200.4.0
  */
 @Composable

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
@@ -68,9 +68,9 @@ public fun SceneViewSample() {
  */
 @Composable
 public fun MapViewSample() {
-    // Display a feature layer MapView using a service feature table
+    // Display a feature layer in a MapView using a service feature table
 
-    // map used to display a feature layer
+    // create a map to display a feature layer
     val map = ArcGISMap(BasemapStyle.ArcGISTopographic).apply {
         initialViewpoint = Viewpoint( // USA viewpoint
             center = Point(-11e6, 5e6, SpatialReference.webMercator()),
@@ -78,7 +78,7 @@ public fun MapViewSample() {
         )
     }
 
-    // create a service feature table and a feature layer from it
+    // create a service feature table (which will be used to create a feature layer)
     val serviceFeatureTable = ServiceFeatureTable(
         uri = "https://services.arcgis.com/jIL9msH9OI208GCb/arcgis/rest/services/USA_Daytime_Population_2016/FeatureServer/0"
     )
@@ -86,7 +86,7 @@ public fun MapViewSample() {
     // create the feature layer using the service feature table
     val featureLayer: FeatureLayer = FeatureLayer.createWithFeatureTable(serviceFeatureTable)
 
-    // use symbol to show U.S. states with a black outline
+    // create symbol to show U.S. states with a black outline
     val lineSymbol = SimpleLineSymbol(
         style = SimpleLineSymbolStyle.Solid,
         color = Color.black,

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
@@ -2,6 +2,7 @@ package com.arcgismaps.toolkit.geocompose.samples
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.arcgismaps.Color
 import com.arcgismaps.data.ServiceFeatureTable
@@ -52,13 +53,18 @@ public fun SceneViewSample() {
         roll = 0.0
     )
 
-    // display the Composable SceneView
-    SceneView(
-        modifier = Modifier.fillMaxSize(),
-        arcGISScene = ArcGISScene(BasemapStyle.ArcGISImagery).apply {
+    // create a scene to display the elevation source
+    val scene = remember {
+        ArcGISScene(BasemapStyle.ArcGISImagery).apply {
             baseSurface = surface
             initialViewpoint = Viewpoint(cameraLocation, camera)
         }
+    }
+
+    // display the Composable SceneView
+    SceneView(
+        modifier = Modifier.fillMaxSize(),
+        arcGISScene = scene
     )
 }
 
@@ -71,11 +77,13 @@ public fun MapViewSample() {
     // Display a feature layer in a MapView using a service feature table
 
     // create a map to display a feature layer
-    val map = ArcGISMap(BasemapStyle.ArcGISTopographic).apply {
-        initialViewpoint = Viewpoint( // USA viewpoint
-            center = Point(-11e6, 5e6, SpatialReference.webMercator()),
-            scale = 1e8
-        )
+    val map = remember {
+        ArcGISMap(BasemapStyle.ArcGISTopographic).apply {
+            initialViewpoint = Viewpoint( // USA viewpoint
+                center = Point(-11e6, 5e6, SpatialReference.webMercator()),
+                scale = 1e8
+            )
+        }
     }
 
     // create a service feature table (which will be used to create a feature layer)

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
@@ -1,0 +1,111 @@
+package com.arcgismaps.toolkit.geocompose.samples
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.arcgismaps.Color
+import com.arcgismaps.data.ServiceFeatureTable
+import com.arcgismaps.geometry.Point
+import com.arcgismaps.geometry.SpatialReference
+import com.arcgismaps.mapping.ArcGISMap
+import com.arcgismaps.mapping.ArcGISScene
+import com.arcgismaps.mapping.ArcGISTiledElevationSource
+import com.arcgismaps.mapping.BasemapStyle
+import com.arcgismaps.mapping.Surface
+import com.arcgismaps.mapping.Viewpoint
+import com.arcgismaps.mapping.layers.FeatureLayer
+import com.arcgismaps.mapping.symbology.SimpleLineSymbol
+import com.arcgismaps.mapping.symbology.SimpleLineSymbolStyle
+import com.arcgismaps.mapping.symbology.SimpleRenderer
+import com.arcgismaps.mapping.view.Camera
+import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geocompose.SceneView
+
+/**
+ * @suppress Suppress this function from being indexed in the KDoc
+ */
+@Composable
+public fun SceneViewSample() {
+    // Display a SceneView with an elevation surface and an initial viewpoint
+
+    // add base surface for elevation data
+    val elevationSource = ArcGISTiledElevationSource(
+        uri = "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+    )
+    val surface = Surface().apply {
+        elevationSources.add(elevationSource)
+        // add an exaggeration factor to increase the 3D effect of the elevation.
+        elevationExaggeration = 2.5f
+    }
+
+    val cameraLocation = Point(
+        x = -118.794,
+        y = 33.909,
+        z = 5330.0,
+        spatialReference = SpatialReference.wgs84()
+    )
+
+    val camera = Camera(
+        locationPoint = cameraLocation,
+        heading = 355.0,
+        pitch = 72.0,
+        roll = 0.0
+    )
+
+    // display the Composable SceneView
+    SceneView(
+        modifier = Modifier.fillMaxSize(),
+        arcGISScene = ArcGISScene(BasemapStyle.ArcGISImagery).apply {
+            baseSurface = surface
+            initialViewpoint = Viewpoint(cameraLocation, camera)
+        }
+    )
+}
+
+
+/**
+ * @suppress Suppress this function from being indexed in the KDoc
+ */
+@Composable
+public fun MapViewSample() {
+    // Display a feature layer MapView using a service feature table
+
+    // map used to display a feature layer
+    val map = ArcGISMap(BasemapStyle.ArcGISTopographic).apply {
+        initialViewpoint = Viewpoint( // USA viewpoint
+            center = Point(-11e6, 5e6, SpatialReference.webMercator()),
+            scale = 1e8
+        )
+    }
+
+    // create a service feature table and a feature layer from it
+    val serviceFeatureTable = ServiceFeatureTable(
+        uri = "https://services.arcgis.com/jIL9msH9OI208GCb/arcgis/rest/services/USA_Daytime_Population_2016/FeatureServer/0"
+    )
+
+    // create the feature layer using the service feature table
+    val featureLayer: FeatureLayer = FeatureLayer.createWithFeatureTable(serviceFeatureTable)
+
+    // use symbol to show U.S. states with a black outline
+    val lineSymbol = SimpleLineSymbol(
+        style = SimpleLineSymbolStyle.Solid,
+        color = Color.black,
+        width = 1.0f
+    )
+
+    // set feature layer properties
+    featureLayer.apply {
+        // set renderer for the feature layer
+        renderer = SimpleRenderer(lineSymbol)
+        opacity = 0.8f
+        maxScale = 10000.0
+    }
+    // add the feature layer to the map's operational layers
+    map.operationalLayers.add(featureLayer)
+
+    // display the Composable MapView
+    MapView(
+        modifier = Modifier.fillMaxSize(),
+        arcGISMap = map
+    )
+}

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
@@ -2,6 +2,8 @@ package com.arcgismaps.toolkit.geocompose.samples
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.arcgismaps.Color
@@ -54,11 +56,11 @@ public fun SceneViewSample() {
     )
 
     // create a scene to display the elevation source
-    val scene = remember {
-        ArcGISScene(BasemapStyle.ArcGISImagery).apply {
+    val scene by remember {
+        mutableStateOf(ArcGISScene(BasemapStyle.ArcGISImagery).apply {
             baseSurface = surface
             initialViewpoint = Viewpoint(cameraLocation, camera)
-        }
+        })
     }
 
     // display the Composable SceneView
@@ -77,13 +79,13 @@ public fun MapViewSample() {
     // Display a feature layer in a MapView using a service feature table
 
     // create a map to display a feature layer
-    val map = remember {
-        ArcGISMap(BasemapStyle.ArcGISTopographic).apply {
+    val map by remember {
+        mutableStateOf(ArcGISMap(BasemapStyle.ArcGISTopographic).apply {
             initialViewpoint = Viewpoint( // USA viewpoint
                 center = Point(-11e6, 5e6, SpatialReference.webMercator()),
                 scale = 1e8
             )
-        }
+        })
     }
 
     // create a service feature table (which will be used to create a feature layer)

--- a/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
+++ b/toolkit/geo-compose/src/main/java/com/arcgismaps/toolkit/geocompose/samples/GeoViewDocSamples.kt
@@ -35,6 +35,7 @@ public fun SceneViewSample() {
     val elevationSource = ArcGISTiledElevationSource(
         uri = "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
     )
+
     val surface = Surface().apply {
         elevationSources.add(elevationSource)
         // add an exaggeration factor to increase the 3D effect of the elevation.
@@ -110,6 +111,7 @@ public fun MapViewSample() {
         opacity = 0.8f
         maxScale = 10000.0
     }
+
     // add the feature layer to the map's operational layers
     map.operationalLayers.add(featureLayer)
 


### PR DESCRIPTION
### Description
PR to add `@see` and `@sample` KDoc tags to help provide compose usage examples. I would like any feedback on the sample code and if we would like to showcase multiple usages. Currently, there is one for each MapView & SceneView. 

<img src="https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/assets/14892474/0df4e15a-23e4-4538-a0e6-d0400c5bc4f6" width="700">


### Doc changes: 
MapView:
- Display a map tutorial
- Display a web map tutorial
- Add a point, line, and polygon tutorial
- Sample: Display a feature layer MapView using a service feature table

SceneView: 
- Display a scene tutorial
- Display a web scene tutorial
- Sample: Display a SceneView with an elevation surface using an image server