### PR TITLE
`Forms` : Consume latest sdk

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -55,4 +55,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.4.0
-sdkBuildNumber=4140
+sdkBuildNumber=4148

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,4 +55,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.4.0
-sdkBuildNumber=4150
+sdkBuildNumber=4155

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,4 +55,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.4.0
-sdkBuildNumber=4148
+sdkBuildNumber=4150

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -288,5 +288,12 @@ internal abstract class BaseFieldState<T>(
         }
     }
 
+    /**
+     * Implement this method to that provides the proper type conversion from [T] to an Any?. This
+     * method is used by [onValueChanged] to cast the [input] before calling
+     * [FieldFormElement.updateValue]
+     *
+     * @param input The value to convert
+     */
     abstract fun typeConverter(input: T) : Any?
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -288,9 +288,9 @@ internal abstract class BaseFieldState<T>(
     }
 
     /**
-     * Implement this method to that provides the proper type conversion from [T] to an Any?. This
+     * Implement this method to provide the proper type conversion from [T] to an Any?. This
      * method is used by [onValueChanged] to cast the [input] before calling
-     * [FieldFormElement.updateValue]
+     * [FieldFormElement.updateValue].
      *
      * @param input The value to convert
      */

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -195,6 +195,15 @@ internal abstract class BaseFieldState<T>(
                     updateValidation()
                 }
             }
+            // start listening to calculated value updates immediately
+            scope.launch {
+                // update the current value when the calculated value changes
+                // calculated properties do not get validated
+                _calculatedValue.collect {
+                    _value.value = Value(it)
+                    updateValidation()
+                }
+            }
         }
     }
 
@@ -251,8 +260,8 @@ internal abstract class BaseFieldState<T>(
         // focus event
         wasFocused = true
         onEditValue(input)
-        _value.value = Value(input)
-        updateValidation()
+        //_value.value = Value(input)
+        //updateValidation()
     }
 
     /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -86,8 +86,7 @@ internal abstract class BaseFieldState<T>(
     /**
      * Backing mutable state for the [value].
      */
-    @Suppress("PropertyName")
-    protected val _value : MutableState<Value<T>> = mutableStateOf(Value(initialValue))
+    private val _value : MutableState<Value<T>> = mutableStateOf(Value(initialValue))
 
     /**
      * Current value for this field state. The actual data of this type is wrapped in a [Value]

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -176,7 +176,6 @@ internal abstract class BaseFieldState<T>(
      * method in any open/abstract class constructors since it directly invokes open members.
      */
     private fun updateValidation(value : T) {
-        //val currentValue = _value.value.data
         val error = filterErrors(validate())
         // update the value with the validation error.
         _value.value = Value(value, error)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -23,6 +23,7 @@ import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
+import com.arcgismaps.toolkit.featureforms.utils.isNullOrEmptyString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
@@ -89,21 +90,19 @@ internal abstract class CodedValueFieldState(
     val fieldType: FieldType = properties.fieldType
 
     /**
-     * Returns the name of the [code] if it is present in [codedValues] else returns null.
+     * Returns the name of the [code] if it is present in [codedValues] else returns an empty string.
      */
-    fun getCodedValueNameOrNull(code: Any?): String? {
+    fun getNameForCodedValue(code: Any?): String {
         return codedValues.find {
             it.code.toString() == code.toString()
-        }?.name
+        }?.name ?: ""
     }
 
-//    override fun onValueChanged(input: Any?) {
-//        wasFocused = true
-//        val code = codedValues.firstOrNull {
-//            it.name == input
-//        }?.code
-//        onEditValue(code)
-//        _value.value = Value(input)
-//        updateValidation(input)
-//    }
+    override fun typeConverter(input: Any?): Any? {
+        return if (input.isNullOrEmptyString()) {
+            null
+        } else {
+            input
+        }
+    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -22,7 +22,6 @@ import com.arcgismaps.data.FieldType
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
-import com.arcgismaps.toolkit.featureforms.components.base.Value
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -31,7 +30,7 @@ internal open class CodedValueFieldProperties(
     label: String,
     placeholder: String,
     description: String,
-    value: StateFlow<String>,
+    value: StateFlow<Any?>,
     required: StateFlow<Boolean>,
     editable: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
@@ -39,7 +38,7 @@ internal open class CodedValueFieldProperties(
     val codedValues: List<CodedValue>,
     val showNoValueOption: FormInputNoValueOption,
     val noValueLabel: String
-) : FieldProperties<String>(label, placeholder, description, value, required, editable, visible)
+) : FieldProperties<Any?>(label, placeholder, description, value, required, editable, visible)
 
 /**
  * A class to handle the state of any coded value type. Essential properties are inherited
@@ -57,11 +56,11 @@ internal open class CodedValueFieldProperties(
 @Stable
 internal abstract class CodedValueFieldState(
     properties: CodedValueFieldProperties,
-    initialValue: String = properties.value.value,
+    initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
     onEditValue: ((Any?) -> Unit),
     defaultValidator: () -> List<Throwable>
-) : BaseFieldState<String>(
+) : BaseFieldState<Any?>(
     properties = properties,
     scope = scope,
     initialValue = initialValue,
@@ -98,13 +97,13 @@ internal abstract class CodedValueFieldState(
         }?.name
     }
 
-    override fun onValueChanged(input: String) {
-        wasFocused = true
-        val code = codedValues.firstOrNull {
-            it.name == input
-        }?.code
-        onEditValue(code)
-        _value.value = Value(input)
-        updateValidation()
-    }
+//    override fun onValueChanged(input: Any?) {
+//        wasFocused = true
+//        val code = codedValues.firstOrNull {
+//            it.name == input
+//        }?.code
+//        onEditValue(code)
+//        _value.value = Value(input)
+//        updateValidation(input)
+//    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -17,7 +17,6 @@
 package com.arcgismaps.toolkit.featureforms.components.codedvalue
 
 import android.content.res.Configuration
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -312,10 +311,6 @@ internal fun ComboBoxDialog(
                                     }
                                 },
                             trailingContent = {
-                                Log.e(
-                                    "TAG",
-                                    "ComboBoxDialog: $label, code:$code, init:$initialValue, name:$name",
-                                )
                                 if ((code == initialValue) || ((name == noValueLabel) && (initialValue == null))) {
                                     Icon(
                                         imageVector = Icons.Outlined.Check,
@@ -379,5 +374,3 @@ private fun ComboBoxPreview() {
     )
     ComboBoxField(state = state)
 }
-
-

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -116,7 +116,7 @@ internal fun ComboBoxField(
     }
 
     BaseTextField(
-        text = state.getCodedValueNameOrNull(value.data) ?: value.data,
+        text = state.getCodedValueNameOrNull(value.data) ?: "",
         onValueChange = state::onValueChanged,
         modifier = modifier,
         readOnly = true,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -17,6 +17,7 @@
 package com.arcgismaps.toolkit.featureforms.components.codedvalue
 
 import android.content.res.Configuration
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -116,8 +117,13 @@ internal fun ComboBoxField(
     }
 
     BaseTextField(
-        text = state.getCodedValueNameOrNull(value.data) ?: "",
-        onValueChange = state::onValueChanged,
+        text = state.getNameForCodedValue(value.data),
+        onValueChange = {
+            // usually only triggered on a "clear" action
+            // this value will be an empty string and the type conversion must be handled
+            // by the state object
+            state.onValueChanged(it)
+        },
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
@@ -149,7 +155,7 @@ internal fun ComboBoxField(
 
 @Composable
 internal fun ComboBoxDialog(
-    initialValue: String,
+    initialValue: Any?,
     values: Map<Any?, String>,
     label: String,
     description: String,
@@ -157,7 +163,7 @@ internal fun ComboBoxDialog(
     noValueOption: FormInputNoValueOption,
     noValueLabel: String,
     keyboardType: KeyboardType,
-    onValueChange: (String) -> Unit,
+    onValueChange: (Any?) -> Unit,
     onDismissRequest: () -> Unit
 ) {
     val configuration = LocalConfiguration.current
@@ -165,7 +171,7 @@ internal fun ComboBoxDialog(
     var searchText by rememberSaveable { mutableStateOf("") }
     val codedValues = if (!isRequired) {
         if (noValueOption == FormInputNoValueOption.Show) {
-            mapOf("" to noValueLabel) + values
+            mapOf(null to noValueLabel) + values
         } else values
     } else values
 
@@ -293,9 +299,9 @@ internal fun ComboBoxDialog(
                                 .clickable {
                                     // if the no value label was selected, set the value to be empty
                                     if (name == noValueLabel) {
-                                        onValueChange("")
+                                        onValueChange(null)
                                     } else {
-                                        onValueChange(name)
+                                        onValueChange(code)
                                     }
                                 }
                                 .semantics {
@@ -306,7 +312,11 @@ internal fun ComboBoxDialog(
                                     }
                                 },
                             trailingContent = {
-                                if (name == initialValue || (name == noValueLabel && initialValue.isEmpty())) {
+                                Log.e(
+                                    "TAG",
+                                    "ComboBoxDialog: $label, code:$code, init:$initialValue, name:$name",
+                                )
+                                if ((code == initialValue) || ((name == noValueLabel) && (initialValue == null))) {
                                     Icon(
                                         imageVector = Icons.Outlined.Check,
                                         contentDescription = "list item check"

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -80,7 +79,7 @@ internal class ComboBoxFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = { newValue ->
-                        formElement.editValue(newValue)
+                        formElement.updateValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = formElement::getValidationErrors
@@ -117,7 +116,7 @@ internal fun rememberComboBoxFieldState(
         ),
         scope = scope,
         onEditValue = {
-            field.editValue(it)
+            field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = field::getValidationErrors

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
@@ -77,7 +77,7 @@ internal class ComboBoxFieldState(
                         noValueLabel = input.noValueLabel,
                         fieldType = formElement.fieldType
                     ),
-                    initialValue = list[0] as String,
+                    initialValue = list[0],
                     scope = scope,
                     onEditValue = { newValue ->
                         formElement.editValue(newValue)
@@ -89,10 +89,6 @@ internal class ComboBoxFieldState(
                 }
             }
         )
-    }
-
-    override fun typeConverter(input: Any?): Any? {
-        TODO("Not yet implemented")
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -67,7 +66,7 @@ internal class ComboBoxFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.valueFlow(scope),
+                        value = formElement.value,
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         visible = formElement.isVisible,
@@ -105,7 +104,7 @@ internal fun rememberComboBoxFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.valueFlow(scope),
+            value = field.value,
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.launch
  */
 internal class ComboBoxFieldState(
     properties: CodedValueFieldProperties,
-    initialValue: String = properties.value.value,
+    initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
     onEditValue: ((Any?) -> Unit),
     defaultValidator: () -> List<Throwable>
@@ -89,6 +89,10 @@ internal class ComboBoxFieldState(
                 }
             }
         )
+    }
+
+    override fun typeConverter(input: Any?): Any? {
+        TODO("Not yet implemented")
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
@@ -24,7 +24,6 @@ import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.toolkit.featureforms.utils.editValue
-import com.arcgismaps.toolkit.featureforms.utils.fieldType
 import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -76,12 +75,12 @@ internal class ComboBoxFieldState(
                         codedValues = input.codedValues,
                         showNoValueOption = input.noValueOption,
                         noValueLabel = input.noValueLabel,
-                        fieldType = form.fieldType(formElement)
+                        fieldType = formElement.fieldType
                     ),
                     initialValue = list[0] as String,
                     scope = scope,
                     onEditValue = { newValue ->
-                        form.editValue(formElement, newValue)
+                        formElement.editValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = formElement::getValidationErrors
@@ -114,11 +113,11 @@ internal fun rememberComboBoxFieldState(
             codedValues = input.codedValues,
             showNoValueOption = input.noValueOption,
             noValueLabel = input.noValueLabel,
-            fieldType = form.fieldType(field)
+            fieldType = field.fieldType
         ),
         scope = scope,
         onEditValue = {
-            form.editValue(field, it)
+            field.editValue(it)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = field::getValidationErrors

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.R
+import com.arcgismaps.toolkit.featureforms.utils.isNullOrEmptyString
 
 @Composable
 internal fun RadioButtonField(
@@ -72,7 +73,7 @@ internal fun RadioButtonField(
 private fun RadioButtonField(
     label: String,
     description: String,
-    value: String,
+    value: Any?,
     editable: Boolean,
     required: Boolean,
     codedValues: Map<Any?, String>,
@@ -119,7 +120,7 @@ private fun RadioButtonField(
                 options.forEach { (_, name) ->
                     RadioButtonRow(
                         value = name,
-                        selected = name == value || (name == noValueLabel && value.isEmpty()),
+                        selected = name == value || (name == noValueLabel && value.isNullOrEmptyString()),
                         enabled = editable,
                         onClick = { onValueChanged(name) }
                     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.components.codedvalue
 
-import android.util.Log
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -29,7 +28,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -43,8 +41,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.R
-import com.arcgismaps.toolkit.featureforms.components.formelement.RecompositionScope
-import com.arcgismaps.toolkit.featureforms.utils.isNullOrEmptyString
 
 @Composable
 internal fun RadioButtonField(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
-import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -83,7 +82,7 @@ internal class RadioButtonFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.valueFlow(scope),
+                        value = formElement.value,
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         visible = formElement.isVisible,
@@ -119,7 +118,7 @@ internal fun rememberRadioButtonFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.valueFlow(scope),
+            value = field.value,
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
-import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -96,7 +95,7 @@ internal class RadioButtonFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = { newValue ->
-                        formElement.editValue(newValue)
+                        formElement.updateValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = formElement::getValidationErrors
@@ -131,7 +130,7 @@ internal fun rememberRadioButtonFieldState(
         ),
         scope = scope,
         onEditValue = {
-            field.editValue(it)
+            field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = field::getValidationErrors

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -24,7 +24,6 @@ import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.toolkit.featureforms.utils.editValue
-import com.arcgismaps.toolkit.featureforms.utils.fieldType
 import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -91,7 +90,7 @@ internal class RadioButtonFieldState(
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         visible = formElement.isVisible,
-                        fieldType = form.fieldType(formElement),
+                        fieldType = formElement.fieldType,
                         codedValues = input.codedValues,
                         showNoValueOption = input.noValueOption,
                         noValueLabel = input.noValueLabel
@@ -99,7 +98,8 @@ internal class RadioButtonFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = { newValue ->
-                        form.editValue(formElement, newValue)
+                        //form.editValue(formElement, newValue)
+                        formElement.editValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = formElement::getValidationErrors
@@ -127,14 +127,14 @@ internal fun rememberRadioButtonFieldState(
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,
-            fieldType = form.fieldType(field),
+            fieldType = field.fieldType,
             codedValues = input.codedValues,
             showNoValueOption = input.noValueOption,
             noValueLabel = input.noValueLabel
         ),
         scope = scope,
         onEditValue = {
-            form.editValue(field, it)
+            field.editValue(it)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = field::getValidationErrors

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -56,17 +56,13 @@ internal class RadioButtonFieldState(
      * trigger a fallback to a ComboBox. If the [value] is empty then this returns false.
      */
     fun shouldFallback(): Boolean {
-        return if (value.value.data.isNullOrEmptyString()) {
+        return if (value.value.data == null) {
             false
         } else {
             !codedValues.any {
                 it.name == value.value.data
             }
         }
-    }
-
-    override fun typeConverter(input: Any?): Any? {
-        TODO("Not yet implemented")
     }
 
     companion object {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -24,7 +24,6 @@ import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.toolkit.featureforms.utils.editValue
-import com.arcgismaps.toolkit.featureforms.utils.isNullOrEmptyString
 import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -52,16 +51,14 @@ internal class RadioButtonFieldState(
     }
 
     /**
-     * Returns true if the current value of [value] is not in the [codedValues]. This should
-     * trigger a fallback to a ComboBox. If the [value] is empty then this returns false.
+     * Returns true if the initial value is not in the [codedValues]. This should
+     * trigger a fallback to a ComboBox. If the [value] is false then this returns false.
      */
-    fun shouldFallback(): Boolean {
-        return if (value.value.data == null) {
-            false
-        } else {
-            !codedValues.any {
-                it.name == value.value.data
-            }
+    val shouldFallback = if (initialValue == null) {
+        false
+    } else {
+        !codedValues.any {
+            it.name == value.value.data
         }
     }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -98,7 +98,6 @@ internal class RadioButtonFieldState(
                     initialValue = list[0],
                     scope = scope,
                     onEditValue = { newValue ->
-                        //form.editValue(formElement, newValue)
                         formElement.editValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -24,6 +24,7 @@ import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.toolkit.featureforms.utils.editValue
+import com.arcgismaps.toolkit.featureforms.utils.isNullOrEmptyString
 import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -32,7 +33,7 @@ internal typealias RadioButtonFieldProperties = CodedValueFieldProperties
 
 internal class RadioButtonFieldState(
     properties: RadioButtonFieldProperties,
-    initialValue: String = properties.value.value,
+    initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
     onEditValue: ((Any?) -> Unit),
     defaultValidator: () -> List<Throwable>
@@ -55,13 +56,17 @@ internal class RadioButtonFieldState(
      * trigger a fallback to a ComboBox. If the [value] is empty then this returns false.
      */
     fun shouldFallback(): Boolean {
-        return if (value.value.data.isEmpty()) {
+        return if (value.value.data.isNullOrEmptyString()) {
             false
         } else {
             !codedValues.any {
                 it.name == value.value.data
             }
         }
+    }
+
+    override fun typeConverter(input: Any?): Any? {
+        TODO("Not yet implemented")
     }
 
     companion object {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
@@ -34,8 +34,8 @@ import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
 
 @Composable
 internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier) {
-    val codeName by state.value
-    val checkedState = codeName.data == state.onValue.name
+    val codeValue by state.value
+    val checkedState = codeValue.data == state.onValue.code
     val value = if (checkedState) state.onValue.name else state.offValue.name
     val isEditable by state.isEditable.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }
@@ -63,9 +63,9 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
             onCheckedChange = { newState ->
                 val newValue = (
                     if (newState)
-                        state.onValue.name
+                        state.onValue.code
                     else
-                        state.offValue.name
+                        state.offValue.code
                     )
                 state.onValueChanged(newValue)
             },
@@ -76,15 +76,15 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
         )
     }
     
-    LaunchedEffect(codeName) {
+    LaunchedEffect(codeValue) {
         interactionSource.interactions.collect {
             if (isEditable) {
                 if (it is PressInteraction.Release) {
                     val newValue = (
                         if (checkedState)
-                            state.offValue.name
+                            state.offValue.code
                         else
-                            state.onValue.name
+                            state.onValue.code
                         )
                     state.onValueChanged(newValue)
                 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
@@ -42,7 +42,7 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
     BaseTextField(
         text = value,
         onValueChange = {
-            state.onValueChanged(it)
+            // nothing happens here. state.onValueChange is triggered by the switch control
         },
         modifier = modifier,
         readOnly = true,
@@ -61,13 +61,12 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
         Switch(
             checked = checkedState,
             onCheckedChange = { newState ->
-                val newValue = (
-                    if (newState)
-                        state.onValue.code
-                    else
-                        state.offValue.code
-                    )
-                state.onValueChanged(newValue)
+                val code = if (newState) {
+                    state.onValue.code
+                } else {
+                    state.offValue.code
+                }
+                state.onValueChanged(code)
             },
             modifier = Modifier
                 .semantics { contentDescription = "switch" }
@@ -75,18 +74,17 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
             enabled = isEditable
         )
     }
-    
+
     LaunchedEffect(codeValue) {
         interactionSource.interactions.collect {
             if (isEditable) {
                 if (it is PressInteraction.Release) {
-                    val newValue = (
-                        if (checkedState)
-                            state.offValue.code
-                        else
-                            state.onValue.code
-                        )
-                    state.onValueChanged(newValue)
+                    val code = if (checkedState) {
+                        state.offValue.code
+                    } else {
+                        state.onValue.code
+                    }
+                    state.onValueChanged(code)
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -78,7 +78,7 @@ internal class SwitchFieldProperties(
 @Stable
 internal class SwitchFieldState(
     properties: SwitchFieldProperties,
-    val initialValue: String = properties.value.value,
+    val initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
     onEditValue: ((Any?) -> Unit),
     defaultValidator: () -> List<Throwable>
@@ -108,6 +108,10 @@ internal class SwitchFieldState(
         // Start observing the properties. Since this method cannot be invoked from any open base
         // class initializer blocks, it is safe to invoke it here.
         observeProperties()
+    }
+
+    override fun typeConverter(input: Any?): Any? {
+        TODO("Not yet implemented")
     }
 
     companion object {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -147,7 +147,6 @@ internal class SwitchFieldState(
                     scope = scope,
                     onEditValue = { code ->
                         formElement.updateValue(code)
-                        //formElement.editValue(if (codedValueName == input.onValue.name) input.onValue.code else input.offValue.code)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = formElement::getValidationErrors

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -28,7 +28,6 @@ import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.mapping.featureforms.SwitchFormInput
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
-import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldIsNullable
 import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
@@ -146,8 +145,9 @@ internal class SwitchFieldState(
                     ),
                     initialValue = list[0],
                     scope = scope,
-                    onEditValue = { codedValueName ->
-                        formElement.editValue(if (codedValueName == input.onValue.name) input.onValue.code else input.offValue.code)
+                    onEditValue = { code ->
+                        formElement.updateValue(code)
+                        //formElement.editValue(if (codedValueName == input.onValue.name) input.onValue.code else input.offValue.code)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = formElement::getValidationErrors
@@ -191,7 +191,7 @@ internal fun rememberSwitchFieldState(
         ),
         scope = scope,
         onEditValue = {
-            field.editValue(it)
+            field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = field::getValidationErrors

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -39,7 +39,7 @@ internal class SwitchFieldProperties(
     label: String,
     placeholder: String,
     description: String,
-    value: StateFlow<String>,
+    value: StateFlow<Any?>,
     editable: StateFlow<Boolean>,
     required: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
@@ -110,10 +110,6 @@ internal class SwitchFieldState(
         observeProperties()
     }
 
-    override fun typeConverter(input: Any?): Any? {
-        TODO("Not yet implemented")
-    }
-
     companion object {
         fun Saver(
             formElement: FieldFormElement,
@@ -148,7 +144,7 @@ internal class SwitchFieldState(
                             FormInputNoValueOption.Hide,
                         noValueLabel = noValueString
                     ),
-                    initialValue = list[0] as String,
+                    initialValue = list[0],
                     scope = scope,
                     onEditValue = { codedValueName ->
                         formElement.editValue(if (codedValueName == input.onValue.name) input.onValue.code else input.offValue.code)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -29,7 +29,6 @@ import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.mapping.featureforms.SwitchFormInput
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.utils.fieldIsNullable
-import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -129,7 +128,7 @@ internal class SwitchFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.valueFlow(scope),
+                        value = formElement.value,
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         visible = formElement.isVisible,
@@ -174,7 +173,7 @@ internal fun rememberSwitchFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.valueFlow(scope),
+            value = field.value,
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -30,7 +30,6 @@ import com.arcgismaps.mapping.featureforms.SwitchFormInput
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.fieldIsNullable
-import com.arcgismaps.toolkit.featureforms.utils.fieldType
 import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -135,7 +134,7 @@ internal class SwitchFieldState(
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         visible = formElement.isVisible,
-                        fieldType = form.fieldType(formElement),
+                        fieldType = formElement.fieldType,
                         onValue = input.onValue,
                         offValue = input.offValue,
                         fallback = list[1] as Boolean,
@@ -148,10 +147,7 @@ internal class SwitchFieldState(
                     initialValue = list[0] as String,
                     scope = scope,
                     onEditValue = { codedValueName ->
-                        form.editValue(
-                            formElement,
-                            if (codedValueName == input.onValue.name) input.onValue.code else input.offValue.code
-                        )
+                        formElement.editValue(if (codedValueName == input.onValue.name) input.onValue.code else input.offValue.code)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = formElement::getValidationErrors
@@ -183,7 +179,7 @@ internal fun rememberSwitchFieldState(
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,
-            fieldType = form.fieldType(field),
+            fieldType = field.fieldType,
             onValue = input.onValue,
             offValue = input.offValue,
             fallback = fallback,
@@ -195,7 +191,7 @@ internal fun rememberSwitchFieldState(
         ),
         scope = scope,
         onEditValue = {
-            form.editValue(field, it)
+            field.editValue(it)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = field::getValidationErrors

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -29,7 +29,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
-import com.arcgismaps.toolkit.featureforms.utils.valueFlow
+import com.arcgismaps.toolkit.featureforms.utils.mapValueAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -104,7 +104,7 @@ internal class DateTimeFieldState(
                         label = field.label,
                         placeholder = field.hint,
                         description = field.description,
-                        value = field.valueFlow(scope),
+                        value = field.mapValueAsStateFlow(scope),
                         editable = field.isEditable,
                         required = field.isRequired,
                         visible = field.isVisible,
@@ -149,7 +149,7 @@ internal fun rememberDateTimeFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.valueFlow(scope),
+            value = field.mapValueAsStateFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -114,7 +114,7 @@ internal class DateTimeFieldState(
                     initialValue = list[0] as Instant?,
                     scope = scope,
                     onEditValue = {
-                        form.editValue(field, it)
+                        field.editValue(it)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = {
@@ -158,7 +158,7 @@ internal fun rememberDateTimeFieldState(
         ),
         scope = scope,
         onEditValue = {
-            form.editValue(field, it)
+            field.editValue(it)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -86,6 +86,8 @@ internal class DateTimeFieldState(
         // class initializer blocks, it is safe to invoke it here.
         observeProperties()
     }
+
+    override fun typeConverter(input: Instant?): Any? = input
     
     companion object {
         fun Saver(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -29,7 +29,6 @@ import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
-import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -116,7 +115,7 @@ internal class DateTimeFieldState(
                     initialValue = list[0] as Instant?,
                     scope = scope,
                     onEditValue = {
-                        field.editValue(it)
+                        field.updateValue(it)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = {
@@ -160,7 +159,7 @@ internal fun rememberDateTimeFieldState(
         ),
         scope = scope,
         onEditValue = {
-            field.editValue(it)
+            field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/formelement/FieldElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/formelement/FieldElement.kt
@@ -54,7 +54,7 @@ internal fun <T> FieldElement(state: BaseFieldState<T>) {
             }
 
             is RadioButtonFieldState -> {
-                if (state.shouldFallback()) {
+                if (state.shouldFallback) {
                     ComboBoxField(state = state)
                 } else {
                     RadioButtonField(state = state)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -43,10 +43,10 @@ import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.
 import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.NotAWholeNumber
 import com.arcgismaps.toolkit.featureforms.utils.asDoubleTuple
 import com.arcgismaps.toolkit.featureforms.utils.asLongTuple
+import com.arcgismaps.toolkit.featureforms.utils.formattedValueAsStateFlow
 import com.arcgismaps.toolkit.featureforms.utils.isFloatingPoint
 import com.arcgismaps.toolkit.featureforms.utils.isIntegerType
 import com.arcgismaps.toolkit.featureforms.utils.isNumeric
-import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -262,7 +262,7 @@ internal class FormTextFieldState(
                         label = formElement.label,
                         placeholder = formElement.hint,
                         description = formElement.description,
-                        value = formElement.valueFlow(scope),
+                        value = formElement.formattedValueAsStateFlow(scope),
                         required = formElement.isRequired,
                         editable = formElement.isEditable,
                         visible = formElement.isVisible,
@@ -303,7 +303,7 @@ internal fun rememberFormTextFieldState(
             label = field.label,
             placeholder = field.hint,
             description = field.description,
-            value = field.valueFlow(scope),
+            value = field.formattedValueAsStateFlow(scope),
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -43,7 +43,6 @@ import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.
 import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.NotAWholeNumber
 import com.arcgismaps.toolkit.featureforms.utils.asDoubleTuple
 import com.arcgismaps.toolkit.featureforms.utils.asLongTuple
-import com.arcgismaps.toolkit.featureforms.utils.editValue
 import com.arcgismaps.toolkit.featureforms.utils.isFloatingPoint
 import com.arcgismaps.toolkit.featureforms.utils.isIntegerType
 import com.arcgismaps.toolkit.featureforms.utils.isNumeric
@@ -51,9 +50,6 @@ import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import java.time.Instant
-import kotlin.math.roundToInt
-import kotlin.math.roundToLong
 
 internal class TextFieldProperties(
     label: String,
@@ -279,7 +275,7 @@ internal class FormTextFieldState(
                     initialValue = list[0] as String,
                     scope = scope,
                     onEditValue = { newValue ->
-                        formElement.editValue(newValue)
+                        formElement.updateValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = { formElement.getValidationErrors() }
@@ -319,7 +315,7 @@ internal fun rememberFormTextFieldState(
         ),
         scope = scope,
         onEditValue = { newValue ->
-            field.editValue(newValue)
+            field.updateValue(newValue)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = { field.getValidationErrors() }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -43,9 +43,7 @@ import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.
 import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.NotAWholeNumber
 import com.arcgismaps.toolkit.featureforms.utils.asDoubleTuple
 import com.arcgismaps.toolkit.featureforms.utils.asLongTuple
-import com.arcgismaps.toolkit.featureforms.utils.domain
 import com.arcgismaps.toolkit.featureforms.utils.editValue
-import com.arcgismaps.toolkit.featureforms.utils.fieldType
 import com.arcgismaps.toolkit.featureforms.utils.isFloatingPoint
 import com.arcgismaps.toolkit.featureforms.utils.isIntegerType
 import com.arcgismaps.toolkit.featureforms.utils.isNumeric
@@ -254,8 +252,8 @@ internal class FormTextFieldState(
                         required = formElement.isRequired,
                         editable = formElement.isEditable,
                         visible = formElement.isVisible,
-                        domain = form.domain(formElement) as? RangeDomain,
-                        fieldType = form.fieldType(formElement),
+                        domain = formElement.domain as? RangeDomain,
+                        fieldType = formElement.fieldType,
                         singleLine = formElement.input is TextBoxFormInput,
                         minLength = minLength.toInt(),
                         maxLength = maxLength.toInt()
@@ -263,7 +261,7 @@ internal class FormTextFieldState(
                     initialValue = list[0] as String,
                     scope = scope,
                     onEditValue = { newValue ->
-                        form.editValue(formElement, newValue)
+                        formElement.editValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
                     defaultValidator = { formElement.getValidationErrors() }
@@ -296,14 +294,14 @@ internal fun rememberFormTextFieldState(
             required = field.isRequired,
             visible = field.isVisible,
             singleLine = field.input is TextBoxFormInput,
-            fieldType = form.fieldType(field),
-            domain = form.domain(field) as? RangeDomain,
+            fieldType = field.fieldType,
+            domain = field.domain as? RangeDomain,
             minLength = minLength,
             maxLength = maxLength
         ),
         scope = scope,
-        onEditValue = {
-            form.editValue(field, it)
+        onEditValue = { newValue ->
+            field.editValue(newValue)
             scope.launch { form.evaluateExpressions() }
         },
         defaultValidator = { field.getValidationErrors() }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -51,6 +51,9 @@ import com.arcgismaps.toolkit.featureforms.utils.valueFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.time.Instant
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 
 internal class TextFieldProperties(
     label: String,
@@ -177,6 +180,21 @@ internal class FormTextFieldState(
         } else {
             NoError
         }
+    }
+
+    override fun typeConverter(input: String): Any? {
+        if (input.isEmpty() && fieldType.isNumeric) {
+            return null
+        }
+        return when (fieldType) {
+            FieldType.Int16 -> input.toIntOrNull()?.toShort()
+            FieldType.Int32 -> input.toIntOrNull()
+            FieldType.Int64 -> input.toLongOrNull()
+            FieldType.Float32 -> input.toFloatOrNull()
+            FieldType.Float64 -> input.toDoubleOrNull()
+            FieldType.Text -> input
+            else -> null
+        } ?: input
     }
 
     override fun validate(): List<ValidationErrorState> {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -52,10 +52,12 @@ internal fun FeatureForm.fieldIsNullable(element: FieldFormElement): Boolean {
  */
 internal fun FieldFormElement.editValue(value: Any?) {
     runCatching {
+        // set the value to null, if the incoming value is null or an empty string
         if (value.isNullOrEmptyString()) {
             updateValue(null)
         } else {
             val castValue = cast(value, fieldType)
+            // if the cast failed, let core coerce the value
             if (castValue == null) {
                 updateValue(value)
             } else {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -50,18 +50,33 @@ internal fun Any?.isNullOrEmptyString(): Boolean {
     }
 }
 
-internal inline fun <reified T> FieldFormElement.valueFlow(scope: CoroutineScope): StateFlow<T> =
+/**
+ * Transforms the state flow [FieldFormElement.value] into a state flow of type [T].
+ * This function creates a new [StateFlow].
+ *
+ * @throws IllegalStateException if the [FieldFormElement.value] cannot be cast to [T].
+ */
+internal inline fun <reified T> FieldFormElement.mapValueAsStateFlow(scope: CoroutineScope): StateFlow<T> =
     if (value.value is T) {
         value.map { it as T }.stateIn(scope, SharingStarted.Eagerly, value.value as T)
-    } else if (formattedValue is T) {
-        // T is String
-        value.map { formattedValue as T }
-            .stateIn(scope, SharingStarted.Eagerly, formattedValue as T)
     } else {
         // usage error.
-        throw IllegalStateException("the generic parameterization of the state object must match either the value or the formattedValue.")
+        throw IllegalStateException("the generic parameterization of the state object must match the type specified.")
     }
 
+/**
+ * Creates and returns a new [StateFlow] of type [String] that emits the [FieldFormElement.formattedValue]
+ * whenever the [FieldFormElement.value] emits.
+ */
+internal fun FieldFormElement.formattedValueAsStateFlow(scope: CoroutineScope): StateFlow<String> {
+    return value.map {
+        formattedValue
+    }.stateIn(
+        scope,
+        SharingStarted.Eagerly,
+        formattedValue
+    )
+}
 
 internal val FieldType.isNumeric: Boolean
     get() {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -51,26 +51,31 @@ internal fun FeatureForm.fieldIsNullable(element: FieldFormElement): Boolean {
  * @return returns a result with failure if the update has failed, else a success result is returned.
  */
 internal fun FieldFormElement.editValue(value: Any?) {
-    runCatching {
-        // set the value to null, if the incoming value is null or an empty string
-        if (value.isNullOrEmptyString()) {
-            updateValue(null)
-        } else {
-            val castValue = cast(value, fieldType)
-            // if the cast failed, let core coerce the value
-            if (castValue == null) {
-                updateValue(value)
-            } else {
-                updateValue(castValue)
-            }
-        }
-    }.onFailure {
-        //TODO: remove when updateValue is no longer throwing. (and also the runCatching)
-        Log.w(
-            "Form.editValue",
-            "caught ${it.message} while updating value of field $label to $value"
-        )
-    }
+    updateValue(value)
+//    runCatching {
+//        // set the value to null, if the incoming value is null or an empty string
+//        if (value.isNullOrEmptyString()) {
+//            if (fieldType == FieldType.Text) {
+//                updateValue("")
+//            } else {
+//                updateValue(null)
+//            }
+//        } else {
+//            val castValue = cast(value, fieldType)
+//            // if the cast failed, let core coerce the value
+//            if (castValue == null) {
+//                updateValue(value)
+//            } else {
+//                updateValue(castValue)
+//            }
+//        }
+//    }.onFailure {
+//        //TODO: remove when updateValue is no longer throwing. (and also the runCatching)
+//        Log.w(
+//            "Form.editValue",
+//            "caught ${it.message} while updating value of field $label to $value"
+//        )
+//    }
 }
 
 /**
@@ -85,12 +90,12 @@ internal fun Any?.isNullOrEmptyString(): Boolean {
 }
 
 internal inline fun <reified T> FieldFormElement.valueFlow(scope: CoroutineScope): StateFlow<T> =
-    if (formattedValue is T) {
+    if (value.value is T) {
+        value.map { it as T }.stateIn(scope, SharingStarted.Eagerly, value.value as T)
+    } else if (formattedValue is T) {
         // T is String
         value.map { formattedValue as T }
             .stateIn(scope, SharingStarted.Eagerly, formattedValue as T)
-    } else if (value.value is T) {
-        value.map { it as T }.stateIn(scope, SharingStarted.Eagerly, value.value as T)
     } else {
         // usage error.
         throw IllegalStateException("the generic parameterization of the state object must match either the value or the formattedValue.")

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.utils
 
-import android.util.Log
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.data.RangeDomain
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -26,9 +25,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import java.time.Instant
-import kotlin.math.roundToInt
-import kotlin.math.roundToLong
 
 /**
  * This file contains logic which will eventually be provided by core. Do not add anything to this file that isn't
@@ -41,41 +37,6 @@ internal fun FeatureForm.fieldIsNullable(element: FieldFormElement): Boolean {
         "expected feature table to have field with name ${element.fieldName}"
     }
     return isNullable
-}
-
-/**
- * Set the value in the feature's attribute map using [FieldFormElement.updateValue].
- *
- * @param value the value to be set on the attribute represented by this FieldFormElement.
- *
- * @return returns a result with failure if the update has failed, else a success result is returned.
- */
-internal fun FieldFormElement.editValue(value: Any?) {
-    updateValue(value)
-//    runCatching {
-//        // set the value to null, if the incoming value is null or an empty string
-//        if (value.isNullOrEmptyString()) {
-//            if (fieldType == FieldType.Text) {
-//                updateValue("")
-//            } else {
-//                updateValue(null)
-//            }
-//        } else {
-//            val castValue = cast(value, fieldType)
-//            // if the cast failed, let core coerce the value
-//            if (castValue == null) {
-//                updateValue(value)
-//            } else {
-//                updateValue(castValue)
-//            }
-//        }
-//    }.onFailure {
-//        //TODO: remove when updateValue is no longer throwing. (and also the runCatching)
-//        Log.w(
-//            "Form.editValue",
-//            "caught ${it.message} while updating value of field $label to $value"
-//        )
-//    }
 }
 
 /**
@@ -190,67 +151,3 @@ internal val RangeDomain.asLongTuple: MinMax<Long>
     }
 
 internal data class MinMax<T : Number>(val min: T?, val max: T?)
-
-private fun cast(value: Any?, fieldType: FieldType): Any? =
-    when (fieldType) {
-        FieldType.Int16 -> {
-            when (value) {
-                is String -> value.toIntOrNull()?.toShort()
-                is Int -> value.toShort()
-                is Double -> value.roundToInt().toShort()
-                else -> null
-            }
-        }
-
-        FieldType.Int32 -> {
-            when (value) {
-                is String -> value.toIntOrNull()
-                is Int -> value
-                is Double -> value.roundToInt()
-                else -> null
-            }
-        }
-
-        FieldType.Int64 -> {
-            when (value) {
-                is String -> value.toLongOrNull()
-                is Int -> value.toLong()
-                is Double -> value.roundToLong()
-                else -> null
-            }
-        }
-
-        FieldType.Float32 -> {
-            when (value) {
-                is String -> value.toFloatOrNull()
-                is Int -> value.toFloat()
-                is Double -> value.toFloat()
-                else -> null
-            }
-        }
-
-        FieldType.Float64 -> {
-            when (value) {
-                is String -> value.toDoubleOrNull()
-                is Int -> value.toDouble()
-                is Float -> value.toDouble()
-                is Double -> value.toDouble()
-                else -> null
-            }
-        }
-
-        FieldType.Date -> {
-            when (value) {
-                is String -> value.toLongOrNull()?.let { Instant.ofEpochMilli(it) }
-                is Long -> Instant.ofEpochMilli(value)
-                is Instant -> value
-                else -> null
-            }
-        }
-
-        FieldType.Text -> {
-            value?.toString()
-        }
-
-        else -> throw IllegalArgumentException("casting FieldFormElement value to $fieldType is not allowed")
-    }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -102,7 +102,7 @@ internal fun FeatureFormDialog() {
         is DialogType.ComboBoxDialog -> {
             val state = (dialogType as DialogType.ComboBoxDialog).state
             ComboBoxDialog(
-                initialValue = state.value.value.data,
+                initialValue = state.value.value.toString(),
                 values = state.codedValues.associateBy({ it.code }, { it.name }),
                 label = state.label,
                 description = state.description,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -102,7 +102,7 @@ internal fun FeatureFormDialog() {
         is DialogType.ComboBoxDialog -> {
             val state = (dialogType as DialogType.ComboBoxDialog).state
             ComboBoxDialog(
-                initialValue = state.value.value.toString(),
+                initialValue = state.value.value.data,
                 values = state.codedValues.associateBy({ it.code }, { it.name }),
                 label = state.label,
                 description = state.description,
@@ -114,8 +114,8 @@ internal fun FeatureFormDialog() {
                     KeyboardType.Ascii
                 },
                 noValueLabel = state.noValueLabel.ifEmpty { stringResource(R.string.no_value) },
-                onValueChange = { nameOrEmpty ->
-                    state.onValueChanged(nameOrEmpty)
+                onValueChange = { code ->
+                    state.onValueChanged(code)
                 },
                 onDismissRequest = { dialogRequester.dismissDialog() }
             )


### PR DESCRIPTION
### Summary of changes

- Renamed `_calculatedValue` to `_attributeValue` since its now called every time the attribute changes.
- Any value changes initiated by a user input are still updated using the `value : State<T>` first. This is followed by a call to `updateValue` which emits into `_attributeValue`. Since the `value` already contains the latest update, when `_attributeValue` is collected, it does not change the state.
- Whenever `_attributeValue` emits, validation is also updated via `updateValidation`.
- `updateValidation` now takes the value parameter.
- Removed the prototype `fieldType`  and `domain` and `editValue` to use the API.
- `BaseFieldState` class declares a new abstract function `typeConverter(input : T) : Any?` that all derived classes must implement. This is used to provide a proper type cast from the declared type `T` to the field type of the `FieldFormElement`. `onValueChanged` uses the `typeConverter` to persist the value using `updateValue()`. 
- `CodedValueFieldState<T>` now specifies the type to be an `Any?` since the `value` is a `Code` of type `Any?`.
- All tests are passing.