### PR TITLE
feature form recomposition when a new Feature is selected

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -84,6 +84,13 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                     ValidationErrorVisibility.Automatic
                 )
             }
+            
+            is UIState.Switching -> {
+                val state = uiState as UIState.Switching
+                Pair(
+                    state.oldState.featureForm, state.oldState.validationErrorVisibility
+                )
+            }
 
             else -> {
                 Pair(null, ValidationErrorVisibility.Automatic)
@@ -180,6 +187,12 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             onCancel = {
                 showDiscardEditsDialog = false
             }
+        )
+    }
+    if (uiState is UIState.Switching) {
+        DiscardEditsDialog(
+            onConfirm = { mapViewModel.selectNewFeature() },
+            onCancel = { mapViewModel.continueEditing() }
         )
     }
 }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -205,8 +205,6 @@ class MapViewModel @Inject constructor(
                             }?.let {
                                 if (_uiState.value is UIState.Editing) {
                                     val currentState = _uiState.value as UIState.Editing
-                                    //set state to trigger DiscardEditsDialog with lambdas to discard edits and unselect the old feature and select the new one
-                                    // or just cancel and do nothing
                                     val newFeature = it as ArcGISFeature
                                     _uiState.value = UIState.Switching(
                                         oldState = currentState,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -167,8 +167,6 @@ class MapViewModel @Inject constructor(
     }
 
     context(MapView, CoroutineScope) override fun onSingleTapConfirmed(singleTapEvent: SingleTapConfirmedEvent) {
-        // do not process any taps on a different feature when a feature is being edited
-        if (_uiState.value is UIState.NotEditing) {
             launch {
                 this@MapView.identifyLayers(
                     screenCoordinate = singleTapEvent.screenCoordinate,
@@ -180,6 +178,13 @@ class MapViewModel @Inject constructor(
                             result.geoElements.firstOrNull {
                                 it is ArcGISFeature && (it.featureTable?.layer as? FeatureLayer)?.featureFormDefinition != null
                             }?.let {
+                                (_uiState.value as? UIState.Editing)?.run {
+                                    val feature = featureForm.feature
+                                    val layer = feature.featureTable?.layer as? FeatureLayer
+                                    layer?.unselectFeature(feature)
+                                    featureForm.discardEdits()
+                                }
+                                
                                 val feature = it as ArcGISFeature
                                 val layer = feature.featureTable!!.layer as FeatureLayer
                                 val featureForm =
@@ -201,7 +206,6 @@ class MapViewModel @Inject constructor(
                 }
             }
         }
-    }
 }
 
 /**

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -164,22 +164,20 @@ class MapViewModel @Inject constructor(
         return Result.success(Unit)
     }
     
-    fun selectNewFeature() {
-        require(_uiState.value is UIState.Switching)
-        val currentState = _uiState.value as UIState.Switching
-        currentState.oldState.featureForm.discardEdits()
-        val layer = currentState.oldState.featureForm.feature.featureTable?.layer as FeatureLayer
-        layer.clearSelection()
-        layer.selectFeature(currentState.newFeature)
-        _uiState.value =
-            UIState.Editing(featureForm = FeatureForm(currentState.newFeature, layer.featureFormDefinition!!))
-    }
+    fun selectNewFeature() =
+        (_uiState.value as? UIState.Switching)?.let { prevState ->
+            prevState.oldState.featureForm.discardEdits()
+            val layer = prevState.oldState.featureForm.feature.featureTable?.layer as FeatureLayer
+            layer.clearSelection()
+            layer.selectFeature(prevState.newFeature)
+            _uiState.value =
+                UIState.Editing(featureForm = FeatureForm(prevState.newFeature, layer.featureFormDefinition!!))
+        }
     
-    fun continueEditing() {
-        require(_uiState.value is UIState.Switching)
-        val currentState = _uiState.value as UIState.Switching
-        _uiState.value = currentState.oldState
-    }
+    fun continueEditing() =
+        (_uiState.value as? UIState.Switching)?.let { prevState ->
+            _uiState.value = prevState.oldState
+        }
 
     fun rollbackEdits(): Result<Unit> {
         (_uiState.value as? UIState.Editing)?.let {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -258,6 +258,7 @@ internal fun rememberStates(
                     }
                 }
                 val groupState = rememberBaseGroupState(
+                    form = form,
                     groupElement = element,
                     fieldStates = fieldStateCollection
                 )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseGroupState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseGroupState.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
+import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FormGroupState
 import com.arcgismaps.mapping.featureforms.GroupFormElement
 import kotlinx.coroutines.flow.StateFlow
@@ -66,9 +67,11 @@ internal class BaseGroupState(
 
 @Composable
 internal fun rememberBaseGroupState(
+    form: FeatureForm,
     groupElement: GroupFormElement,
     fieldStates: FormStateCollection
 ): BaseGroupState = rememberSaveable(
+    inputs = arrayOf(form),
     saver = BaseGroupState.Saver(groupElement, fieldStates)
 ) {
     BaseGroupState(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
@@ -99,6 +99,7 @@ internal fun rememberComboBoxFieldState(
     form: FeatureForm,
     scope: CoroutineScope
 ): ComboBoxFieldState = rememberSaveable(
+    inputs = arrayOf(form),
     saver = ComboBoxFieldState.Saver(field, form, scope)
 ) {
     val input = field.input as ComboBoxFormInput

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -115,6 +115,7 @@ internal fun rememberRadioButtonFieldState(
     form: FeatureForm,
     scope: CoroutineScope
 ): RadioButtonFieldState = rememberSaveable(
+    inputs = arrayOf(form),
     saver = RadioButtonFieldState.Saver(field, form, scope)
 ) {
     val input = field.input as RadioButtonsFormInput

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -168,6 +168,7 @@ internal fun rememberSwitchFieldState(
     scope: CoroutineScope,
     noValueString: String
 ): SwitchFieldState = rememberSaveable(
+    inputs = arrayOf(form),
     saver = SwitchFieldState.Saver(field, form, scope, noValueString)
 ) {
     val input = field.input as SwitchFormInput

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -137,6 +137,7 @@ internal fun rememberDateTimeFieldState(
     form: FeatureForm,
     scope: CoroutineScope
 ): DateTimeFieldState = rememberSaveable(
+    inputs = arrayOf(form),
     saver = DateTimeFieldState.Saver(
         field = field,
         form = form,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -284,6 +284,7 @@ internal fun rememberFormTextFieldState(
     form: FeatureForm,
     scope: CoroutineScope
 ): FormTextFieldState = rememberSaveable(
+    inputs = arrayOf(form),
     saver = FormTextFieldState.Saver(field, form, scope)
 ) {
     FormTextFieldState(


### PR DESCRIPTION
toolkit behavior change to make state object key on the API FeatureForm object in their `remember` functions.

app level changes to present a discard edits dialog when a new Feature is selected and the UIState is editing.