### PR TITLE
`Forms`: Remove experimental `softwarekeyboardcontroller`

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
@@ -51,7 +52,6 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.arcgismaps.toolkit.featureforms.utils.ClearFocus
 import com.arcgismaps.toolkit.featureforms.utils.PlaceholderTransformation
 
 @Composable
@@ -161,7 +161,7 @@ internal fun BaseTextField(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     trailingContent: (@Composable () -> Unit)? = null
 ) {
-    var clearFocus by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
     var isFocused by remember { mutableStateOf(false) }
     val visualTransformation = if (text.isEmpty())
         PlaceholderTransformation(placeholder.ifEmpty { " " })
@@ -178,7 +178,7 @@ internal fun BaseTextField(
         }
         .pointerInput(Unit) {
             // any tap on a blank space will also dismiss the keyboard and clear focus
-            detectTapGestures { clearFocus = true }
+            detectTapGestures { focusManager.clearFocus() }
         }
         .padding(start = 15.dp, end = 15.dp, top = 10.dp, bottom = 10.dp)
     ) {
@@ -206,13 +206,13 @@ internal fun BaseTextField(
                     isFocused,
                     trailingIcon,
                     onValueChange = onValueChange,
-                    onDone = { clearFocus = true }
+                    onDone = { focusManager.clearFocus() }
                 ),
             supportingText = {
                 Column(
                     modifier = Modifier
                         .clickable {
-                            clearFocus = true
+                            focusManager.clearFocus()
                         }
                 ) {
                     supportingText?.invoke(this)
@@ -220,7 +220,7 @@ internal fun BaseTextField(
             },
             visualTransformation = visualTransformation,
             keyboardActions = KeyboardActions(
-                onDone = { clearFocus = true }
+                onDone = { focusManager.clearFocus() }
             ),
             keyboardOptions = KeyboardOptions.Default.copy(
                 imeAction = if (singleLine) ImeAction.Done else ImeAction.None,
@@ -231,8 +231,6 @@ internal fun BaseTextField(
             colors = colors
         )
     }
-    // if the keyboard is gone clear focus from the field as a side-effect
-    ClearFocus(clearFocus) { clearFocus = false }
 }
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Dialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.window.core.layout.WindowSizeClass
@@ -96,6 +97,7 @@ internal sealed class DialogType {
  */
 @Composable
 internal fun FeatureFormDialog() {
+    val focusManager = LocalFocusManager.current
     val dialogRequester = LocalDialogRequester.current
     val dialogType by dialogRequester.requestFlow.collectAsState()
     when (dialogType) {
@@ -157,7 +159,7 @@ internal fun FeatureFormDialog() {
         else -> {
             // clear focus from the originating tapped field
             if (dialogType == null) {
-                ClearFocus(true)
+                focusManager.clearFocus()
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Utils.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Utils.kt
@@ -1,33 +1,10 @@
 package com.arcgismaps.toolkit.featureforms.utils
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
-
-@OptIn(ExperimentalComposeUiApi::class)
-@Composable
-internal fun ClearFocus(key: Boolean, onComplete: () -> Unit = {}) {
-    val focusManager = LocalFocusManager.current
-    val keyboardController = LocalSoftwareKeyboardController.current
-    DisposableEffect(key) {
-        if (key) {
-            // hides the keyboard only if visible
-            keyboardController?.hide()
-            focusManager.clearFocus()
-        }
-        onDispose {
-            onComplete()
-        }
-    }
-}
-
 
 /**
  * Changes the visual output of the placeholder and label properties of a TextField. Using this


### PR DESCRIPTION
### Summary of changes

- Removed experimental api `LocalSoftwareKeyboardController` since it is not needed anymore.
- `FocusManager.clearFocus()` clears the focus in a state-less way and hides the keyboard without causing a extra recomposition. It will still recompose to remove focus but only once, unlike before, which was twice.