### PR TITLE
`Forms`: Consume `validationErrors` stateflow

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -55,4 +55,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.4.0
-sdkBuildNumber=4156
+sdkBuildNumber=4157

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,4 +55,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.4.0
-sdkBuildNumber=4155
+sdkBuildNumber=4156

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -104,7 +104,7 @@ class MapViewModel @Inject constructor(
         // build the list of errors
         val errors = mutableListOf<ErrorInfo>()
         val featureForm = state.featureForm
-        featureForm.getValidationErrors().forEach { entry ->
+        featureForm.validationErrors.value.forEach { entry ->
             entry.value.forEach { error ->
                 featureForm.getFormElement(entry.key)?.let { formElement ->
                     if (formElement.isEditable.value) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
@@ -29,6 +30,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.arcgismaps.mapping.featureforms.AttachmentFormElement
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -117,6 +119,12 @@ public fun FeatureForm(
 }
 
 @Composable
+private fun FeatureFormTitle(featureForm: FeatureForm) {
+    val title by featureForm.title.collectAsState()
+    Text(text = title, style = TextStyle(fontWeight = FontWeight.Bold))
+}
+
+@Composable
 private fun FeatureFormBody(
     form: FeatureForm,
     states: FormStateCollection,
@@ -129,7 +137,7 @@ private fun FeatureFormBody(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // title
-        Text(text = form.title, style = TextStyle(fontWeight = FontWeight.Bold))
+        FeatureFormTitle(featureForm = form)
         Spacer(
             modifier = Modifier
                 .fillMaxWidth()
@@ -160,6 +168,10 @@ private fun FeatureFormBody(
                                     .fillMaxWidth()
                                     .padding(horizontal = 15.dp, vertical = 10.dp)
                             )
+                        }
+
+                        else -> {
+                            // other form elements are not created
                         }
                     }
                 }
@@ -236,6 +248,8 @@ internal fun rememberStates(
                 )
                 states.add(element, groupState)
             }
+
+            is AttachmentFormElement -> { }
         }
     }
     return states

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.arcgismaps.mapping.featureforms.AttachmentFormElement
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -249,7 +248,7 @@ internal fun rememberStates(
                 states.add(element, groupState)
             }
 
-            is AttachmentFormElement -> { }
+            else -> { }
         }
     }
     return states

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseFieldState.kt
@@ -16,30 +16,15 @@
 
 package com.arcgismaps.toolkit.featureforms.components.base
 
-import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
-import com.arcgismaps.data.RangeDomain
-import com.arcgismaps.exceptions.FeatureFormValidationException
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.mapping.featureforms.TextAreaFormInput
-import com.arcgismaps.mapping.featureforms.TextBoxFormInput
-import com.arcgismaps.toolkit.featureforms.utils.asDoubleTuple
-import com.arcgismaps.toolkit.featureforms.utils.asLongTuple
-import com.arcgismaps.toolkit.featureforms.utils.format
-import com.arcgismaps.toolkit.featureforms.utils.isFloatingPoint
-import com.arcgismaps.toolkit.featureforms.utils.isIntegerType
-import com.arcgismaps.toolkit.featureforms.utils.isNumeric
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlin.system.measureTimeMillis
 
 internal open class FieldProperties<T>(
     val label: String,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/Flows.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/Flows.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.components.base
+
+import com.arcgismaps.data.RangeDomain
+import com.arcgismaps.exceptions.FeatureFormValidationException
+import com.arcgismaps.mapping.featureforms.FieldFormElement
+import com.arcgismaps.mapping.featureforms.TextAreaFormInput
+import com.arcgismaps.mapping.featureforms.TextBoxFormInput
+import com.arcgismaps.toolkit.featureforms.utils.asDoubleTuple
+import com.arcgismaps.toolkit.featureforms.utils.asLongTuple
+import com.arcgismaps.toolkit.featureforms.utils.format
+import com.arcgismaps.toolkit.featureforms.utils.isFloatingPoint
+import com.arcgismaps.toolkit.featureforms.utils.isIntegerType
+import com.arcgismaps.toolkit.featureforms.utils.isNumeric
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * Transforms the state flow [FieldFormElement.value] into a state flow of type [T].
+ * This function creates a new [StateFlow].
+ *
+ * @throws IllegalStateException if the [FieldFormElement.value] cannot be cast to [T].
+ */
+internal inline fun <reified T> FieldFormElement.mapValueAsStateFlow(scope: CoroutineScope): StateFlow<T> =
+    if (value.value is T) {
+        value.map { it as T }.stateIn(scope, SharingStarted.Eagerly, value.value as T)
+    } else {
+        // usage error.
+        throw IllegalStateException("the generic parameterization of the state object must match the type specified.")
+    }
+
+/**
+ * Creates and returns a new [StateFlow] of type [String] that emits the [FieldFormElement.formattedValue]
+ * whenever the [FieldFormElement.value] emits.
+ */
+internal fun FieldFormElement.formattedValueAsStateFlow(scope: CoroutineScope): StateFlow<String> {
+    return value.map {
+        formattedValue
+    }.stateIn(
+        scope,
+        SharingStarted.Eagerly,
+        formattedValue
+    )
+}
+
+/**
+ * Creates and returns a new [StateFlow] that maps [FieldFormElement.validationErrors] from
+ * List<[Throwable]> into List<[ValidationErrorState]>.
+ *
+ * @param scope A [CoroutineScope] to run the new [StateFlow] on.
+ *
+ * @return A new StateFlow<[ValidationErrorState]>
+ */
+internal fun FieldFormElement.mapValidationErrors(scope: CoroutineScope): StateFlow<List<ValidationErrorState>> {
+    return validationErrors.map {
+        createValidationErrorStates(it, this)
+    }.stateIn(
+        scope,
+        SharingStarted.Eagerly,
+        createValidationErrorStates(validationErrors.value, this)
+    )
+}
+
+/**
+ * Creates a list of [ValidationErrorState] with appropriate messages with the given [errors] and
+ * [formElement].
+ */
+private fun createValidationErrorStates(
+    errors: List<Throwable>,
+    formElement: FieldFormElement
+): List<ValidationErrorState> {
+    var (hasMinRangeError, hasMaxRangeError) = Pair(false, false)
+    var (hasMinCharError, hasMaxCharError) = Pair(false, false)
+    return buildList {
+        errors.forEach { error ->
+            when (error) {
+                is FeatureFormValidationException.RequiredException -> {
+                    add(ValidationErrorState.Required)
+                }
+
+                is FeatureFormValidationException.OutOfDomainException -> {
+                    add(ValidationErrorState.NotInCodedValueDomain)
+                }
+
+                is FeatureFormValidationException.NullNotAllowedException -> {
+                    add(
+                        ValidationErrorState.NullNotAllowed
+                    )
+                }
+
+                is FeatureFormValidationException.IncorrectValueTypeError -> {
+                    if (formElement.fieldType.isFloatingPoint) {
+                        add(ValidationErrorState.NotANumber)
+                    } else if (formElement.fieldType.isIntegerType) {
+                        add(ValidationErrorState.NotAWholeNumber)
+                    }
+                }
+
+                is FeatureFormValidationException.MinCharConstraintException -> {
+                    hasMinCharError = true
+                }
+
+                is FeatureFormValidationException.MaxCharConstraintException -> {
+                    hasMaxCharError = true
+                }
+
+                is FeatureFormValidationException.MinNumericConstraintException -> {
+                    hasMinRangeError = true
+                }
+
+                is FeatureFormValidationException.MaxNumericConstraintException -> {
+                    hasMaxRangeError = true
+                }
+            }
+            if (formElement.input is TextBoxFormInput || formElement.input is TextAreaFormInput) {
+                if (!formElement.fieldType.isNumeric && (hasMinCharError || hasMaxCharError)) {
+                    val (min, max) = if (formElement.input is TextBoxFormInput) {
+                        val input = formElement.input as TextBoxFormInput
+                        Pair(input.minLength.toInt(), input.maxLength.toInt())
+                    } else {
+                        val input = formElement.input as TextAreaFormInput
+                        Pair(input.minLength.toInt(), input.maxLength.toInt())
+                    }
+                    if (min > 0 && max > 0) {
+                        if (min == max) {
+                            add(ValidationErrorState.ExactCharConstraint(min))
+                        } else {
+                            add(ValidationErrorState.MinMaxCharConstraint(min, max))
+                        }
+                    } else {
+                        add(ValidationErrorState.MaxCharConstraint(max))
+                    }
+
+                } else if (hasMinRangeError || hasMaxRangeError) {
+                    val rangeDomain = formElement.domain as RangeDomain
+                    val (min: Number?, max: Number?) = if (formElement.fieldType.isIntegerType) {
+                        val tuple = rangeDomain.asLongTuple
+                        Pair(tuple.min, tuple.max)
+                    } else if (formElement.fieldType.isFloatingPoint) {
+                        val tuple = rangeDomain.asDoubleTuple
+                        Pair(tuple.min, tuple.max)
+                    } else {
+                        Pair(null, null)
+                    }
+                    if (min != null && max != null) {
+                        add(ValidationErrorState.MinMaxNumericConstraint(min.format(), max.format()))
+                    } else if (min != null) {
+                        add(ValidationErrorState.MinNumericConstraint(min.format()))
+                    } else {
+                        add(ValidationErrorState.MaxNumericConstraint(max.format()))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -22,6 +22,7 @@ import com.arcgismaps.data.FieldType
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
+import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
 import com.arcgismaps.toolkit.featureforms.utils.isNullOrEmptyString
 import kotlinx.coroutines.CoroutineScope
@@ -32,6 +33,7 @@ internal open class CodedValueFieldProperties(
     placeholder: String,
     description: String,
     value: StateFlow<Any?>,
+    validationErrors : StateFlow<List<ValidationErrorState>>,
     required: StateFlow<Boolean>,
     editable: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
@@ -39,7 +41,7 @@ internal open class CodedValueFieldProperties(
     val codedValues: List<CodedValue>,
     val showNoValueOption: FormInputNoValueOption,
     val noValueLabel: String
-) : FieldProperties<Any?>(label, placeholder, description, value, required, editable, visible)
+) : FieldProperties<Any?>(label, placeholder, description, value, validationErrors, required, editable, visible)
 
 /**
  * A class to handle the state of any coded value type. Essential properties are inherited
@@ -50,23 +52,19 @@ internal open class CodedValueFieldProperties(
  * [TextFieldProperties.value] by default.
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
- * is called on [CodedValueFieldState.onValueChanged].
- * @param defaultValidator the default validator that returns the list of validation errors. This
- * is called in [CodedValueFieldState.validate].
+ * is called on [CodedValueFieldState.onValueChanged]
  */
 @Stable
 internal abstract class CodedValueFieldState(
     properties: CodedValueFieldProperties,
     initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
-    onEditValue: ((Any?) -> Unit),
-    defaultValidator: () -> List<Throwable>
+    onEditValue: ((Any?) -> Unit)
 ) : BaseFieldState<Any?>(
     properties = properties,
     scope = scope,
     initialValue = initialValue,
-    onEditValue = onEditValue,
-    defaultValidator = defaultValidator
+    onEditValue = onEditValue
 ) {
     /**
      * The list of coded values associated with this field.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/CodedValueFieldState.kt
@@ -59,12 +59,12 @@ internal abstract class CodedValueFieldState(
     properties: CodedValueFieldProperties,
     initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
-    onEditValue: ((Any?) -> Unit)
+    onEditValue: ((Any?) -> Unit),
 ) : BaseFieldState<Any?>(
     properties = properties,
     scope = scope,
     initialValue = initialValue,
-    onEditValue = onEditValue
+    onEditValue = onEditValue,
 ) {
     /**
      * The list of coded values associated with this field.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -370,7 +370,7 @@ private fun ComboBoxPreview() {
             noValueLabel = "No value"
         ),
         scope = scope,
-        onEditValue = {}
+        onEditValue = {},
     )
     ComboBoxField(state = state)
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -360,6 +360,7 @@ private fun ComboBoxPreview() {
             placeholder = "",
             description = "Select the tree species",
             value = MutableStateFlow(""),
+            validationErrors = MutableStateFlow(emptyList()),
             editable = MutableStateFlow(true),
             required = MutableStateFlow(false),
             visible = MutableStateFlow(true),
@@ -369,8 +370,7 @@ private fun ComboBoxPreview() {
             noValueLabel = "No value"
         ),
         scope = scope,
-        onEditValue = {},
-        defaultValidator = { emptyList() }
+        onEditValue = {}
     )
     ComboBoxField(state = state)
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
+import com.arcgismaps.toolkit.featureforms.components.base.mapValidationErrors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -34,14 +35,7 @@ internal class ComboBoxFieldState(
     initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
     onEditValue: ((Any?) -> Unit),
-    defaultValidator: () -> List<Throwable>
-) : CodedValueFieldState(properties, initialValue, scope, onEditValue, defaultValidator) {
-
-    init {
-        // Start observing the properties. Since this method cannot be invoked from any open base
-        // class initializer blocks, it is safe to invoke it here.
-        observeProperties()
-    }
+) : CodedValueFieldState(properties, initialValue, scope, onEditValue) {
 
     companion object {
         /**
@@ -67,6 +61,7 @@ internal class ComboBoxFieldState(
                         placeholder = formElement.hint,
                         description = formElement.description,
                         value = formElement.value,
+                        validationErrors = formElement.mapValidationErrors(scope),
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         visible = formElement.isVisible,
@@ -81,7 +76,7 @@ internal class ComboBoxFieldState(
                         formElement.updateValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
-                    defaultValidator = formElement::getValidationErrors
+                    //defaultValidator = formElement.validationErrors
                 ).apply {
                     onFocusChanged(list[1] as Boolean)
                 }
@@ -106,6 +101,7 @@ internal fun rememberComboBoxFieldState(
             placeholder = field.hint,
             description = field.description,
             value = field.value,
+            validationErrors = field.mapValidationErrors(scope),
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,
@@ -119,6 +115,6 @@ internal fun rememberComboBoxFieldState(
             field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
         },
-        defaultValidator = field::getValidationErrors
+        //defaultValidator = field::getValidationErrors
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxFieldState.kt
@@ -76,7 +76,6 @@ internal class ComboBoxFieldState(
                         formElement.updateValue(newValue)
                         scope.launch { form.evaluateExpressions() }
                     },
-                    //defaultValidator = formElement.validationErrors
                 ).apply {
                     onFocusChanged(list[1] as Boolean)
                 }
@@ -115,6 +114,5 @@ internal fun rememberComboBoxFieldState(
             field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
         },
-        //defaultValidator = field::getValidationErrors
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -90,7 +90,7 @@ internal class RadioButtonFieldState(
                     onEditValue = { newValue ->
                         formElement.updateValue(newValue)
                         scope.launch { form.evaluateExpressions() }
-                    }
+                    },
                 )
             }
         )
@@ -126,6 +126,6 @@ internal fun rememberRadioButtonFieldState(
         onEditValue = {
             field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
-        }
+        },
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonFieldState.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
+import com.arcgismaps.toolkit.featureforms.components.base.mapValidationErrors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -32,21 +33,13 @@ internal class RadioButtonFieldState(
     properties: RadioButtonFieldProperties,
     initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
-    onEditValue: ((Any?) -> Unit),
-    defaultValidator: () -> List<Throwable>
+    onEditValue: ((Any?) -> Unit)
 ) : CodedValueFieldState(
     properties = properties,
     initialValue = initialValue,
     scope = scope,
-    onEditValue = onEditValue,
-    defaultValidator = defaultValidator
+    onEditValue = onEditValue
 ) {
-
-    init {
-        // Start observing the properties. Since this method cannot be invoked from any open base
-        // class initializer blocks, it is safe to invoke it here.
-        observeProperties()
-    }
 
     /**
      * Returns true if the initial value is not in the [codedValues]. This should
@@ -83,6 +76,7 @@ internal class RadioButtonFieldState(
                         placeholder = formElement.hint,
                         description = formElement.description,
                         value = formElement.value,
+                        validationErrors = formElement.mapValidationErrors(scope),
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         visible = formElement.isVisible,
@@ -96,8 +90,7 @@ internal class RadioButtonFieldState(
                     onEditValue = { newValue ->
                         formElement.updateValue(newValue)
                         scope.launch { form.evaluateExpressions() }
-                    },
-                    defaultValidator = formElement::getValidationErrors
+                    }
                 )
             }
         )
@@ -120,6 +113,7 @@ internal fun rememberRadioButtonFieldState(
             placeholder = field.hint,
             description = field.description,
             value = field.value,
+            validationErrors = field.mapValidationErrors(scope),
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,
@@ -132,7 +126,6 @@ internal fun rememberRadioButtonFieldState(
         onEditValue = {
             field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
-        },
-        defaultValidator = field::getValidationErrors
+        }
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchFieldState.kt
@@ -142,7 +142,7 @@ internal class SwitchFieldState(
                     onEditValue = { code ->
                         formElement.updateValue(code)
                         scope.launch { form.evaluateExpressions() }
-                    }
+                    },
                 )
             }
         )
@@ -187,6 +187,6 @@ internal fun rememberSwitchFieldState(
         onEditValue = {
             field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
-        }
+        },
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -128,7 +128,6 @@ private fun DateTimeFieldPreview() {
             ),
             scope = scope,
             onEditValue = {},
-            //defaultValidator = { emptyList() }
         )
         DateTimeField(state = state)
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -118,6 +118,7 @@ private fun DateTimeFieldPreview() {
                 placeholder = "",
                 description = "Enter the date for apollo 11 launch",
                 value = MutableStateFlow(null),
+                validationErrors = MutableStateFlow(emptyList()),
                 editable = MutableStateFlow(true),
                 required = MutableStateFlow(false),
                 visible = MutableStateFlow(true),
@@ -127,7 +128,7 @@ private fun DateTimeFieldPreview() {
             ),
             scope = scope,
             onEditValue = {},
-            defaultValidator = { emptyList() }
+            //defaultValidator = { emptyList() }
         )
         DateTimeField(state = state)
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -67,25 +67,17 @@ internal class DateTimeFieldState(
     initialValue: Instant? = properties.value.value,
     scope: CoroutineScope,
     onEditValue: (Any?) -> Unit,
-    //defaultValidator: () -> List<Throwable>
 ) : BaseFieldState<Instant?>(
     properties = properties,
     initialValue = initialValue,
     scope = scope,
     onEditValue = onEditValue,
-    //defaultValidator = defaultValidator
 ) {
     val minEpochMillis: Instant? = properties.minEpochMillis
 
     val maxEpochMillis: Instant? = properties.maxEpochMillis
 
     val shouldShowTime: Boolean = properties.shouldShowTime
-
-    init {
-        // Start observing the properties. Since this method cannot be invoked from any open base
-        // class initializer blocks, it is safe to invoke it here.
-        //observeProperties()
-    }
 
     override fun typeConverter(input: Instant?): Any? = input
     
@@ -120,9 +112,6 @@ internal class DateTimeFieldState(
                         field.updateValue(it)
                         scope.launch { form.evaluateExpressions() }
                     },
-//                    defaultValidator = {
-//                        field.getValidationErrors()
-//                    }
                 ).apply {
                     onFocusChanged(list[1] as Boolean)
                 }
@@ -166,8 +155,5 @@ internal fun rememberDateTimeFieldState(
             field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
         },
-//        defaultValidator = {
-//            field.getValidationErrors()
-//        }
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeFieldState.kt
@@ -27,9 +27,11 @@ import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
+import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState
+import com.arcgismaps.toolkit.featureforms.components.base.mapValidationErrors
 import com.arcgismaps.toolkit.featureforms.components.text.FormTextFieldState
 import com.arcgismaps.toolkit.featureforms.components.text.TextFieldProperties
-import com.arcgismaps.toolkit.featureforms.utils.mapValueAsStateFlow
+import com.arcgismaps.toolkit.featureforms.components.base.mapValueAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -40,13 +42,14 @@ internal class DateTimeFieldProperties(
     placeholder: String,
     description: String,
     value: StateFlow<Instant?>,
+    validationErrors : StateFlow<List<ValidationErrorState>>,
     required: StateFlow<Boolean>,
     editable: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
     val minEpochMillis: Instant?,
     val maxEpochMillis: Instant?,
     val shouldShowTime: Boolean
-) : FieldProperties<Instant?>(label, placeholder, description, value, required, editable, visible)
+) : FieldProperties<Instant?>(label, placeholder, description, value, validationErrors, required, editable, visible)
 
 /**
  * A class to handle the state of a [DateTimeField]. Essential properties are inherited from the
@@ -57,22 +60,20 @@ internal class DateTimeFieldProperties(
  * [DateTimeFieldProperties.value] by default.
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
- * is called on [FormTextFieldState.onValueChanged].
- * @param defaultValidator the default validator that returns the list of validation errors. This
- * is called in [DateTimeFieldState.validate].
+ * is called on [FormTextFieldState.onValueChanged]
  */
 internal class DateTimeFieldState(
     properties: DateTimeFieldProperties,
     initialValue: Instant? = properties.value.value,
     scope: CoroutineScope,
     onEditValue: (Any?) -> Unit,
-    defaultValidator: () -> List<Throwable>
+    //defaultValidator: () -> List<Throwable>
 ) : BaseFieldState<Instant?>(
     properties = properties,
     initialValue = initialValue,
     scope = scope,
     onEditValue = onEditValue,
-    defaultValidator = defaultValidator
+    //defaultValidator = defaultValidator
 ) {
     val minEpochMillis: Instant? = properties.minEpochMillis
 
@@ -83,7 +84,7 @@ internal class DateTimeFieldState(
     init {
         // Start observing the properties. Since this method cannot be invoked from any open base
         // class initializer blocks, it is safe to invoke it here.
-        observeProperties()
+        //observeProperties()
     }
 
     override fun typeConverter(input: Instant?): Any? = input
@@ -105,6 +106,7 @@ internal class DateTimeFieldState(
                         placeholder = field.hint,
                         description = field.description,
                         value = field.mapValueAsStateFlow(scope),
+                        validationErrors = field.mapValidationErrors(scope),
                         editable = field.isEditable,
                         required = field.isRequired,
                         visible = field.isVisible,
@@ -118,9 +120,9 @@ internal class DateTimeFieldState(
                         field.updateValue(it)
                         scope.launch { form.evaluateExpressions() }
                     },
-                    defaultValidator = {
-                        field.getValidationErrors()
-                    }
+//                    defaultValidator = {
+//                        field.getValidationErrors()
+//                    }
                 ).apply {
                     onFocusChanged(list[1] as Boolean)
                 }
@@ -151,6 +153,7 @@ internal fun rememberDateTimeFieldState(
             placeholder = field.hint,
             description = field.description,
             value = field.mapValueAsStateFlow(scope),
+            validationErrors = field.mapValidationErrors(scope),
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,
@@ -163,8 +166,8 @@ internal fun rememberDateTimeFieldState(
             field.updateValue(it)
             scope.launch { form.evaluateExpressions() }
         },
-        defaultValidator = {
-            field.getValidationErrors()
-        }
+//        defaultValidator = {
+//            field.getValidationErrors()
+//        }
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -149,7 +149,7 @@ internal class FormTextFieldState(
                     onEditValue = { newValue ->
                         formElement.updateValue(newValue)
                         scope.launch { form.evaluateExpressions() }
-                    }
+                    },
                 ).apply {
                     // focus is lost on rotation. https://devtopia.esri.com/runtime/apollo/issues/230
                     onFocusChanged(list[1] as Boolean)
@@ -190,6 +190,6 @@ internal fun rememberFormTextFieldState(
         onEditValue = { newValue ->
             field.updateValue(newValue)
             scope.launch { form.evaluateExpressions() }
-        }
+        },
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import com.arcgismaps.data.Domain
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.data.RangeDomain
-import com.arcgismaps.exceptions.FeatureFormValidationException
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
@@ -32,20 +31,8 @@ import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState
-import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.ExactCharConstraint
-import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.MaxCharConstraint
-import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.MaxNumericConstraint
-import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.MinMaxCharConstraint
-import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.MinMaxNumericConstraint
-import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.MinNumericConstraint
-import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.NoError
-import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.NotANumber
-import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState.NotAWholeNumber
-import com.arcgismaps.toolkit.featureforms.utils.asDoubleTuple
-import com.arcgismaps.toolkit.featureforms.utils.asLongTuple
-import com.arcgismaps.toolkit.featureforms.utils.formattedValueAsStateFlow
-import com.arcgismaps.toolkit.featureforms.utils.isFloatingPoint
-import com.arcgismaps.toolkit.featureforms.utils.isIntegerType
+import com.arcgismaps.toolkit.featureforms.components.base.formattedValueAsStateFlow
+import com.arcgismaps.toolkit.featureforms.components.base.mapValidationErrors
 import com.arcgismaps.toolkit.featureforms.utils.isNumeric
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -59,12 +46,13 @@ internal class TextFieldProperties(
     required: StateFlow<Boolean>,
     editable: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
+    validationErrors : StateFlow<List<ValidationErrorState>>,
     val fieldType: FieldType,
     val domain: Domain?,
     val singleLine: Boolean,
     val minLength: Int,
     val maxLength: Int,
-) : FieldProperties<String>(label, placeholder, description, value, required, editable, visible)
+) : FieldProperties<String>(label, placeholder, description, value, validationErrors, required, editable, visible)
 
 /**
  * A class to handle the state of a [FormTextField]. Essential properties are inherited from the
@@ -75,23 +63,19 @@ internal class TextFieldProperties(
  * [TextFieldProperties.value] by default.
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
- * is called on [FormTextFieldState.onValueChanged].
- * @param defaultValidator the default validator that returns the list of validation errors. This
- * is called in [FormTextFieldState.validate].
+ * is called on [FormTextFieldState.onValueChanged]
  */
 @Stable
 internal class FormTextFieldState(
     properties: TextFieldProperties,
     initialValue: String = properties.value.value,
     scope: CoroutineScope,
-    onEditValue: (Any?) -> Unit,
-    defaultValidator: () -> List<Throwable>
+    onEditValue: (Any?) -> Unit
 ) : BaseFieldState<String>(
     properties = properties,
     initialValue = initialValue,
     scope = scope,
-    onEditValue = onEditValue,
-    defaultValidator = defaultValidator
+    onEditValue = onEditValue
 ) {
     // indicates singleLine only if TextBoxFeatureFormInput
     val singleLine = properties.singleLine
@@ -112,72 +96,6 @@ internal class FormTextFieldState(
      */
     val fieldType: FieldType = properties.fieldType
 
-    init {
-        // Start observing the properties. Since this method cannot be invoked from any open base
-        // class initializer blocks, it is safe to invoke it here.
-        observeProperties()
-    }
-
-    private fun validateNumericRange(numberVal: Int): ValidationErrorState {
-        require(fieldType.isIntegerType)
-        return if (domain != null && domain is RangeDomain) {
-            val (min, max) = domain.asLongTuple
-            if (min != null && max != null) {
-                if (numberVal in min..max) {
-                    NoError
-                } else {
-                    MinMaxNumericConstraint(min.format(), max.format())
-                }
-            } else if (min != null) {
-                if (min <= numberVal) {
-                    NoError
-                } else {
-                    MinNumericConstraint(min.format())
-                }
-            } else if (max != null) {
-                if (numberVal <= max) {
-                    NoError
-                } else {
-                    MaxNumericConstraint(max.format())
-                }
-            } else {
-                NoError
-            }
-        } else {
-            NoError
-        }
-    }
-
-    private fun validateNumericRange(numberVal: Double): ValidationErrorState {
-        require(fieldType.isFloatingPoint)
-        return if (domain != null && domain is RangeDomain) {
-            val (min, max) = domain.asDoubleTuple
-            if (min != null && max != null) {
-                if (numberVal in min..max) {
-                    NoError
-                } else {
-                    MinMaxNumericConstraint(min.format(), max.format())
-                }
-            } else if (min != null) {
-                if (min <= numberVal) {
-                    NoError
-                } else {
-                    MinNumericConstraint(min.format())
-                }
-            } else if (max != null) {
-                if (numberVal <= max) {
-                    NoError
-                } else {
-                    MaxNumericConstraint(max.format())
-                }
-            } else {
-                NoError
-            }
-        } else {
-            NoError
-        }
-    }
-
     override fun typeConverter(input: String): Any? {
         if (input.isEmpty() && fieldType.isNumeric) {
             return null
@@ -191,53 +109,6 @@ internal class FormTextFieldState(
             FieldType.Text -> input
             else -> null
         } ?: input
-    }
-
-    override fun validate(): List<ValidationErrorState> {
-        val currentValue = value.value.data
-        val coreErrors = defaultValidator()
-        val errors = mutableListOf<ValidationErrorState>()
-        errors += super.validate()
-
-        if (!fieldType.isNumeric) {
-            if (coreErrors.any { it is FeatureFormValidationException.MinCharConstraintException }
-                || coreErrors.any { it is FeatureFormValidationException.MaxCharConstraintException }
-            ) {
-                if (minLength > 0 && maxLength > 0) {
-                    if (minLength == maxLength) {
-                        errors += ExactCharConstraint(minLength)
-                    } else {
-                        errors += MinMaxCharConstraint(minLength, maxLength)
-                    }
-                } else {
-                    errors += MaxCharConstraint(maxLength)
-                }
-            }
-        } else {
-            if (fieldType.isIntegerType) {
-                val numberVal = currentValue.toIntOrNull()
-                if (numberVal == null) {
-                    errors += NotAWholeNumber
-                } else {
-                    val error = validateNumericRange(numberVal)
-                    if (error != NoError) {
-                        errors += error
-                    }
-                }
-            } else {
-                val numberVal = currentValue.toDoubleOrNull()
-                if (numberVal == null) {
-                    errors += NotANumber
-                } else {
-                    val error = validateNumericRange(numberVal)
-                    if (error != NoError) {
-                        errors += error
-                    }
-                }
-            }
-        }
-
-        return errors
     }
 
     companion object {
@@ -263,6 +134,7 @@ internal class FormTextFieldState(
                         placeholder = formElement.hint,
                         description = formElement.description,
                         value = formElement.formattedValueAsStateFlow(scope),
+                        validationErrors = formElement.mapValidationErrors(scope),
                         required = formElement.isRequired,
                         editable = formElement.isEditable,
                         visible = formElement.isVisible,
@@ -277,8 +149,7 @@ internal class FormTextFieldState(
                     onEditValue = { newValue ->
                         formElement.updateValue(newValue)
                         scope.launch { form.evaluateExpressions() }
-                    },
-                    defaultValidator = { formElement.getValidationErrors() }
+                    }
                 ).apply {
                     // focus is lost on rotation. https://devtopia.esri.com/runtime/apollo/issues/230
                     onFocusChanged(list[1] as Boolean)
@@ -305,6 +176,7 @@ internal fun rememberFormTextFieldState(
             placeholder = field.hint,
             description = field.description,
             value = field.formattedValueAsStateFlow(scope),
+            validationErrors = field.mapValidationErrors(scope),
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,
@@ -318,20 +190,6 @@ internal fun rememberFormTextFieldState(
         onEditValue = { newValue ->
             field.updateValue(newValue)
             scope.launch { form.evaluateExpressions() }
-        },
-        defaultValidator = { field.getValidationErrors() }
+        }
     )
 }
-
-/**
- * Provide a format string for any numeric type.
- *
- * @param digits: If the number is floating point, restricts the decimal digits
- * @return a formatted string representing the number.
- */
-private fun Number.format(digits: Int = 2): String =
-    when (this) {
-        is Double -> "%.${digits}f".format(this)
-        is Float -> "%.${digits}f".format(this)
-        else -> "$this"
-    }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/CorePrototypes.kt
@@ -20,11 +20,6 @@ import com.arcgismaps.data.FieldType
 import com.arcgismaps.data.RangeDomain
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 
 /**
  * This file contains logic which will eventually be provided by core. Do not add anything to this file that isn't
@@ -37,45 +32,6 @@ internal fun FeatureForm.fieldIsNullable(element: FieldFormElement): Boolean {
         "expected feature table to have field with name ${element.fieldName}"
     }
     return isNullable
-}
-
-/**
- * Utility function that returns true if the type is null or if it is an empty string.
- */
-internal fun Any?.isNullOrEmptyString(): Boolean {
-    return if (this is String?) {
-        isNullOrEmpty()
-    } else {
-        false
-    }
-}
-
-/**
- * Transforms the state flow [FieldFormElement.value] into a state flow of type [T].
- * This function creates a new [StateFlow].
- *
- * @throws IllegalStateException if the [FieldFormElement.value] cannot be cast to [T].
- */
-internal inline fun <reified T> FieldFormElement.mapValueAsStateFlow(scope: CoroutineScope): StateFlow<T> =
-    if (value.value is T) {
-        value.map { it as T }.stateIn(scope, SharingStarted.Eagerly, value.value as T)
-    } else {
-        // usage error.
-        throw IllegalStateException("the generic parameterization of the state object must match the type specified.")
-    }
-
-/**
- * Creates and returns a new [StateFlow] of type [String] that emits the [FieldFormElement.formattedValue]
- * whenever the [FieldFormElement.value] emits.
- */
-internal fun FieldFormElement.formattedValueAsStateFlow(scope: CoroutineScope): StateFlow<String> {
-    return value.map {
-        formattedValue
-    }.stateIn(
-        scope,
-        SharingStarted.Eagerly,
-        formattedValue
-    )
 }
 
 internal val FieldType.isNumeric: Boolean

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Utils.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/utils/Utils.kt
@@ -42,3 +42,27 @@ internal fun Modifier.conditional(
         }
     }
 }
+
+/**
+ * Utility function that returns true if the type is null or if it is an empty string.
+ */
+internal fun Any?.isNullOrEmptyString(): Boolean {
+    return if (this is String?) {
+        isNullOrEmpty()
+    } else {
+        false
+    }
+}
+
+/**
+ * Provide a format string for any numeric type.
+ *
+ * @param digits: If the number is floating point, restricts the decimal digits
+ * @return a formatted string representing the number.
+ */
+internal fun Number?.format(digits: Int = 2): String =
+    when (this) {
+        is Double -> "%.${digits}f".format(this)
+        is Float -> "%.${digits}f".format(this)
+        else -> "$this"
+    }


### PR DESCRIPTION
### Summary of changes

- Consumes new sdk changes to use `validationErrors` state flow.
- Moved the logic to produce `ValidationErrorState` from the errors list into its own flow `mapValidationErrors`. This removes a lot of the parsing logic from individual field states. As a consequence of this, `validate()` can be removed as well as `observeProperties` and all the `FieldFormElement` flows can be safely collected in the initializer of `BaseFieldState`.
- Moved all the custom state flows creation into `Flows.kt` since its unlikely they will be in core.
- Removed validation on `isRequired` since the `validationErrors` will emit errors if that changes.
- combined `_attribute` and `validationErrors` flow into one flow collector so that the UI always has the latest `value` and `errors`.
- consumes `title` changed event
- fix `attachmentformelement` reference
- passes all tests