### PR TITLE
`Forms` :  Update UI behavior for non-nullable fields

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/ComboBoxFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/ComboBoxFieldTests.kt
@@ -273,18 +273,18 @@ class ComboBoxFieldTests {
         // validate that the pre-populated value shown shown in accurate and as expected
         // assertTextEquals matches the Text(the label) and Editable Text (the actual editable input text)
         comboBoxField.assertTextEquals(requiredLabel, formElement.formattedValue)
-        // find the clear text node within its children
-        val clearButton = comboBoxField.onChildWithContentDescription(clearTextSemanticLabel)
-        // validate the clear icon is visible
-        clearButton.assertIsDisplayed()
-        // clear the value
-        clearButton.performClick()
+        // set the value to null
+        formElement.updateValue(null)
+        // click on the element to open the dialog picker
+        comboBoxField.performClick()
+        // find and tap the done button
+        val doneButton =
+            composeTestRule.onNodeWithContentDescription(comboBoxDialogDoneButtonSemanticLabel).performClick()
         // assert "Enter Value" placeholder is visible
         comboBoxField.assertTextEquals(requiredLabel, context.getString(R.string.enter_value))
         // validate required text is visible and is in error color
         comboBoxField.onChildWithText(context.getString(R.string.required)).assertTextColor(errorTextColor!!)
-
-        // open the picker
+        // open the picker again
         comboBoxField.performClick()
         // find the dialog
         val comboBoxDialogList =
@@ -301,9 +301,6 @@ class ComboBoxFieldTests {
             comboBoxDialogList.onChildWithContentDescription("$codedValueToSelect list item")
         listItem.assertIsDisplayed()
         listItem.performClick()
-        // find and tap the done button
-        val doneButton =
-            composeTestRule.onNodeWithContentDescription(comboBoxDialogDoneButtonSemanticLabel)
         doneButton.performClick()
         // validate the selection has changed
         comboBoxField.assertTextEquals(requiredLabel, codedValueToSelect)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -138,7 +138,13 @@ internal fun ComboBoxField(
             )
         },
         interactionSource = interactionSource,
-        onFocusChange = state::onFocusChanged
+        onFocusChange = state::onFocusChanged,
+        trailingContent = if (isRequired) {
+            // if required then do not show a clear icon
+            {
+                Icon(imageVector = Icons.Outlined.List, contentDescription = "field icon")
+            }
+        } else null
     )
 
     LaunchedEffect(interactionSource) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextFieldState.kt
@@ -97,7 +97,7 @@ internal class FormTextFieldState(
     val fieldType: FieldType = properties.fieldType
 
     override fun typeConverter(input: String): Any? {
-        if (input.isEmpty() && fieldType.isNumeric) {
+        if (input.isEmpty()) {
             return null
         }
         return when (fieldType) {


### PR DESCRIPTION
### Summary of changes

- For non-nullable and nullable string backed fields, when the value is cleared, the value is set to `null` via `updateValue(null)`
- ComboBox fields that are _required_ will not have a _clear_ action
- Updated `ComboBoxTests` Test case 3.5
- All tests are passing