### PR TITLE
`Forms` api backwards compatibility validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.binary.compatibility.validator) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.gradle.secrets) apply false
     alias(libs.plugins.kapt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidxLifecycle = "2.6.2"
 androidxMaterialIcons = "1.4.3"
 androidxTestExt = "1.1.5"
 androidxWindow = "1.2.0"
+binaryCompatibilityValidator = "0.14.0"
 compileSdk = "34"
 compose-navigation = "2.7.5"
 dokka = "1.9.10"
@@ -72,6 +73,7 @@ dokka-versioning = { group = "org.jetbrains.dokka", name = "versioning-plugin", 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator"}
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }

--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -1,0 +1,145 @@
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormKt {
+	public static final fun FeatureForm (Lcom/arcgismaps/mapping/featureforms/FeatureForm;Landroidx/compose/ui/Modifier;Lcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility;Landroidx/compose/runtime/Composer;II)V
+}
+
+public abstract class com/arcgismaps/toolkit/featureforms/ValidationErrorVisibility {
+	public static final field $stable I
+}
+
+public final class com/arcgismaps/toolkit/featureforms/ValidationErrorVisibility$Automatic : com/arcgismaps/toolkit/featureforms/ValidationErrorVisibility {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility$Automatic;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/ValidationErrorVisibility$Visible : com/arcgismaps/toolkit/featureforms/ValidationErrorVisibility {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility$Visible;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/base/ComposableSingletons$BaseTextFieldKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/base/ComposableSingletons$BaseTextFieldKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function3;
+	public static field lambda-5 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$featureforms_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-5$featureforms_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/codedvalue/ComposableSingletons$ComboBoxFieldKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/codedvalue/ComposableSingletons$ComboBoxFieldKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$featureforms_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/codedvalue/ComposableSingletons$RadioButtonFieldKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/codedvalue/ComposableSingletons$RadioButtonFieldKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/datetime/ComposableSingletons$DateTimeFieldKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/datetime/ComposableSingletons$DateTimeFieldKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/datetime/picker/ComposableSingletons$DateTimePickerKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/datetime/picker/ComposableSingletons$DateTimePickerKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public static field lambda-4 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$featureforms_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-4$featureforms_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/datetime/picker/date/ComposableSingletons$DatePickerKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/datetime/picker/date/ComposableSingletons$DatePickerKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/datetime/picker/time/ComposableSingletons$TimePickerKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/datetime/picker/time/ComposableSingletons$TimePickerKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/formelement/AttachmentElementColors {
+	public static final field $stable I
+	public synthetic fun <init> (JJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-0d7_KjU ()J
+	public final fun component2-0d7_KjU ()J
+	public final fun component3-0d7_KjU ()J
+	public final fun copy-ysEtTa8 (JJJ)Lcom/arcgismaps/toolkit/featureforms/components/formelement/AttachmentElementColors;
+	public static synthetic fun copy-ysEtTa8$default (Lcom/arcgismaps/toolkit/featureforms/components/formelement/AttachmentElementColors;JJJILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/components/formelement/AttachmentElementColors;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBorderColor-0d7_KjU ()J
+	public final fun getCarouselContainerColor-0d7_KjU ()J
+	public final fun getContainerColor-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/formelement/AttachmentFormElementKt {
+	public static final fun AttachmentFormElement (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/formelement/ComposableSingletons$AttachmentFormElementKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/formelement/ComposableSingletons$AttachmentFormElementKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-10 Lkotlin/jvm/functions/Function2;
+	public static field lambda-11 Lkotlin/jvm/functions/Function2;
+	public static field lambda-12 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public static field lambda-5 Lkotlin/jvm/functions/Function3;
+	public static field lambda-6 Lkotlin/jvm/functions/Function2;
+	public static field lambda-7 Lkotlin/jvm/functions/Function2;
+	public static field lambda-8 Lkotlin/jvm/functions/Function2;
+	public static field lambda-9 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-10$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-11$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-12$featureforms_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-5$featureforms_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-6$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-7$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-8$featureforms_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-9$featureforms_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/components/formelement/ComposableSingletons$GroupElementKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/formelement/ComposableSingletons$GroupElementKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function3;
+}
+

--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -16,23 +16,3 @@ public final class com/arcgismaps/toolkit/featureforms/ValidationErrorVisibility
 	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility$Visible;
 }
 
-public final class com/arcgismaps/toolkit/featureforms/components/formelement/AttachmentElementColors {
-	public static final field $stable I
-	public synthetic fun <init> (JJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-0d7_KjU ()J
-	public final fun component2-0d7_KjU ()J
-	public final fun component3-0d7_KjU ()J
-	public final fun copy-ysEtTa8 (JJJ)Lcom/arcgismaps/toolkit/featureforms/components/formelement/AttachmentElementColors;
-	public static synthetic fun copy-ysEtTa8$default (Lcom/arcgismaps/toolkit/featureforms/components/formelement/AttachmentElementColors;JJJILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/components/formelement/AttachmentElementColors;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBorderColor-0d7_KjU ()J
-	public final fun getCarouselContainerColor-0d7_KjU ()J
-	public final fun getContainerColor-0d7_KjU ()J
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/components/formelement/AttachmentFormElementKt {
-	public static final fun AttachmentFormElement (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-}
-

--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -16,77 +16,6 @@ public final class com/arcgismaps/toolkit/featureforms/ValidationErrorVisibility
 	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility$Visible;
 }
 
-public final class com/arcgismaps/toolkit/featureforms/components/base/ComposableSingletons$BaseTextFieldKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/base/ComposableSingletons$BaseTextFieldKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
-	public static field lambda-3 Lkotlin/jvm/functions/Function2;
-	public static field lambda-4 Lkotlin/jvm/functions/Function3;
-	public static field lambda-5 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-3$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-4$featureforms_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-5$featureforms_release ()Lkotlin/jvm/functions/Function2;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/components/codedvalue/ComposableSingletons$ComboBoxFieldKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/codedvalue/ComposableSingletons$ComboBoxFieldKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
-	public static field lambda-3 Lkotlin/jvm/functions/Function3;
-	public fun <init> ()V
-	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-3$featureforms_release ()Lkotlin/jvm/functions/Function3;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/components/codedvalue/ComposableSingletons$RadioButtonFieldKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/codedvalue/ComposableSingletons$RadioButtonFieldKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/components/datetime/ComposableSingletons$DateTimeFieldKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/datetime/ComposableSingletons$DateTimeFieldKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/components/datetime/picker/ComposableSingletons$DateTimePickerKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/datetime/picker/ComposableSingletons$DateTimePickerKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function3;
-	public static field lambda-3 Lkotlin/jvm/functions/Function3;
-	public static field lambda-4 Lkotlin/jvm/functions/Function3;
-	public fun <init> ()V
-	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-3$featureforms_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-4$featureforms_release ()Lkotlin/jvm/functions/Function3;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/components/datetime/picker/date/ComposableSingletons$DatePickerKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/datetime/picker/date/ComposableSingletons$DatePickerKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function2;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/components/datetime/picker/time/ComposableSingletons$TimePickerKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/datetime/picker/time/ComposableSingletons$TimePickerKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function3;
-	public fun <init> ()V
-	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function3;
-}
-
 public final class com/arcgismaps/toolkit/featureforms/components/formelement/AttachmentElementColors {
 	public static final field $stable I
 	public synthetic fun <init> (JJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -105,41 +34,5 @@ public final class com/arcgismaps/toolkit/featureforms/components/formelement/At
 
 public final class com/arcgismaps/toolkit/featureforms/components/formelement/AttachmentFormElementKt {
 	public static final fun AttachmentFormElement (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-}
-
-public final class com/arcgismaps/toolkit/featureforms/components/formelement/ComposableSingletons$AttachmentFormElementKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/formelement/ComposableSingletons$AttachmentFormElementKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public static field lambda-10 Lkotlin/jvm/functions/Function2;
-	public static field lambda-11 Lkotlin/jvm/functions/Function2;
-	public static field lambda-12 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
-	public static field lambda-3 Lkotlin/jvm/functions/Function2;
-	public static field lambda-4 Lkotlin/jvm/functions/Function2;
-	public static field lambda-5 Lkotlin/jvm/functions/Function3;
-	public static field lambda-6 Lkotlin/jvm/functions/Function2;
-	public static field lambda-7 Lkotlin/jvm/functions/Function2;
-	public static field lambda-8 Lkotlin/jvm/functions/Function2;
-	public static field lambda-9 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-10$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-11$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-12$featureforms_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-3$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-4$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-5$featureforms_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-6$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-7$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-8$featureforms_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-9$featureforms_release ()Lkotlin/jvm/functions/Function2;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/components/formelement/ComposableSingletons$GroupElementKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/components/formelement/ComposableSingletons$GroupElementKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public fun <init> ()V
-	public final fun getLambda-1$featureforms_release ()Lkotlin/jvm/functions/Function3;
 }
 

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -53,6 +53,9 @@ android {
 
 apiValidation {
     ignoredClasses.add("com.arcgismaps.toolkit.featureforms.BuildConfig")
+    // todo: remove when this is resolved https://github.com/Kotlin/binary-compatibility-validator/issues/74
+    // compose compiler generates public singletons for internal compose functions. this may be resolved in the compose
+    // compiler.
     val composableSingletons = listOf(
         "com.arcgismaps.toolkit.featureforms.components.base.ComposableSingletons\$BaseTextFieldKt",
         "com.arcgismaps.toolkit.featureforms.components.codedvalue.ComposableSingletons\$ComboBoxFieldKt",

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -53,6 +53,19 @@ android {
 
 apiValidation {
     ignoredClasses.add("com.arcgismaps.toolkit.featureforms.BuildConfig")
+    val composableSingletons = listOf(
+        "com.arcgismaps.toolkit.featureforms.components.base.ComposableSingletons\$BaseTextFieldKt",
+        "com.arcgismaps.toolkit.featureforms.components.codedvalue.ComposableSingletons\$ComboBoxFieldKt",
+        "com.arcgismaps.toolkit.featureforms.components.codedvalue.ComposableSingletons\$RadioButtonFieldKt",
+        "com.arcgismaps.toolkit.featureforms.components.datetime.ComposableSingletons\$DateTimeFieldKt",
+        "com.arcgismaps.toolkit.featureforms.components.datetime.picker.ComposableSingletons\$DateTimePickerKt",
+        "com.arcgismaps.toolkit.featureforms.components.datetime.picker.date.ComposableSingletons\$DatePickerKt",
+        "com.arcgismaps.toolkit.featureforms.components.datetime.picker.time.ComposableSingletons\$TimePickerKt",
+        "com.arcgismaps.toolkit.featureforms.components.formelement.ComposableSingletons\$AttachmentFormElementKt",
+        "com.arcgismaps.toolkit.featureforms.components.formelement.ComposableSingletons\$GroupElementKt"
+    )
+    
+    ignoredClasses.addAll(composableSingletons)
 }
 
 

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("artifact-deploy")
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
+    alias(libs.plugins.binary.compatibility.validator) apply true
 }
 
 secrets {
@@ -49,6 +50,11 @@ android {
         }
     }
 }
+
+apiValidation {
+    ignoredClasses.add("com.arcgismaps.toolkit.featureforms.BuildConfig")
+}
+
 
 dependencies {
     api(arcgis.mapsSdk)


### PR DESCRIPTION
Adds the use of the [Kotlin-JVM binary compatibility validator gradle plugin](https://github.com/Kotlin/binary-compatibility-validator)

adds the `api` file which represents the FeatureForms public API
support for generating the `api` file by running gradle task `apiDump`
support for checking backwards compatibility violations by running gradle task `apiCheck`