### PR TITLE
`Forms` : Read only fields re-design

### DIFF
--- a/toolkit/featureforms/README.md
+++ b/toolkit/featureforms/README.md
@@ -101,7 +101,7 @@ FeatureForm(
 
 #### Text Fields
 - Outline color - `MaterialTheme.colorScheme.outline`
-- Label TextStyle - `MaterialTheme.typography.bodyMedium`
+- Label TextStyle - `MaterialTheme.typography.bodySmall`
 - Input TextStyle - `MaterialTheme.typography.bodyLarge`
 - SupportingText TextStyle - `MaterialTheme.typography.bodySmall`
 - Error color - `MaterialTheme.colorScheme.error`
@@ -121,6 +121,8 @@ FeatureForm(
 - Description TextStyle - `MaterialTheme.typography.bodySmall`
 
 #### Read-Only Fields
-Alpha values for read only fields cannot be customized at this time.
+- Label TextStyle - `MaterialTheme.typography.bodyMedium`
+- Input TextStyle - `MaterialTheme.typography.bodyLarge`
+- SupportingText TextStyle - `MaterialTheme.typography.bodySmall`
 
 More information on the material 3 specs [here](https://m3.material.io/components/text-fields/specs#e4964192-72ad-414f-85b4-4b4357abb83c)

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.printToLog
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.data.QueryParameters
@@ -115,8 +116,7 @@ class FormTextFieldTests {
         val label = composeTestRule.onNodeWithContentDescription(labelSemanticLabel)
         label.assertIsDisplayed()
         
-        val supportingText = composeTestRule.onNode(hasContentDescription(supportingTextSemanticLabel), useUnmergedTree = true)
-        supportingText.assertExists()
+        composeTestRule.onNode(hasContentDescription(supportingTextSemanticLabel), useUnmergedTree = true).assertDoesNotExist()
     }
     
     /**
@@ -134,9 +134,7 @@ class FormTextFieldTests {
         val label = composeTestRule.onNodeWithContentDescription(labelSemanticLabel)
         label.assertIsDisplayed()
         
-        val supportingText = composeTestRule.onNode(hasContentDescription(supportingTextSemanticLabel), useUnmergedTree = true)
-        supportingText.assertExists()
-        assertEquals(field.description, supportingText.getTextString())
+        composeTestRule.onNode(hasContentDescription(supportingTextSemanticLabel), useUnmergedTree = true).assertDoesNotExist()
     }
     
     /**
@@ -155,9 +153,7 @@ class FormTextFieldTests {
         val label = composeTestRule.onNodeWithContentDescription(labelSemanticLabel)
         label.assertIsDisplayed()
         
-        val supportingText = composeTestRule.onNode(hasContentDescription(supportingTextSemanticLabel), useUnmergedTree = true)
-        supportingText.assertExists()
-        assertEquals(field.description, supportingText.getTextString())
+        composeTestRule.onNode(hasContentDescription(supportingTextSemanticLabel), useUnmergedTree = true).assertDoesNotExist()
         
         val charCountNode =
             composeTestRule.onNode(hasContentDescription(charCountSemanticLabel), useUnmergedTree = true)
@@ -184,10 +180,10 @@ class FormTextFieldTests {
         outlinedTextField.assertIsFocused()
         val label = composeTestRule.onNodeWithContentDescription(labelSemanticLabel)
         label.assertIsDisplayed()
+
+        outlinedTextField.printToLog("TAG")
         
-        val supportingText = composeTestRule.onNode(hasContentDescription(supportingTextSemanticLabel), useUnmergedTree = true)
-        supportingText.assertExists()
-        assertEquals(field.description, supportingText.getTextString())
+        composeTestRule.onNode(hasContentDescription(supportingTextSemanticLabel), useUnmergedTree = true).assertDoesNotExist()
         
         outlinedTextField.performImeAction()
         outlinedTextField.assertIsNotFocused()

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
-import androidx.compose.ui.test.printToLog
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.data.QueryParameters
@@ -180,8 +179,6 @@ class FormTextFieldTests {
         outlinedTextField.assertIsFocused()
         val label = composeTestRule.onNodeWithContentDescription(labelSemanticLabel)
         label.assertIsDisplayed()
-
-        outlinedTextField.printToLog("TAG")
         
         composeTestRule.onNode(hasContentDescription(supportingTextSemanticLabel), useUnmergedTree = true).assertDoesNotExist()
         

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -11,11 +11,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Divider
 import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -11,9 +11,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Divider
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -173,6 +175,7 @@ private fun FeatureFormBody(
                             // other form elements are not created
                         }
                     }
+                    Divider()
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.components.base
 
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -57,47 +56,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.featureforms.utils.PlaceholderTransformation
 
-@Composable
-private fun trailingIcon(
-    isEmpty: Boolean,
-    singleLine: Boolean,
-    isFocused: Boolean,
-    trailingIcon: ImageVector?,
-    onValueChange: (String) -> Unit,
-    onDone: () -> Unit
-): @Composable () -> Unit = {
-    if (singleLine && isEmpty && trailingIcon != null) {
-        // show a trailing icon if provided when the field is empty
-        Icon(imageVector = trailingIcon, contentDescription = "field icon")
-    } else if (singleLine && !isEmpty) {
-        // show a clear icon instead if the field is not empty
-        IconButton(onClick = { onValueChange("") }, modifier = Modifier.semantics {
-            contentDescription = "Clear text button"
-        }) {
-            Icon(
-                imageVector = Icons.Rounded.Clear, contentDescription = "Clear Text"
-            )
-        }
-    } else if (!singleLine && isFocused) {
-        // show a done button only when focused
-        IconButton(onClick = { onDone() }, modifier = Modifier.semantics {
-            contentDescription = "Save local edit button"
-        }) {
-            Icon(
-                imageVector = Icons.Rounded.CheckCircle, contentDescription = "Done"
-            )
-        }
-    } else if (!singleLine && !isEmpty) {
-        // show a clear icon instead if the multiline field is not empty
-        IconButton(onClick = { onValueChange("") }, modifier = Modifier.semantics {
-            contentDescription = "Clear text button"
-        }) {
-            Icon(
-                imageVector = Icons.Rounded.Clear, contentDescription = "Clear Text"
-            )
-        }
-    }
-}
 
 /**
  * A base text field component built on top of an [OutlinedTextField] that provides a standard for
@@ -109,20 +67,20 @@ private fun trailingIcon(
  * @param text the input text to be shown in the text field.
  * @param onValueChange the callback that is triggered when the input service updates the text. An
  * updated text comes as a parameter of the callback.
- * be modified. However, a user can focus it and copy text from it. Read-only text fields are
- * usually used to display pre-filled forms that a user cannot edit.
  * @param isEditable controls if the text field can be edited. When false, this component will
- * not respond to user input, and it will appear visually disabled.
+ * not respond to user input, and will be rendered differently without an outline.
  * @param label the title to be displayed for the text field.
  * @param placeholder the text to be displayed when the text field input text is empty.
  * @param supportingText supporting text to be displayed below the text field.
- * @param isError
- * @param isRequired
- * @param singleLine when set to true, this text field becomes a single horizontally scrolling
+ * @param isError indicates if the text field's current value is in error. If set to true, the
+ * label, bottom indicator and trailing icon by default will be displayed in error color.
+ * @param isRequired if true, the [label] will be suffixed with a "*".
+ * @param singleLine when set to true, this text field becomes a single horizontally scrolling text
+ * field instead of wrapping onto multiple lines.
  * @param modifier a [Modifier] for this text field.
  * @param readOnly controls the editable state of the text field. When true, the text field cannot
- * text field instead of wrapping onto multiple lines.
- * @param showCharacterCount
+ * be modified. However, a user can focus it and copy text from it.
+ * @param showCharacterCount if true shows the current character count of the [text].
  * @param keyboardType the keyboard type to use depending on the FormFieldElement input type.
  * @param trailingIcon the icon to be displayed at the end of the text field container.
  * @param onFocusChange callback that is triggered when the focus state for this text field changes.
@@ -253,6 +211,37 @@ internal fun BaseTextField(
 }
 
 @Composable
+private fun trailingIcon(
+    isEmpty: Boolean,
+    singleLine: Boolean,
+    isFocused: Boolean,
+    trailingIcon: ImageVector?,
+    onValueChange: (String) -> Unit,
+    onDone: () -> Unit
+): @Composable () -> Unit = {
+    if (!isEmpty) {
+        // show a clear icon if the field is not empty
+        IconButton(
+            onClick = { onValueChange("") },
+            modifier = Modifier.semantics { contentDescription = "Clear text button" }
+        ) {
+            Icon(imageVector = Icons.Rounded.Clear, contentDescription = "Clear Text")
+        }
+    } else if (singleLine && trailingIcon != null) {
+        // show a trailing icon if provided when the single line field is empty
+        Icon(imageVector = trailingIcon, contentDescription = "field icon")
+    } else if (!singleLine && isFocused) {
+        // show a done button only when focused for a multi line text field
+        IconButton(
+            onClick = onDone,
+            modifier = Modifier.semantics { contentDescription = "Save local edit button" }
+        ) {
+            Icon(imageVector = Icons.Rounded.CheckCircle, contentDescription = "Done")
+        }
+    }
+}
+
+@Composable
 private fun ReadOnlyTextField(
     label: String,
     text: String,
@@ -282,7 +271,7 @@ private fun ReadOnlyTextField(
 private fun ReadOnlyTextFieldPreview() {
     MaterialTheme {
         BaseTextField(
-            text = "This is a text",
+            text = "This is a read-only text field",
             onValueChange = {},
             isEditable = false,
             label = "Title",
@@ -307,7 +296,7 @@ private fun BaseTextFieldPreview() {
             label = "Title",
             placeholder = "Enter Value",
             supportingText = "A Description",
-            isError = true,
+            isError = false,
             isRequired = true,
             singleLine = false,
             trailingIcon = Icons.Rounded.TextFields,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextField.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.components.base
 
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -58,62 +59,43 @@ import com.arcgismaps.toolkit.featureforms.utils.PlaceholderTransformation
 
 @Composable
 private fun trailingIcon(
-    text: String,
+    isEmpty: Boolean,
     singleLine: Boolean,
     isFocused: Boolean,
     trailingIcon: ImageVector?,
     onValueChange: (String) -> Unit,
     onDone: () -> Unit
-): (@Composable () -> Unit)? {
-    // single line field and is editable
-    return if (singleLine && text.isEmpty() && trailingIcon != null) {
-        {
-            // show a trailing icon if provided when the field is empty
-            Icon(imageVector = trailingIcon, contentDescription = "field icon")
-        }
-    } else if (singleLine && text.isNotEmpty()) {
-        {
-            // show a clear icon instead if the field is not empty
-            IconButton(onClick = { onValueChange("") }, modifier = Modifier.semantics {
-                contentDescription = "Clear text button"
-            }) {
-                Icon(
-                    imageVector = Icons.Rounded.Clear, contentDescription = "Clear Text"
-                )
-            }
-        }
-    } else if (singleLine && trailingIcon != null) {
-        // single line field but not editable
-        {
-            // show a trailing icon to indicate field type
-            Icon(imageVector = trailingIcon, contentDescription = "field icon")
+): @Composable () -> Unit = {
+    if (singleLine && isEmpty && trailingIcon != null) {
+        // show a trailing icon if provided when the field is empty
+        Icon(imageVector = trailingIcon, contentDescription = "field icon")
+    } else if (singleLine && !isEmpty) {
+        // show a clear icon instead if the field is not empty
+        IconButton(onClick = { onValueChange("") }, modifier = Modifier.semantics {
+            contentDescription = "Clear text button"
+        }) {
+            Icon(
+                imageVector = Icons.Rounded.Clear, contentDescription = "Clear Text"
+            )
         }
     } else if (!singleLine && isFocused) {
-        // multiline editable field
-        {
-            // show a done button only when focused
-            IconButton(onClick = { onDone() }, modifier = Modifier.semantics {
-                contentDescription = "Save local edit button"
-            }) {
-                Icon(
-                    imageVector = Icons.Rounded.CheckCircle, contentDescription = "Done"
-                )
-            }
+        // show a done button only when focused
+        IconButton(onClick = { onDone() }, modifier = Modifier.semantics {
+            contentDescription = "Save local edit button"
+        }) {
+            Icon(
+                imageVector = Icons.Rounded.CheckCircle, contentDescription = "Done"
+            )
         }
-
-    } else if (!singleLine && text.isNotEmpty()) {
-        {
-            // show a clear icon instead if the multiline field is not empty
-            IconButton(onClick = { onValueChange("") }, modifier = Modifier.semantics {
-                contentDescription = "Clear text button"
-            }) {
-                Icon(
-                    imageVector = Icons.Rounded.Clear, contentDescription = "Clear Text"
-                )
-            }
+    } else if (!singleLine && !isEmpty) {
+        // show a clear icon instead if the multiline field is not empty
+        IconButton(onClick = { onValueChange("") }, modifier = Modifier.semantics {
+            contentDescription = "Clear text button"
+        }) {
+            Icon(
+                imageVector = Icons.Rounded.Clear, contentDescription = "Clear Text"
+            )
         }
-    } else {
-        null
     }
 }
 
@@ -157,7 +139,7 @@ internal fun BaseTextField(
     placeholder: String,
     supportingText: String,
     isError: Boolean,
-    isRequired : Boolean,
+    isRequired: Boolean,
     singleLine: Boolean,
     modifier: Modifier = Modifier,
     readOnly: Boolean = !isEditable,
@@ -173,10 +155,6 @@ internal fun BaseTextField(
     val visualTransformation = if (text.isEmpty())
         PlaceholderTransformation(placeholder.ifEmpty { " " })
     else VisualTransformation.None
-    val colors = baseTextFieldColors(
-        text.isEmpty(),
-        placeholder.isEmpty()
-    )
     val title = remember(isRequired, isEditable) {
         if (isRequired && isEditable) {
             "$label *"
@@ -186,6 +164,7 @@ internal fun BaseTextField(
     }
     val contentLength = "${text.length}"
     val isSupportingTextAvailable = supportingText.isNotEmpty() || (showCharacterCount && isFocused)
+    val colors = baseTextFieldColors(text.isEmpty(), placeholder.isEmpty())
     Column(modifier = modifier
         .onFocusChanged {
             isFocused = it.hasFocus
@@ -219,7 +198,7 @@ internal fun BaseTextField(
                 },
                 trailingIcon = trailingContent
                     ?: trailingIcon(
-                        text,
+                        text.isEmpty(),
                         singleLine,
                         isFocused,
                         trailingIcon,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/BaseTextFieldDefaults.kt
@@ -30,31 +30,14 @@ import androidx.compose.ui.graphics.Color
  */
 @Composable
 internal fun baseTextFieldColors(
-    isEditable: Boolean,
     isEmpty: Boolean,
     isPlaceholderEmpty: Boolean,
 ): TextFieldColors {
-    val textColor = defaultTextColor(isEditable = isEditable, isEmpty = isEmpty, isPlaceholderEmpty = isPlaceholderEmpty)
-    return if (isEditable) {
-        OutlinedTextFieldDefaults.colors(
-            focusedTextColor = textColor,
-            unfocusedTextColor = textColor
-        )
-    } else {
-        // non editable field colors are similar to disabled field colors.
-        val disabledColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-        val outlineColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
-        OutlinedTextFieldDefaults.colors(
-            focusedLabelColor = disabledColor,
-            unfocusedLabelColor = disabledColor,
-            focusedSupportingTextColor = disabledColor,
-            unfocusedSupportingTextColor = disabledColor,
-            focusedTextColor = textColor,
-            unfocusedTextColor = textColor,
-            focusedBorderColor = outlineColor,
-            unfocusedBorderColor = outlineColor,
-        )
-    }
+    val textColor = defaultTextColor(isEmpty = isEmpty, isPlaceholderEmpty = isPlaceholderEmpty)
+    return OutlinedTextFieldDefaults.colors(
+        focusedTextColor = textColor,
+        unfocusedTextColor = textColor
+    )
 }
 
 /**
@@ -62,17 +45,13 @@ internal fun baseTextFieldColors(
  */
 @Composable
 internal fun defaultTextColor(
-    isEditable: Boolean,
     isEmpty: Boolean,
     isPlaceholderEmpty: Boolean,
-) : Color {
+): Color {
     val baseColor = MaterialTheme.colorScheme.onSurface
     return if ((isEmpty && !isPlaceholderEmpty)) {
         // if placeholder is visible, make it lighter than the actual input text color
         baseColor.copy(alpha = 0.6f)
-    } else if (!isEditable) {
-        // if disabled
-        baseColor.copy(alpha = 0.38f)
     } else {
         // input text color
         baseColor

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FieldValidation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/base/FieldValidation.kt
@@ -17,25 +17,27 @@
 package com.arcgismaps.toolkit.featureforms.components.base
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.res.stringResource
 import com.arcgismaps.toolkit.featureforms.R
 
 internal sealed class ValidationErrorState(
     private vararg val formatArgs: Any
 ) {
-    object NoError : ValidationErrorState()
-    object Required : ValidationErrorState()
+    data object NoError : ValidationErrorState()
+    data object Required : ValidationErrorState()
     class MinMaxCharConstraint(min: Int, max: Int) : ValidationErrorState(min, max)
     class ExactCharConstraint(length: Int) : ValidationErrorState(length)
     class MaxCharConstraint(max: Int) : ValidationErrorState(max)
     class MinNumericConstraint(min: String) : ValidationErrorState(min)
     class MaxNumericConstraint(max: String) : ValidationErrorState(max)
     class MinMaxNumericConstraint(min: String, max: String) : ValidationErrorState(min, max)
-    object NotANumber : ValidationErrorState()
-    object NotAWholeNumber : ValidationErrorState()
-    object NotInCodedValueDomain : ValidationErrorState()
-    object NullNotAllowed : ValidationErrorState()
+    data object NotANumber : ValidationErrorState()
+    data object NotAWholeNumber : ValidationErrorState()
+    data object NotInCodedValueDomain : ValidationErrorState()
+    data object NullNotAllowed : ValidationErrorState()
 
+    @ReadOnlyComposable
     @Composable
     open fun getString(): String {
         return when (this) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/ComboBoxField.kt
@@ -96,23 +96,17 @@ internal fun ComboBoxField(
     val isEditable by state.isEditable.collectAsState()
     val isRequired by state.isRequired.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }
-    val label = remember(isRequired) {
-        if (isRequired) {
-            "${state.label} *"
-        } else {
-            state.label
-        }
-    }
     val placeholder = if (isRequired) {
         stringResource(R.string.enter_value)
     } else if (state.showNoValueOption == FormInputNoValueOption.Show) {
         state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
     } else ""
-    // show if any errors are present as the supporting text with the error color
-    val (supportingText, supportingTextColor) = if (value.error is ValidationErrorState.NoError) {
-        Pair(state.description, Color.Unspecified)
+    val isError = value.error !is ValidationErrorState.NoError
+    // if any errors are present, show the error as the supporting text
+    val supportingText = if (!isError) {
+        state.description
     } else {
-        Pair(value.error.getString(), MaterialTheme.colorScheme.error)
+        value.error.getString()
     }
 
     BaseTextField(
@@ -126,17 +120,13 @@ internal fun ComboBoxField(
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
-        label = label,
+        label = state.label,
         placeholder = placeholder,
+        supportingText = supportingText,
+        isError = isError,
+        isRequired = isRequired,
         singleLine = true,
         trailingIcon = Icons.Outlined.List,
-        supportingText = {
-            Text(
-                text = supportingText,
-                color = supportingTextColor,
-                modifier = Modifier.semantics { contentDescription = "supporting text" }
-            )
-        },
         interactionSource = interactionSource,
         onFocusChange = state::onFocusChanged,
         trailingContent = if (isRequired) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
 import com.arcgismaps.toolkit.featureforms.R
+import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
 
 @Composable
 internal fun RadioButtonField(
@@ -52,19 +53,33 @@ internal fun RadioButtonField(
     val editable by state.isEditable.collectAsState()
     val required by state.isRequired.collectAsState()
     val noValueLabel = state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
-    RadioButtonField(
-        label = state.label,
-        description = state.description,
-        valueProvider = { state.value.value.data },
-        editable = editable,
-        required = required,
-        codedValues = state.codedValues.associateBy({ it.code }, { it.name }),
-        showNoValueOption = state.showNoValueOption,
-        noValueLabel = noValueLabel,
-        modifier = modifier,
-        colors = colors
-    ) {
-        state.onValueChanged(it)
+    if (editable) {
+        RadioButtonField(
+            label = state.label,
+            description = state.description,
+            valueProvider = { state.value.value.data },
+            editable = editable,
+            required = required,
+            codedValues = state.codedValues.associateBy({ it.code }, { it.name }),
+            showNoValueOption = state.showNoValueOption,
+            noValueLabel = noValueLabel,
+            modifier = modifier,
+            colors = colors
+        ) {
+            state.onValueChanged(it)
+        }
+    } else {
+        BaseTextField(
+            text = state.value.value.data.toString(),
+            onValueChange = {},
+            isEditable = false,
+            label = state.label,
+            placeholder = state.placeholder,
+            supportingText = state.description,
+            isError = false,
+            isRequired = required,
+            singleLine = true
+        )
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/RadioButtonField.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -50,6 +49,7 @@ internal fun RadioButtonField(
     modifier: Modifier = Modifier,
     colors: RadioButtonFieldColors = RadioButtonFieldDefaults.colors()
 ) {
+    val value by state.value
     val editable by state.isEditable.collectAsState()
     val required by state.isRequired.collectAsState()
     val noValueLabel = state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
@@ -57,8 +57,7 @@ internal fun RadioButtonField(
         RadioButtonField(
             label = state.label,
             description = state.description,
-            valueProvider = { state.value.value.data },
-            editable = editable,
+            value = value.data,
             required = required,
             codedValues = state.codedValues.associateBy({ it.code }, { it.name }),
             showNoValueOption = state.showNoValueOption,
@@ -70,7 +69,7 @@ internal fun RadioButtonField(
         }
     } else {
         BaseTextField(
-            text = state.value.value.data.toString(),
+            text = state.getNameForCodedValue(value.data),
             onValueChange = {},
             isEditable = false,
             label = state.label,
@@ -87,8 +86,7 @@ internal fun RadioButtonField(
 private fun RadioButtonField(
     label: String,
     description: String,
-    valueProvider: () -> Any?,
-    editable: Boolean,
+    value: Any?,
     required: Boolean,
     codedValues: Map<Any?, String>,
     showNoValueOption: FormInputNoValueOption,
@@ -97,7 +95,6 @@ private fun RadioButtonField(
     colors: RadioButtonFieldColors = RadioButtonFieldDefaults.colors(),
     onValueChanged: (Any?) -> Unit = {}
 ) {
-    val value = valueProvider()
     val options = if (!required) {
         if (showNoValueOption == FormInputNoValueOption.Show) {
             mapOf(null to noValueLabel) + codedValues
@@ -135,7 +132,6 @@ private fun RadioButtonField(
                     RadioButtonRow(
                         value = name,
                         selected = code == value || (name == noValueLabel && value == null),
-                        enabled = editable,
                         onClick = { onValueChanged(code) }
                     )
                 }
@@ -155,7 +151,6 @@ private fun RadioButtonField(
 private fun RadioButtonRow(
     value: String,
     selected: Boolean,
-    enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -164,7 +159,6 @@ private fun RadioButtonRow(
             .fillMaxWidth()
             .selectable(
                 selected = selected,
-                enabled = enabled,
                 role = Role.RadioButton,
                 onClick = onClick,
             )
@@ -175,7 +169,6 @@ private fun RadioButtonRow(
         RadioButton(
             selected = selected,
             onClick = null,
-            enabled = enabled
         )
         Text(
             text = value
@@ -190,8 +183,7 @@ private fun RadioButtonFieldPreview() {
         RadioButtonField(
             label = "A list of values",
             description = "Description",
-            valueProvider = { "" },
-            editable = true,
+            value = "One",
             required = true,
             codedValues = mapOf(
                 "One" to "One",

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/codedvalue/SwitchField.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -49,13 +48,10 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
         isEditable = isEditable,
         label = state.label,
         placeholder = state.placeholder,
+        supportingText = state.description,
+        isError = false,
+        isRequired = false,
         singleLine = true,
-        supportingText = {
-            Text(
-                text = state.description,
-                modifier = Modifier.semantics { contentDescription = "description" },
-            )
-        },
         interactionSource = interactionSource
     ) {
         Switch(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CalendarMonth
 import androidx.compose.material.icons.rounded.EditCalendar
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -32,11 +31,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/DateTimeField.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -54,16 +55,12 @@ internal fun DateTimeField(
     val isRequired by state.isRequired.collectAsState()
     val value by state.value
     val interactionSource = remember { MutableInteractionSource() }
-    val label = if (isRequired) {
-        "${state.label} *"
+    val isError = value.error !is ValidationErrorState.NoError
+    // if any errors are present, show the error as the supporting text
+    val supportingText = if (!isError) {
+        state.description
     } else {
-        state.label
-    }
-    // show if any errors are present as the supporting text with the error color
-    val (supportingText, supportingTextColor) = if (value.error is ValidationErrorState.NoError) {
-        Pair(state.description, Color.Unspecified)
-    } else {
-        Pair(value.error.getString(), MaterialTheme.colorScheme.error)
+        value.error.getString()
     }
 
     BaseTextField(
@@ -77,20 +74,14 @@ internal fun DateTimeField(
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
-        label = label,
+        label = state.label,
         placeholder = state.placeholder.ifEmpty { stringResource(id = R.string.no_value) },
+        supportingText = supportingText,
+        isError = isError,
+        isRequired = isRequired,
         singleLine = true,
         interactionSource = interactionSource,
         trailingIcon = if (isEditable) Icons.Rounded.EditCalendar else Icons.Rounded.CalendarMonth,
-        supportingText = {
-            Text(
-                text = supportingText,
-                color = supportingTextColor,
-                modifier = Modifier.semantics {
-                    contentDescription = "supporting text"
-                }
-            )
-        },
         onFocusChange = state::onFocusChanged
     )
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/time/TimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/time/TimePicker.kt
@@ -1536,7 +1536,6 @@ internal fun numberContentDescription(
 private fun valuesForAnimation(current: Float, new: Float): Pair<Float, Float> {
     var start = current
     var end = new
-
     if (abs(start - end) <= PI) {
         return Pair(start, end)
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/time/TimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/datetime/picker/time/TimePicker.kt
@@ -1536,6 +1536,7 @@ internal fun numberContentDescription(
 private fun valuesForAnimation(current: Float, new: Float): Pair<Float, Float> {
     var start = current
     var end = new
+
     if (abs(start - end) <= PI) {
         return Pair(start, end)
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -16,19 +16,12 @@
 
 package com.arcgismaps.toolkit.featureforms.components.text
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
 import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField
 import com.arcgismaps.toolkit.featureforms.components.base.ValidationErrorState
@@ -42,24 +35,14 @@ internal fun FormTextField(
     val value by state.value
     val isEditable by state.isEditable.collectAsState()
     val isRequired by state.isRequired.collectAsState()
-    val isFocused by state.isFocused.collectAsState()
-    val label = remember(isRequired) {
-        if (isRequired) {
-            "${state.label} *"
-        } else {
-            state.label
-        }
-    }
-    val contentLength = if (state.minLength > 0 || state.maxLength > 0) {
-        "${value.data.length}"
+    val isError = value.error !is ValidationErrorState.NoError
+    // only show character count if there is a min or max length for this field
+    val showCharacterCount = state.minLength > 0 || state.maxLength > 0
+    // if any errors are present, show the error as the supporting text
+    val supportingText = if (!isError) {
+        state.description
     } else {
-        ""
-    }
-    // show if any errors are present as the supporting text with the error color
-    val (supportingText, supportingTextColor) = if (value.error is ValidationErrorState.NoError) {
-        Pair(state.description, Color.Unspecified)
-    } else {
-        Pair(value.error.getString(), MaterialTheme.colorScheme.error)
+       value.error.getString()
     }
 
     BaseTextField(
@@ -67,28 +50,14 @@ internal fun FormTextField(
         onValueChange = state::onValueChanged,
         modifier = modifier.fillMaxWidth(),
         isEditable = isEditable,
-        label = label,
+        label = state.label,
         placeholder = state.placeholder,
+        supportingText = supportingText,
+        isError = isError,
+        isRequired = isRequired,
         singleLine = state.singleLine,
         keyboardType = if (state.fieldType.isNumeric) KeyboardType.Number else KeyboardType.Ascii,
-        supportingText = {
-            Row {
-                Text(
-                    text = supportingText,
-                    color = supportingTextColor,
-                    modifier = Modifier.semantics { contentDescription = "supporting text" }
-                )
-                // show character count
-                if (isFocused && isEditable) {
-                    Spacer(modifier = Modifier.weight(1f))
-                    Text(
-                        text = contentLength,
-                        modifier = Modifier.semantics { contentDescription = "char count" },
-                        color = supportingTextColor
-                    )
-                }
-            }
-        },
+        showCharacterCount = showCharacterCount,
         onFocusChange = state::onFocusChanged
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/components/text/FormTextField.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import com.arcgismaps.toolkit.featureforms.components.base.BaseTextField


### PR DESCRIPTION
### Summary of changes

- Updated read-only fields design. This is implemented by introducing a `ReadOnlyTextField` that is used when the `BaseTextField` is called with `isEditable=false`
- Showing supportingText, character count and `*` on required field labels is moved into the `BaseTextField` to avoid code duplication and since it is common behavior for all field elements that use the `BaseTextField`.
- `BaseTextField` now takes an `isError` parameter that uses the material 3 spec for showing an error state.
- A `Divider` is now shown between form elements.
- Optimizations to the `trailingContent` of the `BaseTextField`.
- If no `supportingText` is provided and `showCharacterCount` is false, then no UI node exists in the composition. Otherwise if an empty text is created, it takes up a blank space which doesn't look consistent.
- Fixed tests to assert the above statement.
- All tests are passing.