### PR TITLE
`Forms`: bump sdk to 4167

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -55,4 +55,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.4.0
-sdkBuildNumber=4159
+sdkBuildNumber=4167

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -173,7 +173,6 @@ private fun FeatureFormBody(
                             // other form elements are not created
                         }
                     }
-                    Divider()
                 }
             }
         }


### PR DESCRIPTION
### Summary of changes

- Update sdk to 4167
- Remove divider from read only fields
- All tests are passing