### PR TITLE
`Forms` : Revert map state

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-#android.enableBuildConfigAsBytecode=true
 artifactoryUrl=https://olympus.esri.com/artifactory/arcgisruntime-snapshot-local
 artifactoryGroupId=com.esri
 artifactoryArtifactBaseId=arcgis-maps-kotlin-toolkit

--- a/microapps/CompassApp/app/src/main/java/com/arcgismaps/toolkit/compassapp/screens/MainScreen.kt
+++ b/microapps/CompassApp/app/src/main/java/com/arcgismaps/toolkit/compassapp/screens/MainScreen.kt
@@ -47,7 +47,7 @@ fun MainScreen() {
     // show a composable map using the mapViewModel
     ComposableMap(
         modifier = Modifier.fillMaxSize(),
-        mapState = mapViewModel
+        mapInterface = mapViewModel
     ) {
         Row(modifier = Modifier
             .height(IntrinsicSize.Max)

--- a/microapps/CompassApp/app/src/main/java/com/arcgismaps/toolkit/compassapp/screens/MapViewModel.kt
+++ b/microapps/CompassApp/app/src/main/java/com/arcgismaps/toolkit/compassapp/screens/MapViewModel.kt
@@ -22,12 +22,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.toolkit.composablemap.MapInsets
-import com.arcgismaps.toolkit.composablemap.MapState
+import com.arcgismaps.toolkit.composablemap.MapInterface
 
 class MapViewModel(
     arcGISMap: ArcGISMap,
     mapInsets: MapInsets = MapInsets()
-) : ViewModel(), MapState by MapState(arcGISMap, mapInsets)
+) : ViewModel(), MapInterface by MapInterface(arcGISMap, mapInsets)
 
 class MapViewModelFactory(
     private val arcGISMap: ArcGISMap,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -133,7 +133,7 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize(),
-            mapState = mapViewModel
+            mapInterface = mapViewModel
         )
         AnimatedVisibility(
             visible = featureForm != null,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -17,7 +17,8 @@ import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.view.MapView
 import com.arcgismaps.mapping.view.SingleTapConfirmedEvent
-import com.arcgismaps.toolkit.composablemap.MapState
+import com.arcgismaps.toolkit.composablemap.MapInterface
+import com.arcgismaps.toolkit.composablemap.MapInterfaceImpl
 import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureformsapp.data.PortalItemRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -75,7 +76,7 @@ class MapViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val portalItemRepository: PortalItemRepository
 ) : ViewModel(),
-    MapState by MapState() {
+    MapInterface by MapInterfaceImpl(ArcGISMap()) {
     private val itemId: String = savedStateHandle["uri"]!!
     lateinit var portalItem: PortalItem
 

--- a/microapps/TemplateApp/app/src/main/java/com/arcgismaps/toolkit/templateapp/screens/MainScreen.kt
+++ b/microapps/TemplateApp/app/src/main/java/com/arcgismaps/toolkit/templateapp/screens/MainScreen.kt
@@ -34,7 +34,7 @@ fun MainScreen() {
     val mapViewModel = viewModel<MapViewModel>(factory = MapViewModelFactory(map))
     ComposableMap(
         modifier = Modifier.fillMaxSize(),
-        mapState = mapViewModel
+        mapInterface = mapViewModel
     )
     
     val templateViewModel = viewModel<TemplateViewModel>(

--- a/microapps/TemplateApp/app/src/main/java/com/arcgismaps/toolkit/templateapp/screens/MapViewModel.kt
+++ b/microapps/TemplateApp/app/src/main/java/com/arcgismaps/toolkit/templateapp/screens/MapViewModel.kt
@@ -23,13 +23,13 @@ import androidx.lifecycle.ViewModelProvider
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.view.MapView
 import com.arcgismaps.mapping.view.SingleTapConfirmedEvent
-import com.arcgismaps.toolkit.composablemap.MapState
-import com.arcgismaps.toolkit.composablemap.MapStateImpl
+import com.arcgismaps.toolkit.composablemap.MapInterface
+import com.arcgismaps.toolkit.composablemap.MapInterfaceImpl
 import kotlinx.coroutines.CoroutineScope
 
 class MapViewModel(
     arcGISMap: ArcGISMap
-) : ViewModel(), MapState by MapStateImpl(arcGISMap) {
+) : ViewModel(), MapInterface by MapInterfaceImpl(arcGISMap) {
     
     context(MapView, CoroutineScope) override fun onSingleTapConfirmed(singleTapEvent: SingleTapConfirmedEvent) {
         // example of how to add a tap handler with a MapView and CoroutineScope in context.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,7 +26,6 @@ val projects = listOf("template", "featureforms", "authentication", "compass")
 
 pluginManagement {
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         google()
         mavenCentral()
@@ -43,7 +42,6 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenLocal()
         google()
         mavenCentral()
         maven {

--- a/toolkit/composable-map/src/androidTest/java/com/arcgismaps/toolkit/composablemap/ComposableMapTests.kt
+++ b/toolkit/composable-map/src/androidTest/java/com/arcgismaps/toolkit/composablemap/ComposableMapTests.kt
@@ -40,10 +40,10 @@ class ComposableMapTests {
 
     @Test
     fun testComposableMapLayout() {
-        val mockMapInterface = MapState(ArcGISMap())
+        val mockMapInterface = MapInterface(ArcGISMap())
 
         composeTestRule.setContent {
-            ComposableMap(mapState = mockMapInterface) {
+            ComposableMap(mapInterface = mockMapInterface) {
                 Card(modifier = Modifier.semantics { contentDescription = "Card" }) {}
             }
         }

--- a/toolkit/composable-map/src/main/java/com/arcgismaps/toolkit/composablemap/ComposableMap.kt
+++ b/toolkit/composable-map/src/main/java/com/arcgismaps/toolkit/composablemap/ComposableMap.kt
@@ -41,7 +41,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 public fun ComposableMap(
-    mapState: MapState,
+    mapInterface: MapInterface,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit = {},
 ) {
@@ -49,56 +49,56 @@ public fun ComposableMap(
     val coroutineScope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    val map by mapState.map.collectAsState()
-    val insets by mapState.insets.collectAsState()
+    val map by mapInterface.map.collectAsState()
+    val insets by mapInterface.insets.collectAsState()
     val mapView = remember {
         MapView(context).also { view ->
             with(view) {
                 with(coroutineScope) {
                     launch {
                         view.onDown.collect {
-                            mapState.onDown(it)
+                            mapInterface.onDown(it)
                         }
                     }
                     launch {
                         view.onUp.collect {
-                            mapState.onUp(it)
+                            mapInterface.onUp(it)
                         }
                     }
                     launch {
                         view.onSingleTapConfirmed.collect {
-                            mapState.onSingleTapConfirmed(it)
+                            mapInterface.onSingleTapConfirmed(it)
                         }
                     }
                     launch {
                         view.onDoubleTap.collect {
-                            mapState.onDoubleTap(it)
+                            mapInterface.onDoubleTap(it)
                         }
                     }
                     launch {
                         view.onLongPress.collect {
-                            mapState.onLongPress(it)
+                            mapInterface.onLongPress(it)
                         }
                     }
                     launch {
                         view.onTwoPointerTap.collect {
-                            mapState.onTwoPointerTap(it)
+                            mapInterface.onTwoPointerTap(it)
                         }
                     }
                     launch {
                         view.onPan.collect {
-                            mapState.onPan(it)
+                            mapInterface.onPan(it)
                         }
                     }
                     launch {
                         view.mapRotation.collect {
-                            mapState.onViewpointRotationChanged(it)
+                            mapInterface.onViewpointRotationChanged(it)
                         }
                     }
                     launch {
                         view.viewpointChanged.collect {
                             view.getCurrentViewpoint(ViewpointType.CenterAndScale)?.let {
-                                mapState.onViewpointChanged(it)
+                                mapInterface.onViewpointChanged(it)
                             }
                         }
                     }
@@ -117,12 +117,12 @@ public fun ComposableMap(
 
     LaunchedEffect(Unit) {
         launch {
-            mapState.mapRotation.collect(DuplexFlow.Type.Write) {
+            mapInterface.mapRotation.collect(DuplexFlow.Type.Write) {
                 mapView.setViewpointRotation(it)
             }
         }
         launch {
-            mapState.viewpoint.collect(DuplexFlow.Type.Write) {
+            mapInterface.viewpoint.collect(DuplexFlow.Type.Write) {
                 it?.let {
                     mapView.setViewpoint(it)
                 }

--- a/toolkit/composable-map/src/main/java/com/arcgismaps/toolkit/composablemap/MapInterface.kt
+++ b/toolkit/composable-map/src/main/java/com/arcgismaps/toolkit/composablemap/MapInterface.kt
@@ -131,11 +131,11 @@ public interface MapEvents {
  * An interface for consumption by [ComposableMap]. This interface represents the state needed
  * for [ComposableMap] to re/compose.
  */
-public interface MapState : MapEvents {
+public interface MapInterface : MapEvents {
     /**
      * The model for [ComposableMap]
      */
-    public val map: StateFlow<ArcGISMap?>
+    public val map: StateFlow<ArcGISMap>
 
     /**
      * Insets to apply to the Box which contains the [ComposableMap]
@@ -154,22 +154,22 @@ public interface MapState : MapEvents {
 }
 
 /**
- * Factory function for the default implementation of [MapState]
+ * Factory function for the default implementation of [MapInterface]
  */
-public fun MapState(map: ArcGISMap? = null, mapInsets: MapInsets = MapInsets()): MapState =
-    MapStateImpl(map, mapInsets)
+public fun MapInterface(arcGISMap: ArcGISMap, mapInsets: MapInsets = MapInsets()): MapInterface =
+    MapInterfaceImpl(arcGISMap, mapInsets)
 
 /**
- * A default implementation for the [MapState]
+ * A default implementation for the [MapInterface]
  */
 
-public class MapStateImpl(
-    map: ArcGISMap?,
+public class MapInterfaceImpl(
+    arcGISMap: ArcGISMap,
     mapInsets: MapInsets = MapInsets()
-) : MapState {
+) : MapInterface {
 
-    private val _map: MutableStateFlow<ArcGISMap?> = MutableStateFlow(map)
-    override val map: StateFlow<ArcGISMap?> = _map.asStateFlow()
+    private val _map: MutableStateFlow<ArcGISMap> = MutableStateFlow(arcGISMap)
+    override val map: StateFlow<ArcGISMap> = _map.asStateFlow()
 
     private val _insets: MutableStateFlow<MapInsets> = MutableStateFlow(mapInsets)
     override val insets: StateFlow<MapInsets> = _insets.asStateFlow()


### PR DESCRIPTION
### Summary of changes

- Revert the change from `MapInterface` to `MapState` to make it consistent with `v.next`.
- Remove `mavenLocal()` from settings.gradle.
- Remove commented `android.enableBuildConfigAsBytecode=true` from `gradle.properties`.
- Verified with a diff into v.next -> https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/compare/v.next...kaushik/forms/revert-map-state