### PR TITLE
replace clear button on required date time fields

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/DateTimeFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/DateTimeFieldTests.kt
@@ -117,7 +117,7 @@ class DateTimeFieldTests {
             "expected helper text: Date Entry is Required"
             
         }
-        val iconMatcher = hasContentDescription("field icon")
+        val iconMatcher = hasContentDescription("date time picker button")
         assert(iconMatcher.matches(dateTimeField.fetchSemanticsNode()))
     }
     
@@ -136,7 +136,7 @@ class DateTimeFieldTests {
         val col = composeTestRule.onNodeWithContentDescription("lazy column")
         col.performScrollToIndex(8)
         val dateTimeField = composeTestRule.onNodeWithText("${formElement.label} *")
-        val iconMatcher = hasContentDescription("field icon")
+        val iconMatcher = hasContentDescription("date time picker button")
         assert(iconMatcher.matches(dateTimeField.fetchSemanticsNode()))
         dateTimeField.assertHasClickAction()
         dateTimeField.performClick()
@@ -149,7 +149,6 @@ class DateTimeFieldTests {
         val helperTextInDialog = dialogSurface.onChildWithText("Date Entry is Required", true)
         helperTextInDialog.assertIsDisplayed()
     }
-    
     
     /**
      * Given a FieldFormElement with an editable datetime input

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
@@ -21,7 +21,6 @@ package com.arcgismaps.toolkit.featureforms.internal.components.datetime
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.CalendarMonth
 import androidx.compose.material.icons.rounded.EditCalendar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -77,17 +76,13 @@ internal fun DateTimeField(
         isRequired = isRequired,
         singleLine = true,
         interactionSource = interactionSource,
-        trailingIcon = if (isEditable) Icons.Rounded.EditCalendar else Icons.Rounded.CalendarMonth,
+        trailingIcon = Icons.Rounded.EditCalendar,
         onFocusChange = state::onFocusChanged,
         trailingContent =
         if (isRequired) {
             {
                 Icon(
-                    imageVector = if (isEditable) {
-                        Icons.Rounded.EditCalendar
-                    } else {
-                        Icons.Rounded.CalendarMonth
-                    } ,
+                    imageVector = Icons.Rounded.EditCalendar,
                     contentDescription = "date time picker button"
                 )
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CalendarMonth
 import androidx.compose.material.icons.rounded.EditCalendar
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -77,7 +78,22 @@ internal fun DateTimeField(
         singleLine = true,
         interactionSource = interactionSource,
         trailingIcon = if (isEditable) Icons.Rounded.EditCalendar else Icons.Rounded.CalendarMonth,
-        onFocusChange = state::onFocusChanged
+        onFocusChange = state::onFocusChanged,
+        trailingContent =
+        if (isRequired) {
+            {
+                Icon(
+                    imageVector = if (isEditable) {
+                        Icons.Rounded.EditCalendar
+                    } else {
+                        Icons.Rounded.CalendarMonth
+                    } ,
+                    contentDescription = "date time picker button"
+                )
+            }
+        } else {
+            null
+        }
     )
 
     LaunchedEffect(interactionSource) {


### PR DESCRIPTION
when a date time element is required, do not show a clear button. Instead show the edit calendar button (the non-editable calendar button is no longer needed since we show read only fields with no trailing icon.)

editable, required, empty or non-empty
show Icons.Rounded.EditCalendar

editable, not-required, empty
show Icons.Rounded.EditCalendar

editable, non-required, non-empty
show clear

non-editable 
show no icon
