### PR TITLE
FloorFliter: silence exception when floorManager is not set, targeting v.next

### DIFF
--- a/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilterState.kt
+++ b/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilterState.kt
@@ -226,16 +226,16 @@ private class FloorFilterStateImpl(
     private suspend fun loadFloorManager() {
         geoModel.load().onSuccess {
             val floorManager: FloorManager = geoModel.floorManager
-                ?: throw IllegalStateException("The map is not configured to be floor aware")
+                ?: return
             floorManager.load().onSuccess {
                 _floorManager.value = floorManager
                 // no FloorLevel is selected at this point, so clear the FloorFilter from the selected GeoModel
                 filterMap()
             }.onFailure {
-                throw it
+                return
             }
         }.onFailure {
-            throw it
+            return
         }
     }
 


### PR DESCRIPTION
The scope of this issue is to make sure that an exception is not thrown and the app does not crash if the GeoModel used to create it doesn't have the floorManager. The failure should eventually be handled by a callback, but that will be handled in a different issue. Related PR: #353 

#### Changes

- Replace error throwing with `return`.