### PR TITLE
`Forms`: Updated radio button tests

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/RadioButtonFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/RadioButtonFieldTests.kt
@@ -66,6 +66,8 @@ class RadioButtonFieldTests {
      * Then the RadioButtonField indicates the pre-existing value is selected
      * And when a new option is selected
      * Then the new selection is visible
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-41-test-regular-selection
      */
     @Test
     fun testRadioButtonSelection() {
@@ -91,6 +93,8 @@ class RadioButtonFieldTests {
      * Given a RadioFormInput with a pre-existing value that is not in the given domain
      * When the FeatureForm is displayed
      * Then the FieldFormElement is rendered as a ComboBoxField
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-42-test-radio-button-fallback-to-combo-box-and-no-value-label
      */
     @Test
     fun testFallback() {
@@ -114,6 +118,8 @@ class RadioButtonFieldTests {
      * Given a RadioFormInput with no pre-existing value and a noValueLabel
      * When the FeatureForm is displayed
      * Then the RadioButtonField displays the noValueLabel
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-42-test-radio-button-fallback-to-combo-box-and-no-value-label
      */
     @Test
     fun testNoValueLabelExists() {
@@ -137,6 +143,8 @@ class RadioButtonFieldTests {
      * Given a RadioFormInput with no pre-existing value and no noValueLabel
      * When the FeatureForm is displayed
      * Then the RadioButtonField does not display the noValueLabel
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-42-test-radio-button-fallback-to-combo-box-and-no-value-label
      */
     @Test
     fun testNoValueLabelDoesNotExist() {

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/RadioButtonFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/RadioButtonFieldTests.kt
@@ -21,11 +21,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertContentDescriptionContains
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.data.QueryParameters
@@ -35,6 +38,7 @@ import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.mapping.layers.FeatureLayer
 import junit.framework.TestCase
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertThrows
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.BeforeClass
@@ -57,25 +61,22 @@ class RadioButtonFieldTests {
     }
 
     /**
-     * Given a RadioFormInput with a pre-existing value and a no value label
+     * Given a RadioFormInput with a pre-existing value
      * When the FeatureForm is displayed
-     * Then the RadioButtonField shows a no value option and indicates the pre-existing value is selected
-     * And a new option is selected
+     * Then the RadioButtonField indicates the pre-existing value is selected
+     * And when a new option is selected
      * Then the new selection is visible
      */
     @Test
     fun testRadioButtonSelection() {
         val radioElement = featureForm.getFieldFormElementWithLabel("Radio Button Text")
             ?: return fail("element not found")
-        val input = radioElement.input as RadioButtonsFormInput
         // find the field with the the label
-        val radioField = composeTestRule.onNodeWithText(radioElement.label)
+        val radioField = composeTestRule.onNodeWithText("${radioElement.label} *")
         // assert it is displayed
         radioField.assertIsDisplayed()
         // assert the node has group selection indicating it is a radio button field
         radioField.assert(SemanticsMatcher.expectValue(SemanticsProperties.SelectableGroup, Unit))
-        // assert "no value" option is visible
-        radioField.onChildWithText(input.noValueLabel.ifEmpty { context.getString(R.string.no_value) }).assertExists()
         // check if the current value of the element is visible and selected
         radioField.onChildWithText(radioElement.formattedValue).assertIsSelected()
         // select the "dog" option
@@ -84,6 +85,77 @@ class RadioButtonFieldTests {
         assert(radioElement.formattedValue == "dog")
         // check if the current value of the element is visible and selected
         radioField.onChildWithText(radioElement.formattedValue).assertIsSelected()
+    }
+
+    /**
+     * Given a RadioFormInput with a pre-existing value that is not in the given domain
+     * When the FeatureForm is displayed
+     * Then the FieldFormElement is rendered as a ComboBoxField
+     */
+    @Test
+    fun testFallback() {
+        // find the lazy column and scroll to the appropriate index
+        val column = composeTestRule.onNodeWithContentDescription("lazy column")
+        column.performScrollToIndex(7)
+        val radioElement = featureForm.getFieldFormElementWithLabel("Fallback 1")
+            ?: return fail("element not found")
+        // find the field with the the label
+        val radioField = composeTestRule.onNodeWithText(radioElement.label)
+        // assert it is displayed
+        radioField.assertIsDisplayed()
+        // assert the node does not have a  group selection indicating it is not a radio field
+        radioField.assert(!SemanticsMatcher.expectValue(SemanticsProperties.SelectableGroup, Unit))
+        // also assert that this is rendered with an outlined text field which also assures
+        // the fallback behavior
+        radioField.assertContentDescriptionContains("outlined text field")
+    }
+
+    /**
+     * Given a RadioFormInput with no pre-existing value and a noValueLabel
+     * When the FeatureForm is displayed
+     * Then the RadioButtonField displays the noValueLabel
+     */
+    @Test
+    fun testNoValueLabelExists() {
+        // find the lazy column and scroll to the appropriate index
+        val column = composeTestRule.onNodeWithContentDescription("lazy column")
+        column.performScrollToIndex(8)
+        val radioElement = featureForm.getFieldFormElementWithLabel("No Value Enabled")
+            ?: return fail("element not found")
+        val input = radioElement.input as RadioButtonsFormInput
+        // find the field with the the label
+        val radioField = composeTestRule.onNodeWithText(radioElement.label)
+        // assert it is displayed
+        radioField.assertIsDisplayed()
+        // assert the node has group selection indicating it is a radio button field
+        radioField.assert(SemanticsMatcher.expectValue(SemanticsProperties.SelectableGroup, Unit))
+        // assert the no value label is visible
+        radioField.onChildWithText(input.noValueLabel).assertExists()
+    }
+
+    /**
+     * Given a RadioFormInput with no pre-existing value and no noValueLabel
+     * When the FeatureForm is displayed
+     * Then the RadioButtonField does not display the noValueLabel
+     */
+    @Test
+    fun testNoValueLabelDoesNotExist() {
+        // find the lazy column and scroll to the appropriate index
+        val column = composeTestRule.onNodeWithContentDescription("lazy column")
+        column.performScrollToIndex(8)
+        val radioElement = featureForm.getFieldFormElementWithLabel("No Value Disabled")
+            ?: return fail("element not found")
+        val input = radioElement.input as RadioButtonsFormInput
+        // find the field with the the label
+        val radioField = composeTestRule.onNodeWithText(radioElement.label)
+        // assert it is displayed
+        radioField.assertIsDisplayed()
+        // assert the node has group selection indicating it is a radio button field
+        radioField.assert(SemanticsMatcher.expectValue(SemanticsProperties.SelectableGroup, Unit))
+        // assert the no value label is not visible by catching the assertion error
+        assertThrows(AssertionError::class.java) {
+            radioField.onChildWithText(input.noValueLabel)
+        }
     }
 
     companion object {


### PR DESCRIPTION
### Summary of changes

- Updates the `testRadioButtonSelection` test to not assert a no value label, since the field is now required because of the `ArcGISFeatureTable.typeIdField`.
- Adds 3 more tests based on the common-toolkit test design.