### PR TITLE
`Forms` : Optimize FeatureForm

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -159,7 +159,7 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             label = "feature form"
         ) {
             val isSwitching = uiState is UIState.Switching
-            // remember the form and update it when a new form opened
+            // remember the form and update it when a new form is opened
             val rememberedForm = remember(this, isSwitching) {
                 featureForm!!
             }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -158,7 +158,9 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             exit = slideOutVertically { h -> h },
             label = "feature form"
         ) {
-            val rememberedForm = remember(this) {
+            val isSwitching = uiState is UIState.Switching
+            // remember the form and update it when a new form opened
+            val rememberedForm = remember(this, isSwitching) {
                 featureForm!!
             }
             val bottomSheetState = rememberStandardBottomSheetState(

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -102,7 +102,7 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                     ValidationErrorVisibility.Automatic
                 )
             }
-            
+
             is UIState.Switching -> {
                 val state = uiState as UIState.Switching
                 Pair(
@@ -130,7 +130,6 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                     showDiscardEditsDialog = true
                 },
                 onSave = {
-                    //SubmitForm(mapViewModel = mapViewModel, featureForm = (uiState as UIState.Editing).featureForm)
                     scope.launch {
                         mapViewModel.commitEdits().onFailure {
                             Log.w("Forms", "Applying edits failed : ${it.message}")
@@ -159,6 +158,9 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             exit = slideOutVertically { h -> h },
             label = "feature form"
         ) {
+            val rememberedForm = remember(this) {
+                featureForm!!
+            }
             val bottomSheetState = rememberStandardBottomSheetState(
                 initialValue = SheetValue.PartiallyExpanded,
                 confirmValueChange = { it != SheetValue.Hidden },
@@ -180,13 +182,11 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                     sheetWidth = with(LocalDensity.current) { layoutWidth.toDp() }
                 ) {
                     // set bottom sheet content to the FeatureForm
-                    if (featureForm != null) {
-                        FeatureForm(
-                            featureForm = featureForm,
-                            modifier = Modifier.fillMaxSize(),
-                            validationErrorVisibility = errorVisibility
-                        )
-                    }
+                    FeatureForm(
+                        featureForm = rememberedForm,
+                        modifier = Modifier.fillMaxSize(),
+                        validationErrorVisibility = errorVisibility
+                    )
                 }
             }
         }
@@ -282,7 +282,7 @@ fun TopFormBar(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SubmitForm(errors : List<ErrorInfo>, onDismissRequest: () -> Unit) {
+private fun SubmitForm(errors: List<ErrorInfo>, onDismissRequest: () -> Unit) {
     if (errors.isEmpty()) {
         // show a progress dialog if no errors are present
         AlertDialog(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -18,7 +18,6 @@
 
 package com.arcgismaps.toolkit.featureforms
 
-import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -268,7 +267,6 @@ internal fun rememberStates(
     form: FeatureForm,
     scope: CoroutineScope
 ): FormStateCollection {
-    Log.e("TAG", "rememberStates: remember states")
     val states = MutableFormStateCollection()
     form.elements.forEach { element ->
         when (element) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -18,6 +18,7 @@
 
 package com.arcgismaps.toolkit.featureforms
 
+import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -32,10 +33,13 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -111,6 +115,30 @@ public fun FeatureForm(
     modifier: Modifier = Modifier,
     validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.Automatic
 ) {
+    val stateData = remember(featureForm) {
+        StateData(featureForm)
+    }
+    FeatureForm(
+        stateData = stateData,
+        modifier = modifier,
+        validationErrorVisibility = validationErrorVisibility
+    )
+}
+
+/**
+ * A wrapper to hold state data. This provides a [Stable] class to enable smart recompositions,
+ * since [FeatureForm] is not stable.
+ */
+@Immutable
+internal data class StateData(@Stable val featureForm: FeatureForm)
+
+@Composable
+internal fun FeatureForm(
+    stateData: StateData,
+    modifier: Modifier = Modifier,
+    validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.Automatic
+) {
+    val featureForm = stateData.featureForm
     val scope = rememberCoroutineScope()
     val states = rememberStates(form = featureForm, scope = scope)
     FeatureFormBody(form = featureForm, states = states, modifier = modifier)
@@ -234,6 +262,7 @@ internal fun rememberStates(
     form: FeatureForm,
     scope: CoroutineScope
 ): FormStateCollection {
+    Log.e("TAG", "rememberStates: remember states")
     val states = MutableFormStateCollection()
     form.elements.forEach { element ->
         when (element) {
@@ -266,7 +295,7 @@ internal fun rememberStates(
                 states.add(element, groupState)
             }
 
-            else -> { }
+            else -> {}
         }
     }
     return states

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -100,6 +100,9 @@ public sealed class ValidationErrorVisibility {
  * layer using forms that have been configured externally. Forms may be configured in the [Web Map Viewer](https://www.arcgis.com/home/webmap/viewer.html)
  * or [Fields Maps Designer](https://www.arcgis.com/apps/fieldmaps/)).
  *
+ * Note : Even though the [FeatureForm] class is not stable, there exists an internal mechanism to
+ * enable smart recompositions.
+ *
  * @param featureForm The [FeatureForm] configuration.
  * @param modifier The [Modifier] to be applied to layout corresponding to the content of this
  * FeatureForm.
@@ -132,6 +135,9 @@ public fun FeatureForm(
 @Immutable
 internal data class StateData(@Stable val featureForm: FeatureForm)
 
+/**
+ * This composable uses the [StateData] class to display a [FeatureForm].
+ */
 @Composable
 internal fun FeatureForm(
     stateData: StateData,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.base
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
+@Immutable
 internal open class FieldProperties<T>(
     val label: String,
     val placeholder: String,
@@ -41,6 +43,7 @@ internal open class FieldProperties<T>(
 /**
  * A class that provides a validation error [error] for the value of [data].
  */
+@Immutable
 internal data class Value<T>(
     val data: T,
     val error: ValidationErrorState = ValidationErrorState.NoError

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
@@ -17,10 +17,12 @@
 package com.arcgismaps.toolkit.featureforms.internal.components.base
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.res.stringResource
 import com.arcgismaps.toolkit.featureforms.R
 
+@Immutable
 internal sealed class ValidationErrorState(
     private vararg val formatArgs: Any
 ) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormElementState.kt
@@ -16,8 +16,9 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.base
 
-import kotlinx.coroutines.flow.StateFlow
+import androidx.compose.runtime.Immutable
 import com.arcgismaps.mapping.featureforms.FormElement
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Base state class for a [FormElement].
@@ -26,6 +27,7 @@ import com.arcgismaps.mapping.featureforms.FormElement
  * @param description Description text for the field.
  * @param isVisible Property that indicates if the field is visible.
  */
+@Immutable
 internal abstract class FormElementState(
     val label : String,
     val description: String,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
@@ -16,12 +16,14 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.base
 
+import androidx.compose.runtime.Immutable
 import com.arcgismaps.mapping.featureforms.FormElement
 
 /**
  * An iterable collection that provides a [FormElement] and its [FormElementState] as a
  * [FormStateCollection.Entry].
  */
+@Immutable
 internal interface FormStateCollection : Iterable<FormStateCollection.Entry> {
     interface Entry {
         val formElement: FormElement

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.codedvalue
 
-import androidx.compose.runtime.Stable
 import com.arcgismaps.data.CodedValue
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
@@ -54,7 +53,6 @@ internal open class CodedValueFieldProperties(
  * @param onEditValue a callback to invoke when the user edits result in a change of value. This
  * is called on [CodedValueFieldState.onValueChanged]
  */
-@Stable
 internal abstract class CodedValueFieldState(
     properties: CodedValueFieldProperties,
     initialValue: Any? = properties.value.value,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -18,6 +18,7 @@ package com.arcgismaps.toolkit.featureforms.internal.utils
 
 import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -49,6 +50,7 @@ internal val LocalDialogRequester = staticCompositionLocalOf { DialogRequester()
 /**
  * A handler that handles dialog requests during the lifetime of a FeatureForm.
  */
+@Immutable
 internal class DialogRequester {
 
     private val _requestFlow: MutableStateFlow<DialogType?> = MutableStateFlow(null)


### PR DESCRIPTION
### Summary

- Adds `@Stable` and `@Immutable` annotations to classes that are indeed stable and immutable so that compose compiler can enable smart recompositions by making the Composables that use these classes skippable.
- `FeatureForm` composable now uses an internal `StateData` class which is marked as `Immutable` as a internal mechanism to enable smart recompositions.
- Updated `MapScreen` to remember the form inside the `AnimatedVisibility` so that exit animation is played correctly.
