### PR TITLE
do not pass a selected date into date picker if it is out of range.

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/picker/DateTimePicker.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/picker/DateTimePicker.kt
@@ -135,10 +135,17 @@ internal fun DateTimePicker(
     // DateTime from the state's value
     val dateTime by state.dateTime
     // create and remember a DatePickerState
+    val initialSelectedDateTimeMillis = dateTime.dateForPicker?.let {
+        if (state.dateValidator(it)) {
+            it
+        } else {
+            null
+        }
+    }
     val datePickerState = rememberSaveable(dateTime, saver = DatePickerState.Saver()) {
         DatePickerState(
-            initialSelectedDateMillis = dateTime.dateForPicker,
-            initialDisplayedMonthMillis = dateTime.dateForPicker
+            initialSelectedDateMillis = initialSelectedDateTimeMillis,
+            initialDisplayedMonthMillis = initialSelectedDateTimeMillis
                 ?: (state.minDateTime?.toEpochMilli() ?: state.maxDateTime?.toEpochMilli()),
             datePickerRange,
             DisplayMode.Picker


### PR DESCRIPTION
If the datetime in the field is not within the range of the form, don't set it as the selected date in the DatePicker. 

Fixes the crash when the datetime in the field is not within the same calendar year as the range, but also will not show any selected date that is out of the form's range. 

In our microapp, a form with a date that is out of range cannot be submitted, even if that date was already in the field.