### PR TITLE
agree with exception name change

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,4 +54,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.4.0
-sdkBuildNumber=4180
+sdkBuildNumber=4191

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -360,7 +360,7 @@ private fun SubmitForm(errors: List<ErrorInfo>, onDismissRequest: () -> Unit) {
 @Composable
 fun FeatureFormValidationException.getString(): String {
     return when (this) {
-        is FeatureFormValidationException.IncorrectValueTypeError -> {
+        is FeatureFormValidationException.IncorrectValueTypeException -> {
             stringResource(id = R.string.value_must_be_of_correct_type)
         }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
@@ -106,7 +106,7 @@ private fun createValidationErrorStates(
                     )
                 }
 
-                is FeatureFormValidationException.IncorrectValueTypeError -> {
+                is FeatureFormValidationException.IncorrectValueTypeException -> {
                     if (formElement.fieldType.isFloatingPoint) {
                         add(ValidationErrorState.NotANumber)
                     } else if (formElement.fieldType.isIntegerType) {


### PR DESCRIPTION
There's a breaking change to the name of a FeatureFormValidationException in SDK build 200.4.0 as of 4191.

This will accommodate the change. Do not merge until after 4191 is built!