### PR TITLE
Moves rememberLauncherForActivityResult outside of conditional

### DIFF
--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthAuthenticator.kt
@@ -56,6 +56,14 @@ internal fun OAuthAuthenticator(
         // OAuth challenge the OAuthAuthenticator will re-enter the composition and a new `didLaunch` state
         // variable will be initialized again here to false.
         var didLaunch by rememberSaveable { mutableStateOf(false) }
+        val launcher =
+            rememberLauncherForActivityResult(contract = OAuthUserSignInActivity.Contract()) { redirectUrl ->
+                redirectUrl?.let {
+                    oAuthPendingSignIn.complete(redirectUrl)
+                } ?: run {
+                    oAuthPendingSignIn.cancel()
+                }
+            }
         // Launching an activity is a side effect. We don't need `LaunchedEffect` because this is not suspending
         // and there's nothing that needs to keep running if it gets recomposed. In reality, we also don't
         // expect `oAuthPendingSignIn` to change while this composable is displayed.
@@ -66,12 +74,6 @@ internal fun OAuthAuthenticator(
                     onPendingOAuthUserSignIn.invoke(oAuthPendingSignIn)
                 }
             } else {
-                val launcher =
-                    rememberLauncherForActivityResult(contract = OAuthUserSignInActivity.Contract()) { redirectUrl ->
-                        redirectUrl?.let {
-                            oAuthPendingSignIn.complete(redirectUrl)
-                        } ?: oAuthPendingSignIn.cancel()
-                    }
                 SideEffect {
                     launcher.launch(oAuthPendingSignIn)
                 }


### PR DESCRIPTION
Fixes following issue:
When the OAuth Sign in page is rotated , the activity does not complete the result contract and the activity hangs indefinitely. 