### PR TITLE
`Forms`: fix title padding

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -169,9 +170,18 @@ internal fun FeatureForm(
 }
 
 @Composable
-private fun FeatureFormTitle(featureForm: FeatureForm) {
+private fun FeatureFormTitle(featureForm: FeatureForm, modifier: Modifier = Modifier) {
     val title by featureForm.title.collectAsState()
-    Text(text = title, style = TextStyle(fontWeight = FontWeight.Bold))
+    Text(
+        text = title,
+        style = TextStyle(fontWeight = FontWeight.Bold),
+        modifier = modifier
+    )
+    DisposableEffect(key1 =) {
+        onDispose {
+
+        }
+    }
 }
 
 @Composable
@@ -187,7 +197,10 @@ private fun FeatureFormBody(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // title
-        FeatureFormTitle(featureForm = form)
+        FeatureFormTitle(
+            featureForm = form,
+            modifier = Modifier.padding(horizontal = 15.dp)
+        )
         Spacer(
             modifier = Modifier
                 .fillMaxWidth()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Divider
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,8 +49,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
@@ -173,7 +172,7 @@ private fun FeatureFormTitle(featureForm: FeatureForm, modifier: Modifier = Modi
     val title by featureForm.title.collectAsState()
     Text(
         text = title,
-        style = TextStyle(fontWeight = FontWeight.Bold),
+        style = MaterialTheme.typography.titleMedium,
         modifier = modifier
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -177,11 +176,6 @@ private fun FeatureFormTitle(featureForm: FeatureForm, modifier: Modifier = Modi
         style = TextStyle(fontWeight = FontWeight.Bold),
         modifier = modifier
     )
-    DisposableEffect(key1 =) {
-        onDispose {
-
-        }
-    }
 }
 
 @Composable


### PR DESCRIPTION
- Adds a horizontal padding for the `FeatureFormTitle`.
- Use `MaterialTheme.typography` for `FeatureFormTitle`