### PR TITLE
Fixes BackHandler Bug

### DIFF
--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
@@ -22,6 +22,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.security.KeyChain
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.AlertDialog
@@ -132,9 +133,11 @@ private fun AuthenticatorDelegate(
     onPendingOAuthUserSignIn: ((OAuthUserSignIn) -> Unit)? = null,
     container: (@Composable (@Composable () -> Unit) -> Unit)? = null
 ) {
-    // If the back button is pressed, this ensures that any prompts get dismissed.
-    BackHandler {
-        authenticatorState.dismissAll()
+
+    val hasActivePrompt = authenticatorState.isDisplayed.collectAsStateWithLifecycle(initialValue = false).value
+    // Dismiss all prompts when the back button is pressed, only if there is an active prompt.
+    BackHandler(enabled = hasActivePrompt) {
+            authenticatorState.dismissAll()
     }
 
     val pendingOAuthUserSignIn =

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
@@ -22,7 +22,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.security.KeyChain
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.AlertDialog


### PR DESCRIPTION
Fix the following: 
Any other BackHandler defined in the app will not work when the Authenticator composable is placed last as the Authenticator will have the inner most BackHandler enabled.
```kotlin
@Composable
fun MyApp() {
    val authenticatorState: AuthenticatorState = remember { AuthenticatorState() }
    MyAppContent()
    Authenticator(authenticatorState)
}
```
