### PR TITLE
MicroApp typo fix

### DIFF
--- a/microapps/SceneViewLightingOptionsApp/app/src/main/java/com/arcgismaps/toolkit/sceneviewlightingoptionsapp/screens/MainScreen.kt
+++ b/microapps/SceneViewLightingOptionsApp/app/src/main/java/com/arcgismaps/toolkit/sceneviewlightingoptionsapp/screens/MainScreen.kt
@@ -296,7 +296,7 @@ fun SunTimeOptions(
  * @param currentLightingMode the current sun lighting mode set on the composable SceneView
  * @param setSunLighting called when the sun lighting mode should be changed
  * @param onDismissRequest called when the dialog should be dismissed
- * @since 200.4.9
+ * @since 200.4.0
  */
 @Composable
 fun SunLightingOptions(


### PR DESCRIPTION
PR to correct the `@since` tag for the micro-app SceneView Lighting Options App. 