### PR TITLE
`Forms` : Add OAuth login

### DIFF
--- a/microapps/FeatureFormsApp/README.md
+++ b/microapps/FeatureFormsApp/README.md
@@ -17,4 +17,11 @@ webMapUser=XXX
 webMapPassword=YYY
 ```
 
+To authenticate using OAuth, provide the Client ID value in `local.properties`. If an OAuth client id
+is not provided, the app will prompt a username and password dialog.
+
+```
+clientId=YOUR_CLIENT_ID
+```
+
 For more information on the `FeatureForm` component and how it works, see it's [Readme](../../toolkit/featureforms/README.md).

--- a/microapps/FeatureFormsApp/app/src/main/AndroidManifest.xml
+++ b/microapps/FeatureFormsApp/app/src/main/AndroidManifest.xml
@@ -41,6 +41,22 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.arcgismaps.toolkit.authentication.OAuthUserSignInActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:exported="true"
+            android:launchMode="singleTop" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="auth"
+                    android:scheme="featureformsapp" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginViewModel.kt
@@ -106,11 +106,13 @@ class LoginViewModel @Inject constructor(
             if (url.isNotEmpty()) {
                 urlHistoryDao.insert(UrlEntry(url))
             }
-            authenticatorState.oAuthUserConfiguration = OAuthUserConfiguration(
-                portalUrl =  url,
-                clientId =  BuildConfig.clientId,
-                redirectUrl = oAuthRedirectUri,
-            )
+            authenticatorState.oAuthUserConfiguration = if (BuildConfig.clientId.isNotBlank())
+                OAuthUserConfiguration(
+                    portalUrl = url,
+                    clientId = BuildConfig.clientId,
+                    redirectUrl = oAuthRedirectUri,
+                )
+            else null
             portalSettings.setPortalUrl(url)
             portalSettings.setPortalConnection(Portal.Connection.Authenticated)
             val portal = Portal(url, Portal.Connection.Authenticated)

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginViewModel.kt
@@ -18,6 +18,7 @@ package com.arcgismaps.toolkit.featureformsapp.screens.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arcgismaps.httpcore.authentication.OAuthUserConfiguration
 import com.arcgismaps.portal.Portal
 import com.arcgismaps.toolkit.authentication.AuthenticatorState
 import com.arcgismaps.toolkit.featureformsapp.BuildConfig
@@ -58,6 +59,8 @@ class LoginViewModel @Inject constructor(
 
     private val _loginState: MutableStateFlow<LoginState> = MutableStateFlow(LoginState.NotLoggedIn)
     val loginState = _loginState.asStateFlow()
+
+    private val oAuthRedirectUri = "featureformsapp://auth"
 
     private var credentials: Credentials? = Credentials()
 
@@ -103,7 +106,11 @@ class LoginViewModel @Inject constructor(
             if (url.isNotEmpty()) {
                 urlHistoryDao.insert(UrlEntry(url))
             }
-            authenticatorState.oAuthUserConfiguration = null
+            authenticatorState.oAuthUserConfiguration = OAuthUserConfiguration(
+                portalUrl =  url,
+                clientId =  BuildConfig.clientId,
+                redirectUrl = oAuthRedirectUri,
+            )
             portalSettings.setPortalUrl(url)
             portalSettings.setPortalConnection(Portal.Connection.Authenticated)
             val portal = Portal(url, Portal.Connection.Authenticated)

--- a/secrets.defaults.properties
+++ b/secrets.defaults.properties
@@ -22,3 +22,4 @@
 API_KEY=XX
 webMapUser=XX
 webMapPassword=XX
+clientId=" "


### PR DESCRIPTION
### Summary of changes

- The enterprise login will now use OAuth to sign in.
- Created an OAuth configuration on the developer dashboard that is linked to the micro app.
- This OAuth config `clientId` must be specified in the `local.properties` file that gets picked up by gradle secrets.