### PR TITLE
`Forms` : Attachment Form Element

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,4 +54,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.5.0
-sdkBuildNumber=4212
+sdkBuildNumber=4220

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.neverEqualPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -64,9 +65,9 @@ import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.mapping.featureforms.SwitchFormInput
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentElementState
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentFormElement
-import com.arcgismaps.toolkit.featureforms.internal.components.attachment.FakeAttachmentElementState
-import com.arcgismaps.toolkit.featureforms.internal.components.attachment.fakeAttachments
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.rememberAttachmentElementState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseFieldState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseGroupState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.FormStateCollection
@@ -253,6 +254,7 @@ private fun FeatureFormBody(
 
                         is AttachmentFormElement -> {
                             AttachmentFormElement(
+                                state = entry.getState(),
                                 Modifier
                                     .fillMaxWidth()
                                     .padding(horizontal = 15.dp, vertical = 10.dp)
@@ -271,8 +273,8 @@ private fun FeatureFormBody(
     LaunchedEffect(form) {
         // ensure expressions are evaluated
         form.evaluateExpressions()
-        onExpressionsEvaluated()
         initialEvaluation = true
+        onExpressionsEvaluated()
     }
 }
 
@@ -306,7 +308,7 @@ internal fun InitializingExpressions(
 @Composable
 internal fun rememberStates(
     form: FeatureForm,
-    elements : List<FormElement>,
+    elements: List<FormElement>,
     scope: CoroutineScope
 ): FormStateCollection {
     val states = MutableFormStateCollection()
@@ -342,8 +344,7 @@ internal fun rememberStates(
             }
 
             is AttachmentFormElement -> {
-                val state =
-                    rememberFakeAttachmentElementState(form = form, attachmentFormElement = element)
+                val state = rememberAttachmentElementState(form, element)
                 states.add(element, state)
             }
 
@@ -430,13 +431,4 @@ internal fun rememberFieldState(
             null
         }
     }
-}
-
-@Suppress("UNUSED_PARAMETER")
-@Composable
-internal fun rememberFakeAttachmentElementState(
-    form: FeatureForm,
-    attachmentFormElement: AttachmentFormElement
-): FakeAttachmentElementState {
-    return FakeAttachmentElementState(fakeAttachments)
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -18,7 +18,6 @@
 
 package com.arcgismaps.toolkit.featureforms
 
-import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -39,14 +38,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.neverEqualPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
@@ -65,7 +61,6 @@ import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.mapping.featureforms.SwitchFormInput
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
-import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentElementState
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentFormElement
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.rememberAttachmentElementState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseFieldState
@@ -83,7 +78,6 @@ import com.arcgismaps.toolkit.featureforms.internal.components.formelement.Group
 import com.arcgismaps.toolkit.featureforms.internal.components.text.rememberFormTextFieldState
 import com.arcgismaps.toolkit.featureforms.internal.utils.FeatureFormDialog
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 
 /**
  * The "property" determines the behavior of when the validation errors are visible.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementDefaults.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementDefaults.kt
@@ -1,20 +1,20 @@
 /*
- * COPYRIGHT 1995-2024 ESRI
+ * Copyright 2024 Esri
  *
- * TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
- * Unpublished material - all rights reserved under the
- * Copyright Laws of the United States.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * For additional information, contact:
- * Environmental Systems Research Institute, Inc.
- * Attn: Contracts Dept
- * 380 New York Street
- * Redlands, California, USA 92373
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * email: contracts@esri.com
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
-package com.arcgismaps.toolkit.featureforms.internal.components.formelement
+package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -137,18 +137,6 @@ internal class FormAttachmentState(
             }
         }
     }
-
-    companion object {
-        fun Saver(
-            attachment: FormAttachment,
-            scope: CoroutineScope
-        ): Saver<FormAttachmentState, Any> = Saver(
-            save = {},
-            restore = {
-                FormAttachmentState(attachment, scope)
-            }
-        )
-    }
 }
 
 @Composable

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -16,15 +16,154 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
+import android.graphics.drawable.BitmapDrawable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import com.arcgismaps.LoadStatus
 import com.arcgismaps.mapping.featureforms.AttachmentFormElement
+import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.featureforms.FormAttachment
 import com.arcgismaps.toolkit.featureforms.internal.components.base.FormElementState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
+/**
+ * Represents the state of an [AttachmentFormElement]
+ */
 internal class AttachmentElementState(
-    private val formElement : AttachmentFormElement
+    private val formElement: AttachmentFormElement,
+    private val scope: CoroutineScope
 ) : FormElementState(
     label = formElement.label,
     description = formElement.description,
     isVisible = formElement.isVisible,
-){
-    val keyword = formElement.keyword
+) {
+    /**
+     * The attachments associated with the form element.
+     */
+    val attachments = SnapshotStateList<FormAttachmentState>()
+
+    init {
+        scope.launch {
+            loadAttachments()
+        }
+    }
+
+    /**
+     * Loads the attachments associated with the form element. This clears the current list of
+     * attachments and updates it with the list of attachments from the [formElement].
+     */
+    private suspend fun loadAttachments() {
+        formElement.fetchAttachments()
+        attachments.clear()
+        attachments.addAll(
+            formElement.attachments.map {
+                FormAttachmentState(it, scope)
+            }
+        )
+    }
+
+    companion object {
+        fun Saver(
+            attachmentFormElement: AttachmentFormElement,
+            scope: CoroutineScope
+        ): Saver<AttachmentElementState, Any> = listSaver(
+            save = {
+                // save the list of indices of attachments that have been loaded
+                buildList<Int> {
+                    for (i in it.attachments.indices) {
+                        if (it.attachments[i].loadStatus.value is LoadStatus.Loaded) {
+                            add(i)
+                        }
+                    }
+                }
+            },
+            restore = { savedList ->
+                AttachmentElementState(attachmentFormElement, scope).also {
+                    scope.launch {
+                        it.loadAttachments()
+                        // load the attachments that were previously loaded
+                        savedList.forEach { index ->
+                            it.attachments[index].loadAttachment()
+                        }
+                    }
+                }
+            }
+        )
+    }
+}
+
+/**
+ * Represents the state of a [FormAttachment].
+ */
+internal class FormAttachmentState(
+    val name: String,
+    val size: Long,
+    val loadStatus: StateFlow<LoadStatus>,
+    private val onLoadAttachment: suspend () -> Result<Unit>,
+    private val onLoadThumbnail: suspend () -> Result<BitmapDrawable?>,
+    private val scope: CoroutineScope
+) {
+    private val _thumbnail: MutableState<ImageBitmap?> = mutableStateOf(null)
+    val thumbnail: State<ImageBitmap?> = _thumbnail
+
+    constructor(attachment: FormAttachment, scope: CoroutineScope) : this(
+        name = attachment.name,
+        size = attachment.size,
+        loadStatus = attachment.loadStatus,
+        onLoadAttachment = attachment::load,
+        onLoadThumbnail = attachment::createFullImage,
+        scope = scope
+    )
+
+    fun loadAttachment() {
+        scope.launch {
+            onLoadAttachment().onSuccess {
+                onLoadThumbnail().onSuccess {
+                    if (it != null) {
+                        _thumbnail.value = it.bitmap.asImageBitmap()
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun Saver(
+            attachment: FormAttachment,
+            scope: CoroutineScope
+        ): Saver<FormAttachmentState, Any> = Saver(
+            save = {},
+            restore = {
+                FormAttachmentState(attachment, scope)
+            }
+        )
+    }
+}
+
+@Composable
+internal fun rememberAttachmentElementState(
+    form: FeatureForm,
+    attachmentFormElement: AttachmentFormElement
+): AttachmentElementState {
+    val scope = rememberCoroutineScope()
+    return rememberSaveable(
+        inputs = arrayOf(form),
+        saver = AttachmentElementState.Saver(attachmentFormElement, scope)
+    ) {
+        AttachmentElementState(
+            formElement = attachmentFormElement,
+            scope = scope
+        )
+    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.attachment
+
+import com.arcgismaps.mapping.featureforms.AttachmentFormElement
+import com.arcgismaps.toolkit.featureforms.internal.components.base.FormElementState
+
+internal class AttachmentElementState(
+    private val formElement : AttachmentFormElement
+) : FormElementState(
+    label = formElement.label,
+    description = formElement.description,
+    isVisible = formElement.isVisible,
+){
+    val keyword = formElement.keyword
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -1,22 +1,20 @@
 /*
+ * Copyright 2024 Esri
  *
- *  Copyright 2024 Esri
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
-package com.arcgismaps.toolkit.featureforms.internal.components.formelement
+package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloat

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -16,149 +16,49 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Add
-import androidx.compose.material.icons.rounded.AddAPhoto
-import androidx.compose.material.icons.rounded.AddPhotoAlternate
-import androidx.compose.material.icons.rounded.Delete
-import androidx.compose.material.icons.rounded.Download
-import androidx.compose.material.icons.rounded.Edit
-import androidx.compose.material.icons.rounded.LibraryAdd
-import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.font.FontWeight.Companion.W300
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
-import com.arcgismaps.toolkit.featureforms.R
-import com.arcgismaps.toolkit.featureforms.internal.components.base.FormElementState
+import com.arcgismaps.LoadStatus
 import kotlinx.coroutines.flow.MutableStateFlow
 
-
-internal data class FakeAttachmentElementState(
-    val attachments: List<FakeAttachment>,
-    val editable: Boolean = true,
-    val title: String = "Titanic",
-    val keyword: String = "point of impact",// not used
-    val input: String = "123",// not used
-    var selectedAttachment: FakeAttachment? = null
-): FormElementState(label = "fake attachments", description = "fake description", isVisible = MutableStateFlow<Boolean>(true))
-
-internal data class FakeAttachment(val name: String = "front of ship.jpg", val size: Long = 1234L)
-
-internal val fakeAttachments =
-    buildList {
-        repeat(40) {
-            add(FakeAttachment("Bow point of collision.jpeg", 1234))
-        }
-    }
-
-private fun Modifier.feedbackClickable(
-    enabled: Boolean = true,
-    currentAlpha: Float = 1f,
-    onClick: () -> Unit = {}
-) = composed {
-    
-    val source = remember { MutableInteractionSource() }
-    val isPressed by source.collectIsPressedAsState()
-    val animationTransition = updateTransition(isPressed, label = "BouncingClickableTransition")
-    val opacity by animationTransition.animateFloat(
-        targetValueByState = { pressed -> if (pressed) currentAlpha * 0.4f else currentAlpha },
-        label = "ClickableOpacityTransition"
-    )
-    
-    val scaleFactor by animationTransition.animateFloat(
-        targetValueByState = { pressed -> if (pressed) 0.8f else 1f },
-        label = "ClickableScaleFactorTransition",
-        transitionSpec = {
-            spring(
-                dampingRatio = Spring.DampingRatioHighBouncy,
-                stiffness = Spring.StiffnessLow
-            )
-        }
-    )
-    
-    this
-        .graphicsLayer {
-            this.scaleX = scaleFactor
-            this.scaleY = scaleFactor
-            this.alpha = opacity
-        }
-        .clickable(
-            interactionSource = source,
-            indication = null,
-            enabled = enabled,
-            onClick = onClick
-        )
-}
-
 @Composable
-internal fun AttachmentFormElement(modifier: Modifier = Modifier) {
+internal fun AttachmentFormElement(
+    state: AttachmentElementState,
+    modifier: Modifier = Modifier
+) {
     AttachmentFormElement(
-        state = FakeAttachmentElementState(attachments = fakeAttachments, selectedAttachment = null),
+        label = state.label,
+        description = state.description,
+        editable = true,
+        attachments = state.attachments,
         modifier = modifier
     )
 }
 
-/**
- * Todo: make public with a proper state object, and call from FeatureFormBody.
- */
 @Composable
-private fun AttachmentFormElement(
-    state: FakeAttachmentElementState,
+internal fun AttachmentFormElement(
+    label: String,
+    description: String,
+    editable: Boolean,
+    attachments: List<FormAttachmentState>,
     modifier: Modifier = Modifier,
     colors: AttachmentElementColors = AttachmentElementDefaults.colors()
 ) {
@@ -168,275 +68,35 @@ private fun AttachmentFormElement(
         border = BorderStroke(AttachmentElementDefaults.borderThickness, colors.borderColor)
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 10.dp)
+            modifier = Modifier.padding(15.dp)
         ) {
-            AttachmentElementHeader(
-                title = state.title,
-                description = state.description,
-                editable = state.editable
+            Header(
+                title = label,
+                description = description,
+                editable = editable
             )
-            Spacer(modifier = Modifier.height(10.dp))
-            Carousel(
-                onDetailsTap = {
-                    state.selectedAttachment = it
-                }
-            )
+            Spacer(modifier = Modifier.height(20.dp))
+            Carousel(attachments)
         }
     }
 }
 
 @Composable
-private fun Carousel(onThumbnailTap: (FakeAttachment) -> Unit = {}, onDetailsTap: (FakeAttachment) -> Unit) {
-    Row(
-        Modifier
-            .horizontalScroll(rememberScrollState())
-            .height(intrinsicSize = IntrinsicSize.Max),
-        horizontalArrangement = Arrangement.spacedBy(10.dp)
+private fun Carousel(attachments: List<FormAttachmentState>) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(15.dp),
     ) {
-        fakeAttachments.forEach {
-            CarouselThumbnail(
-                it.name,
-                it.size,
-                onThumbnailTap = { onThumbnailTap(it) },
-                onDetailsTap = { onDetailsTap(it) }
-            )
+        items(attachments) {
+            AttachmentTile(it)
         }
     }
 }
 
 @Composable
-private fun CarouselThumbnail(name: String, size: Long, onThumbnailTap: () -> Unit, onDetailsTap: () -> Unit) {
-    var downloaded by rememberSaveable { mutableStateOf(false) }
-    Column(
-        Modifier
-            .feedbackClickable { onThumbnailTap() }
-            .width(80.dp)
-            .border(
-                border = BorderStroke(
-                    AttachmentElementDefaults.borderThickness,
-                    AttachmentElementDefaults.colors().borderColor
-                ),
-                shape = RoundedCornerShape(10.dp)
-            ),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Box(
-            modifier = Modifier
-                .alpha(0.4f)
-                .aspectRatio(1.0f)
-        ) {
-            var showMenu by rememberSaveable { mutableStateOf(false) }
-            ThumbnailMenu(showMenu) {
-                showMenu = false
-            }
-            
-            if (downloaded) {
-                Image(
-                    painter = rememberAsyncImagePainter(
-                        ImageRequest.Builder(LocalContext.current)
-                            .data("https://i.postimg.cc/65yws9mR/Screenshot-2024-02-02-at-6-20-49-PM.png").apply {
-                                placeholder(
-                                    LocalContext.current.getDrawable(R.drawable.baseline_cloud_download_16)
-                                )
-                            }.build()
-                    ),
-                    contentScale = ContentScale.Crop,
-                    contentDescription = "Thumbnail image",
-                    modifier = Modifier
-                        .size(80.dp)
-                        .clip(shape = RoundedCornerShape(15.dp, 15.dp, 0.dp, 0.dp))
-                )
-                Icon(
-                    Icons.Rounded.MoreVert,
-                    "more",
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(vertical = 3.dp)
-                        .clickable {
-                            showMenu = true
-                            onDetailsTap()
-                        }
-                )
-            } else {
-                Icon(
-                    Icons.Rounded.Download,
-                    contentDescription = "Download attachment",
-                    modifier = Modifier
-                        .size(80.dp)
-                        .clip(shape = RoundedCornerShape(15.dp, 15.dp, 0.dp, 0.dp))
-                        .clickable { downloaded = true }
-                
-                )
-            }
-        }
-        
-        HorizontalDivider()
-        CarouselText(name, size)
-    }
-}
-
-@Composable
-private fun ThumbnailMenu(expanded: Boolean, onDismiss: () -> Unit = {}) {
-    MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = RoundedCornerShape(8.dp))) {
-        DropdownMenu(
-            expanded = expanded,
-            offset = DpOffset(15.dp, (-5).dp),
-            onDismissRequest = onDismiss
-        ) {
-            DropdownMenuItem(
-                text = { Text(text = "Rename") },
-                trailingIcon = {
-                    Icon(
-                        imageVector = Icons.Rounded.Edit,
-                        contentDescription = "Rename attachment",
-                        modifier = Modifier.alpha(0.4f)
-                    )
-                },
-                contentPadding = PaddingValues(horizontal = 3.dp),
-                onClick = {}
-            )
-            HorizontalDivider(modifier = Modifier.padding(vertical = 5.dp))
-            DropdownMenuItem(
-                text = { Text(text = "Delete") },
-                trailingIcon = {
-                    Icon(
-                        imageVector = Icons.Rounded.Delete,
-                        contentDescription = "Delete attachment",
-                        modifier = Modifier.alpha(0.4f)
-                    )
-                },
-                contentPadding = PaddingValues(horizontal = 3.dp),
-                onClick = {}
-            )
-//            Row(
-//                modifier = Modifier.padding(horizontal = 3.dp),
-//                horizontalArrangement = Arrangement.Start,
-//                verticalAlignment = Alignment.CenterVertically
-//            ) {
-//                Text(text = "Delete")
-//                Spacer(modifier = Modifier.weight(1f))
-//                Icon(
-//                    imageVector = Icons.Rounded.Delete,
-//                    contentDescription = "Delete attachment",
-//                    modifier = Modifier.alpha(0.4f)
-//                )
-//            }
-//
-        }
-    }
-}
-
-@Composable
-private fun CarouselText(
-    name: String,
-    size: Long
-) {
-    Column {
-        Text(
-            text = name,
-            style = MaterialTheme.typography.labelSmall.copy(
-                fontWeight = FontWeight.W600
-            ),
-            textAlign = TextAlign.Center,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(horizontal = 1.dp)
-        )
-        Text(
-            text = "$size KB",
-            style = MaterialTheme.typography.labelSmall.copy(
-                fontWeight = W300,
-                fontSize = 9.sp
-            ),
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier
-                .padding(horizontal = 1.dp)
-                .align(Alignment.CenterHorizontally)
-        
-        )
-        Spacer(modifier = Modifier.height(5.dp))
-    }
-}
-
-@Composable
-private fun AddAttachmentMenu(expanded: Boolean, onDismiss: () -> Unit = {}) {
-    MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = RoundedCornerShape(8.dp))) {
-        DropdownMenu(
-            expanded = expanded,
-            offset = DpOffset.Zero,
-            onDismissRequest = onDismiss
-        ) {
-            DropdownMenuItem(
-                text= { Text(text = "Take Photo") },
-                trailingIcon = {
-                    Icon(
-                        imageVector = Icons.Rounded.AddAPhoto,
-                        contentDescription = "Add a photo",
-                        modifier = Modifier.alpha(0.4f)
-                    )
-                },
-                onClick = {}
-            )
-            HorizontalDivider(modifier = Modifier.padding(vertical = 5.dp))
-            DropdownMenuItem(
-                text= { Text(text = "Add Photo From Gallery") },
-                trailingIcon = {
-                    Icon(
-                        imageVector = Icons.Rounded.AddPhotoAlternate,
-                        contentDescription = "Add photo from gallery",
-                        modifier = Modifier.alpha(0.4f)
-                    )
-                },
-                onClick = {}
-            )
-            HorizontalDivider(modifier = Modifier.padding(vertical = 5.dp))
-            DropdownMenuItem(
-                text= { Text(text = "Add File") },
-                trailingIcon = {
-                    Icon(
-                        imageVector = Icons.Rounded.LibraryAdd,
-                        contentDescription = "Add File",
-                        modifier = Modifier.alpha(0.4f)
-                    )
-                },
-                onClick = {}
-            )
-        }
-    }
-    
-}
-
-
-@Composable
-private fun AddAttachment() {
-    var showMenu by remember { mutableStateOf(false) }
-    
-    Row {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .feedbackClickable {
-                    showMenu = true
-                }
-        ) {
-            AddAttachmentMenu(expanded = showMenu, onDismiss = { showMenu = false })
-            Icon(
-                Icons.Rounded.Add,
-                contentDescription = "Add attachment",
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .size(32.dp)
-            )
-        }
-        
-    }
-}
-
-@Composable
-private fun AttachmentElementHeader(
+private fun Header(
     title: String,
     description: String,
     modifier: Modifier = Modifier,
-    showingDetails: Boolean = false,
     editable: Boolean = true
 ) {
     Row(
@@ -460,17 +120,25 @@ private fun AttachmentElementHeader(
             }
         }
         Spacer(modifier = Modifier.weight(1f))
-        if (editable && !showingDetails) {
-            AddAttachment()
-        }
     }
 }
 
 @Preview
 @Composable
-private fun PreviewFormAttachmentElement() {
+private fun AttachmentFormElementPreview() {
     AttachmentFormElement(
-        modifier = Modifier
-            .fillMaxWidth()
+        label = "Attachments",
+        description = "Add attachments",
+        editable = true,
+        attachments = listOf(
+            FormAttachmentState(
+                "Photo 1.jpg",
+                2024,
+                MutableStateFlow(LoadStatus.Loaded),
+                { Result.success(Unit) },
+                { Result.success(null) },
+                scope = rememberCoroutineScope()
+            )
+        )
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.attachment
+
+import android.text.format.Formatter
+import android.util.Log
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.AudioFile
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.FileCopy
+import androidx.compose.material.icons.outlined.FilePresent
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.VideoCameraBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.arcgismaps.LoadStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+
+@Composable
+internal fun AttachmentTile(
+    state: FormAttachmentState
+) {
+    val loadStatus by state.loadStatus.collectAsState()
+    val thumbnail by state.thumbnail
+    Log.e("TAG", "AttachmentTile ${state.name}: $loadStatus", )
+    Box(
+        modifier = Modifier
+            .width(92.dp)
+            .height(75.dp)
+            .clip(shape = RoundedCornerShape(8.dp))
+            .border(
+                border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outline),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    awaitLongPressOrCancellation(down.id)?.let {
+                        // handle long press
+                    }
+                }
+            }
+            .clickable {
+                if (loadStatus is LoadStatus.NotLoaded || loadStatus is LoadStatus.FailedToLoad) {
+                    // load attachment
+                    state.loadAttachment()
+                } else if (loadStatus is LoadStatus.Loaded) {
+                    // open attachment
+                }
+            }
+    ) {
+        when (loadStatus) {
+            LoadStatus.Loaded -> LoadedView(
+                thumbnail = thumbnail,
+                title = state.name
+            )
+
+            LoadStatus.Loading -> DefaultView(
+                title = state.name,
+                size = state.size,
+                isLoading = true,
+                isError = false
+            )
+
+            LoadStatus.NotLoaded -> DefaultView(
+                title = state.name,
+                size = state.size,
+                isLoading = false,
+                isError = false
+            )
+
+            is LoadStatus.FailedToLoad -> DefaultView(
+                title = state.name,
+                size = state.size,
+                isLoading = false,
+                isError = true
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadedView(
+    thumbnail: ImageBitmap?,
+    title: String,
+    modifier: Modifier = Modifier
+) {
+    val attachmentType = remember(title) {
+        getAttachmentType(title)
+    }
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+    ) {
+        if (thumbnail != null) {
+            Image(
+                bitmap = thumbnail,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            Icon(
+                imageVector = attachmentType.getIcon(),
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 10.dp, bottom = 25.dp)
+                    .align(Alignment.Center)
+            )
+        }
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(20.dp)
+                .background(
+                    MaterialTheme.colorScheme.onBackground.copy(
+                        alpha = 0.7f
+                    )
+                ),
+            verticalArrangement = Arrangement.Center
+        ) {
+            Title(
+                text = title,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 5.dp),
+                color = MaterialTheme.colorScheme.background
+            )
+        }
+    }
+}
+
+@Composable
+private fun DefaultView(
+    title: String,
+    size: Long,
+    isLoading: Boolean,
+    isError: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val attachmentType = remember(title) {
+        getAttachmentType(title)
+    }
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 5.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceEvenly
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Size(size = size)
+            Icon(
+                imageVector = Icons.Outlined.ArrowDownward,
+                contentDescription = null,
+                modifier = Modifier.size(11.dp)
+            )
+        }
+        if (isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                strokeWidth = 2.dp
+            )
+        } else if (isError) {
+            Image(
+                imageVector = Icons.Outlined.ErrorOutline,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.error)
+            )
+        } else {
+            Icon(
+                imageVector = attachmentType.getIcon(),
+                contentDescription = null,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+        Title(text = title, modifier = Modifier)
+    }
+}
+
+@Composable
+private fun Title(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    style: TextStyle = MaterialTheme.typography.labelSmall
+) {
+    Text(
+        text = text,
+        color = color,
+        style = style,
+        textAlign = TextAlign.Center,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        modifier = modifier.padding(horizontal = 1.dp)
+    )
+}
+
+@Composable
+private fun Size(
+    size: Long, modifier:
+    Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val fileSize = Formatter.formatFileSize(context, size)
+    Text(
+        text = fileSize,
+        style = MaterialTheme.typography.labelSmall.copy(
+            fontWeight = FontWeight.W300,
+            fontSize = 9.sp
+        ),
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier
+            .padding(horizontal = 1.dp)
+    )
+}
+
+private sealed class AttachmentType {
+    data object Image : AttachmentType()
+    data object Audio : AttachmentType()
+    data object Video : AttachmentType()
+    data object Document : AttachmentType()
+    data object Other : AttachmentType()
+}
+
+private fun getAttachmentType(filename: String): AttachmentType {
+    val extension = filename.substring(filename.lastIndexOf(".") + 1)
+    return when (extension) {
+        "jpg", "jpeg", "png", "gif", "bmp" -> AttachmentType.Image
+        "mp3", "wav", "ogg", "flac" -> AttachmentType.Audio
+        "mp4", "avi", "mov", "wmv", "flv" -> AttachmentType.Video
+        "doc", "docx", "pdf", "txt", "rtf" -> AttachmentType.Document
+        else -> AttachmentType.Other
+    }
+}
+
+@Composable
+private fun AttachmentType.getIcon(): ImageVector = when (this) {
+    AttachmentType.Image -> Icons.Outlined.Image
+    AttachmentType.Audio -> Icons.Outlined.AudioFile
+    AttachmentType.Video -> Icons.Outlined.VideoCameraBack
+    AttachmentType.Document -> Icons.Outlined.FilePresent
+    AttachmentType.Other -> Icons.Outlined.FileCopy
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -17,7 +17,6 @@
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 import android.text.format.Formatter
-import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -53,7 +52,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -68,11 +66,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arcgismaps.LoadStatus
-import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
 internal fun AttachmentTile(
@@ -80,7 +76,6 @@ internal fun AttachmentTile(
 ) {
     val loadStatus by state.loadStatus.collectAsState()
     val thumbnail by state.thumbnail
-    Log.e("TAG", "AttachmentTile ${state.name}: $loadStatus", )
     Box(
         modifier = Modifier
             .width(92.dp)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.text
 
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.saveable.Saver
@@ -37,7 +36,6 @@ import com.arcgismaps.toolkit.featureforms.internal.components.base.formattedVal
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 internal class TextFieldProperties(
     label: String,
@@ -173,7 +171,6 @@ internal fun rememberFormTextFieldState(
     inputs = arrayOf(form),
     saver = FormTextFieldState.Saver(field, form, scope)
 ) {
-    Log.e("TAG", "rememberFormTextFieldState: init for ${field.label}", )
     FormTextFieldState(
         properties = TextFieldProperties(
             label = field.label,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.text
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.saveable.Saver
@@ -172,6 +173,7 @@ internal fun rememberFormTextFieldState(
     inputs = arrayOf(form),
     saver = FormTextFieldState.Saver(field, form, scope)
 ) {
+    Log.e("TAG", "rememberFormTextFieldState: init for ${field.label}", )
     FormTextFieldState(
         properties = TextFieldProperties(
             label = field.label,


### PR DESCRIPTION
Summary of changes

Issue - https://devtopia.esri.com/runtime/apollo/issues/409

- Adds `AttachmentFormElement` composable with the api object and the state objects.
- Supports only display of attachments.
- This also includes loading the attachments and transition between different load states.
- Moved the attachment related files into their own sub package.