### PR TITLE
Authenticator theme fix

### DIFF
--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Authenticator.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -58,12 +59,14 @@ public fun Authenticator(
     modifier: Modifier = Modifier,
     onPendingOAuthUserSignIn: ((OAuthUserSignIn) -> Unit)? = null
 ) {
-    AuthenticatorDelegate(
-        authenticatorState = authenticatorState,
-        // `fillMaxSize()` is needed, otherwise the prompts are displayed at the top of the screen.
-        modifier = modifier.fillMaxSize(),
-        onPendingOAuthUserSignIn = onPendingOAuthUserSignIn
-    )
+    Surface {
+        AuthenticatorDelegate(
+            authenticatorState = authenticatorState,
+            // `fillMaxSize()` is needed, otherwise the prompts are displayed at the top of the screen.
+            modifier = modifier.fillMaxSize(),
+            onPendingOAuthUserSignIn = onPendingOAuthUserSignIn
+        )
+    }
 }
 
 /**
@@ -94,16 +97,18 @@ public fun DialogAuthenticator(
 ) {
     val showDialog = authenticatorState.isDisplayed.collectAsStateWithLifecycle(initialValue = false).value
     if (showDialog) {
-        AuthenticatorDelegate(
-            authenticatorState = authenticatorState,
-            modifier = modifier,
-            onPendingOAuthUserSignIn,
-        ) { authenticationPrompt ->
-            AlertDialog(
-                onDismissRequest = authenticatorState::dismissAll,
-                modifier = Modifier.clip(MaterialTheme.shapes.extraLarge),
-            ) {
-                authenticationPrompt()
+        Surface {
+            AuthenticatorDelegate(
+                authenticatorState = authenticatorState,
+                modifier = modifier,
+                onPendingOAuthUserSignIn,
+            ) { authenticationPrompt ->
+                AlertDialog(
+                    onDismissRequest = authenticatorState::dismissAll,
+                    modifier = Modifier.clip(MaterialTheme.shapes.extraLarge),
+                ) {
+                    authenticationPrompt()
+                }
             }
         }
     }


### PR DESCRIPTION
### Description
PR to wrap the `Authenticator` in a `Surface` to apply the correct theme. 

### How to review
Try out the authenticator merged with `shubham/microapp-resources` [branch](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/pull/405), to verify the theme applied in the authenticator in light/dark mode. 

### Screenshots
- `v.next` Authenticator with theme applied: 

<img src="https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/assets/14892474/8d8129a0-fa13-45c8-8469-2d65deac5952" height="600">

- `shubham/authenticator-theme-fix` with theme applied:

<img src="https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/assets/14892474/9646fa1a-2d0c-4758-a35e-9f0ed1409ed4" height="600">


