### PR TITLE
`Forms` : Fix state references

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -18,6 +18,7 @@
 
 package com.arcgismaps.toolkit.featureforms
 
+import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -180,7 +181,7 @@ private fun FeatureForm(
         // expressions evaluated, load attachments
         formElements.value = featureForm.elements
     }
-    FeatureFormDialog()
+    FeatureFormDialog(states)
     // launch a new side effect in a launched effect when validationErrorVisibility changes
     LaunchedEffect(validationErrorVisibility) {
         // if it set to always show errors force each field to validate itself and show any errors

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -18,7 +18,6 @@
 
 package com.arcgismaps.toolkit.featureforms
 
-import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -20,6 +20,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.drawable.BitmapDrawable
+import android.util.Log
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AudioFile
@@ -59,11 +60,13 @@ import kotlinx.coroutines.launch
 internal class AttachmentElementState(
     private val formElement: AttachmentFormElement,
     private val scope: CoroutineScope,
+    id : Int,
     private val evaluateExpressions : suspend () -> Unit
 ) : FormElementState(
     label = formElement.label,
     description = formElement.description,
     isVisible = formElement.isVisible,
+    id = id
 ) {
     /**
      * The attachments associated with the form element.
@@ -84,6 +87,7 @@ internal class AttachmentElementState(
         scope.launch {
             loadAttachments()
         }
+        Log.e("TAG", "id: $id, ${hashCode()}", )
     }
 
     /**
@@ -136,7 +140,7 @@ internal class AttachmentElementState(
                 }
             },
             restore = { savedList ->
-                AttachmentElementState(attachmentFormElement, scope, evaluateExpressions).also {
+                AttachmentElementState(attachmentFormElement, scope, attachmentFormElement.hashCode() , evaluateExpressions).also {
                     scope.launch {
                         it.loadAttachments()
                         // load the attachments that were previously loaded
@@ -218,6 +222,7 @@ internal fun rememberAttachmentElementState(
         AttachmentElementState(
             formElement = attachmentFormElement,
             scope = scope,
+            id = attachmentFormElement.hashCode(),
             evaluateExpressions = form::evaluateExpressions
         )
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -20,7 +20,6 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.drawable.BitmapDrawable
-import android.util.Log
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AudioFile
@@ -87,7 +86,6 @@ internal class AttachmentElementState(
         scope.launch {
             loadAttachments()
         }
-        Log.e("TAG", "id: $id, ${hashCode()}", )
     }
 
     /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -106,7 +106,7 @@ internal fun AttachmentFormElement(
     label: String,
     description: String,
     editable: Boolean,
-    stateId : Int,
+    stateId: Int,
     attachments: List<FormAttachmentState>,
     lazyListState: LazyListState,
     hasCameraPermission: Boolean,
@@ -187,7 +187,7 @@ private fun Header(
 
 @Composable
 private fun AddAttachment(
-    stateId : Int,
+    stateId: Int,
     hasCameraPermission: Boolean,
 ) {
     var showMenu by remember { mutableStateOf(false) }
@@ -249,17 +249,20 @@ private fun AddAttachment(
         pickerStyle.collect {
             when (it) {
                 PickerStyle.Camera -> {
-                    dialogRequester.requestDialog(DialogType.ImageCaptureDialog(
-                        stateId = stateId,
-                        contentType = "image/jpeg"
-                    ))
+                    dialogRequester.requestDialog(
+                        DialogType.ImageCaptureDialog(
+                            stateId = stateId,
+                            contentType = "image/jpeg"
+                        )
+                    )
                 }
 
                 PickerStyle.PickImage -> {
                     dialogRequester.requestDialog(
-                        DialogType.ImagePickerDialog { uri ->
-                            //onAttachment("image/jpeg", uri)
-                        }
+                        DialogType.ImagePickerDialog(
+                            stateId = stateId,
+                            contentType = "image/jpeg"
+                        )
                     )
                 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
@@ -76,7 +76,7 @@ internal abstract class BaseFieldState<T>(
     id = id,
     label = properties.label,
     description = properties.description,
-    isVisible = properties.visible,
+    isVisible = properties.visible
 ) {
     /**
      * Placeholder hint for the field.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
@@ -55,6 +55,7 @@ internal data class Value<T>(
  * Base state class for any Field within a feature form. It provides the default set of properties
  * that are common to all [FieldFormElement]'s.
  *
+ * @param id Unique identifier for the field.
  * @param properties the [FieldProperties] associated with this state.
  * @param initialValue optional initial value to set for this field. It is set to the value of
  * [FieldProperties.value] by default.
@@ -65,15 +66,17 @@ internal data class Value<T>(
  * called after a successful [updateValue].
  */
 internal abstract class BaseFieldState<T>(
+    id: Int,
     properties: FieldProperties<T>,
     initialValue: T = properties.value.value,
     private val scope: CoroutineScope,
     private val updateValue: (Any?) -> Unit,
     private val evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>,
 ) : FormElementState(
+    id = id,
     label = properties.label,
     description = properties.description,
-    isVisible = properties.visible
+    isVisible = properties.visible,
 ) {
     /**
      * Placeholder hint for the field.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseGroupState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseGroupState.kt
@@ -27,15 +27,17 @@ import com.arcgismaps.mapping.featureforms.GroupFormElement
 import kotlinx.coroutines.flow.StateFlow
 
 internal class BaseGroupState(
+    id : Int,
     label: String,
     description: String,
     isVisible: StateFlow<Boolean>,
     expanded: Boolean,
     val fieldStates: FormStateCollection
 ) : FormElementState(
+    id = id,
     label = label,
     description = description,
-    isVisible = isVisible
+    isVisible = isVisible,
 ) {
     private val _expanded = mutableStateOf(expanded)
     val expanded: State<Boolean> = _expanded
@@ -54,11 +56,12 @@ internal class BaseGroupState(
             },
             restore = {
                 BaseGroupState(
+                    id = groupElement.hashCode(),
                     label = groupElement.label,
                     description = groupElement.description,
                     isVisible = groupElement.isVisible,
                     expanded = it,
-                    fieldStates = fieldStates
+                    fieldStates = fieldStates,
                 )
             }
         )
@@ -75,10 +78,11 @@ internal fun rememberBaseGroupState(
     saver = BaseGroupState.Saver(groupElement, fieldStates)
 ) {
     BaseGroupState(
+        id = groupElement.hashCode(),
         label = groupElement.label,
         description = groupElement.description,
         isVisible = groupElement.isVisible,
         expanded = groupElement.initialState == FormGroupState.Expanded,
-        fieldStates = fieldStates
+        fieldStates = fieldStates,
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseGroupState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseGroupState.kt
@@ -37,7 +37,7 @@ internal class BaseGroupState(
     id = id,
     label = label,
     description = description,
-    isVisible = isVisible,
+    isVisible = isVisible
 ) {
     private val _expanded = mutableStateOf(expanded)
     val expanded: State<Boolean> = _expanded
@@ -61,7 +61,7 @@ internal class BaseGroupState(
                     description = groupElement.description,
                     isVisible = groupElement.isVisible,
                     expanded = it,
-                    fieldStates = fieldStates,
+                    fieldStates = fieldStates
                 )
             }
         )
@@ -83,6 +83,6 @@ internal fun rememberBaseGroupState(
         description = groupElement.description,
         isVisible = groupElement.isVisible,
         expanded = groupElement.initialState == FormGroupState.Expanded,
-        fieldStates = fieldStates,
+        fieldStates = fieldStates
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormElementState.kt
@@ -23,13 +23,15 @@ import kotlinx.coroutines.flow.StateFlow
 /**
  * Base state class for a [FormElement].
  *
+ * @param id Unique identifier for the field.
  * @param label Title for the field.
  * @param description Description text for the field.
  * @param isVisible Property that indicates if the field is visible.
  */
 @Immutable
 internal abstract class FormElementState(
+    val id : Int,
     val label : String,
     val description: String,
-    val isVisible : StateFlow<Boolean>
+    val isVisible : StateFlow<Boolean>,
 )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormElementState.kt
@@ -33,5 +33,5 @@ internal abstract class FormElementState(
     val id : Int,
     val label : String,
     val description: String,
-    val isVisible : StateFlow<Boolean>,
+    val isVisible : StateFlow<Boolean>
 )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
@@ -33,6 +33,15 @@ internal interface FormStateCollection : Iterable<FormStateCollection.Entry> {
      * @return the [FormElementState] associated with the formElement, or null if none.
      */
     operator fun get(formElement: FormElement): FormElementState?
+
+    /**
+     * Provides the bracket operator to the collection.
+     *
+     * @param id the unique identifier [FormElementState.id]
+     * @return the [FormElementState] associated with the id, or null if none.
+     */
+    operator fun get(id: Int): FormElementState?
+
     interface Entry {
         val formElement: FormElement
         val state: FormElementState
@@ -64,7 +73,8 @@ internal interface MutableFormStateCollection : FormStateCollection {
 /**
  * Creates a new [MutableFormStateCollection].
  */
-internal fun MutableFormStateCollection(): MutableFormStateCollection = MutableFormStateCollectionImpl()
+internal fun MutableFormStateCollection(): MutableFormStateCollection =
+    MutableFormStateCollectionImpl()
 
 /**
  * Default implementation for a [MutableFormStateCollection].
@@ -83,6 +93,9 @@ private class MutableFormStateCollectionImpl : MutableFormStateCollection {
 
     override operator fun get(formElement: FormElement): FormElementState? =
         entries.firstOrNull { it.formElement == formElement }?.state
+
+    override fun get(id: Int): FormElementState? =
+        entries.firstOrNull { it.formElement.hashCode() == id }?.state
 
     /**
      * Default implementation for a [FormStateCollection.Entry].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
@@ -47,6 +47,7 @@ internal open class CodedValueFieldProperties(
  * A class to handle the state of any coded value type. Essential properties are inherited
  * from the [BaseFieldState].
  *
+ * @param id Unique identifier for the field.
  * @param properties the [CodedValueFieldProperties] associated with this state.
  * @param initialValue optional initial value to set for this field. It is set to the value of
  * [TextFieldProperties.value] by default.
@@ -57,12 +58,14 @@ internal open class CodedValueFieldProperties(
  * called after a successful [updateValue].
  */
 internal abstract class CodedValueFieldState(
+    id : Int,
     properties: CodedValueFieldProperties,
     initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
 ) : BaseFieldState<Any?>(
+    id = id,
     properties = properties,
     scope = scope,
     initialValue = initialValue,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
@@ -141,7 +141,7 @@ internal fun ComboBoxField(
         interactionSource.interactions.collect {
             if (it is PressInteraction.Release) {
                 if (isEditable) {
-                    dialogRequester.requestDialog(DialogType.ComboBoxDialog(state))
+                    dialogRequester.requestDialog(DialogType.ComboBoxDialog(state.id))
                 }
             }
         }
@@ -366,6 +366,7 @@ private fun ComboBoxPreview() {
             noValueLabel = "No value"
         ),
         scope = scope,
+        id = 1,
         updateValue = {},
         evaluateExpressions = {
             return@ComboBoxFieldState Result.success(emptyList())

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxFieldState.kt
@@ -32,12 +32,13 @@ import kotlinx.coroutines.launch
  * A concrete class for use with a [ComboBoxField].
  */
 internal class ComboBoxFieldState(
+    id : Int,
     properties: CodedValueFieldProperties,
     initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
-) : CodedValueFieldState(properties, initialValue, scope, updateValue, evaluateExpressions) {
+) : CodedValueFieldState(id, properties, initialValue, scope, updateValue, evaluateExpressions) {
 
     companion object {
         /**
@@ -58,6 +59,7 @@ internal class ComboBoxFieldState(
             restore = { list ->
                 val input = formElement.input as ComboBoxFormInput
                 ComboBoxFieldState(
+                    id = formElement.hashCode(),
                     properties = CodedValueFieldProperties(
                         label = formElement.label,
                         placeholder = formElement.hint,
@@ -95,6 +97,7 @@ internal fun rememberComboBoxFieldState(
 ) {
     val input = field.input as ComboBoxFormInput
     ComboBoxFieldState(
+        id = field.hashCode(),
         properties = CodedValueFieldProperties(
             label = field.label,
             placeholder = field.hint,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonFieldState.kt
@@ -30,12 +30,14 @@ import kotlinx.coroutines.CoroutineScope
 internal typealias RadioButtonFieldProperties = CodedValueFieldProperties
 
 internal class RadioButtonFieldState(
+    id : Int,
     properties: RadioButtonFieldProperties,
     initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
 ) : CodedValueFieldState(
+    id,
     properties = properties,
     initialValue = initialValue,
     scope = scope,
@@ -73,6 +75,7 @@ internal class RadioButtonFieldState(
             restore = { list ->
                 val input = formElement.input as RadioButtonsFormInput
                 RadioButtonFieldState(
+                    id = formElement.hashCode(),
                     properties = RadioButtonFieldProperties(
                         label = formElement.label,
                         placeholder = formElement.hint,
@@ -108,6 +111,7 @@ internal fun rememberRadioButtonFieldState(
 ) {
     val input = field.input as RadioButtonsFormInput
     RadioButtonFieldState(
+        id = field.hashCode(),
         properties = RadioButtonFieldProperties(
             label = field.label,
             placeholder = field.hint,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchFieldState.kt
@@ -80,12 +80,14 @@ internal class SwitchFieldProperties(
  */
 @Stable
 internal class SwitchFieldState(
+    id : Int,
     properties: SwitchFieldProperties,
     val initialValue: Any? = properties.value.value,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
 ) : CodedValueFieldState(
+    id = id,
     properties = properties,
     scope = scope,
     initialValue = initialValue,
@@ -123,6 +125,7 @@ internal class SwitchFieldState(
             restore = { list ->
                 val input = formElement.input as SwitchFormInput
                 SwitchFieldState(
+                    id = formElement.hashCode(),
                     properties = SwitchFieldProperties(
                         label = formElement.label,
                         placeholder = formElement.hint,
@@ -167,6 +170,7 @@ internal fun rememberSwitchFieldState(
     val fallback = initialValue.isEmpty()
         || (field.value.value != input.onValue.code && field.value.value != input.offValue.code)
     SwitchFieldState(
+        id = field.hashCode(),
         properties = SwitchFieldProperties(
             label = field.label,
             placeholder = field.hint,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
@@ -97,7 +97,7 @@ internal fun DateTimeField(
                 // request to show the date picker dialog only when the touch is released
                 // the dialog is responsible for updating the value on the state
                 if (isEditable) {
-                    dialogRequester.requestDialog(DialogType.DateTimeDialog(state))
+                    dialogRequester.requestDialog(DialogType.DateTimeDialog(state.id))
                 }
             }
         }
@@ -125,6 +125,7 @@ private fun DateTimeFieldPreview() {
             ),
             scope = scope,
             updateValue = {},
+            id = 1,
             evaluateExpressions = {
                 return@DateTimeFieldState Result.success(emptyList())
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeFieldState.kt
@@ -18,6 +18,7 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.datetime
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
@@ -66,12 +67,14 @@ internal class DateTimeFieldProperties(
  * called after a successful [updateValue].
  */
 internal class DateTimeFieldState(
+    id : Int,
     properties: DateTimeFieldProperties,
     initialValue: Instant? = properties.value.value,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
 ) : BaseFieldState<Instant?>(
+    id = id,
     properties = properties,
     initialValue = initialValue,
     scope = scope,
@@ -85,6 +88,10 @@ internal class DateTimeFieldState(
     val shouldShowTime: Boolean = properties.shouldShowTime
 
     override fun typeConverter(input: Instant?): Any? = input
+
+    init {
+        Log.e("TAG", "id : $label: ${hashCode()}", )
+    }
     
     companion object {
         fun Saver(
@@ -98,6 +105,7 @@ internal class DateTimeFieldState(
             restore = { list ->
                 val input = field.input as DateTimePickerFormInput
                 DateTimeFieldState(
+                    id = field.hashCode(),
                     properties = DateTimeFieldProperties(
                         label = field.label,
                         placeholder = field.hint,
@@ -140,6 +148,7 @@ internal fun rememberDateTimeFieldState(
     )
 ) {
     DateTimeFieldState(
+        id = field.hashCode(),
         properties = DateTimeFieldProperties(
             label = field.label,
             placeholder = field.hint,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeFieldState.kt
@@ -18,7 +18,6 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.datetime
 
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
@@ -31,12 +30,10 @@ import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseFieldSta
 import com.arcgismaps.toolkit.featureforms.internal.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
-import com.arcgismaps.toolkit.featureforms.internal.components.text.FormTextFieldState
-import com.arcgismaps.toolkit.featureforms.internal.components.text.TextFieldProperties
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValueAsStateFlow
+import com.arcgismaps.toolkit.featureforms.internal.components.text.TextFieldProperties
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import java.time.Instant
 
 internal class DateTimeFieldProperties(
@@ -88,10 +85,6 @@ internal class DateTimeFieldState(
     val shouldShowTime: Boolean = properties.shouldShowTime
 
     override fun typeConverter(input: Instant?): Any? = input
-
-    init {
-        Log.e("TAG", "id : $label: ${hashCode()}", )
-    }
     
     companion object {
         fun Saver(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
@@ -68,12 +68,14 @@ internal class TextFieldProperties(
  */
 @Stable
 internal class FormTextFieldState(
+    id : Int,
     properties: TextFieldProperties,
     initialValue: String = properties.value.value,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
 ) : BaseFieldState<String>(
+    id = id,
     properties = properties,
     initialValue = initialValue,
     scope = scope,
@@ -132,6 +134,7 @@ internal class FormTextFieldState(
                 val maxLength = (formElement.input as? TextBoxFormInput)?.maxLength
                     ?: (formElement.input as TextAreaFormInput).maxLength
                 FormTextFieldState(
+                    id = formElement.hashCode(),
                     properties = TextFieldProperties(
                         label = formElement.label,
                         placeholder = formElement.hint,
@@ -172,6 +175,7 @@ internal fun rememberFormTextFieldState(
     saver = FormTextFieldState.Saver(field, form, scope)
 ) {
     FormTextFieldState(
+        id = field.hashCode(),
         properties = TextFieldProperties(
             label = field.label,
             placeholder = field.hint,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
@@ -57,6 +57,7 @@ internal class TextFieldProperties(
  * A class to handle the state of a [FormTextField]. Essential properties are inherited from the
  * [BaseFieldState].
  *
+ * @param id Unique identifier for the field.
  * @param properties the [TextFieldProperties] associated with this state.
  * @param initialValue optional initial value to set for this field. It is set to the value of
  * [TextFieldProperties.value] by default.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -18,7 +18,6 @@ package com.arcgismaps.toolkit.featureforms.internal.utils
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.collectAsState
@@ -187,7 +186,6 @@ internal fun FeatureFormDialog(states : FormStateCollection) {
                 onDismissRequest = { dialogRequester.dismissDialog() },
                 onCancelled = { dialogRequester.dismissDialog() },
                 onConfirmed = {
-                    Log.e("TAG", "FeatureFormDialog: ${state.hashCode()}", )
                     state.onValueChanged(pickerState.selectedDateTimeMillis?.let {
                         Instant.ofEpochMilli(it)
                     })
@@ -198,7 +196,6 @@ internal fun FeatureFormDialog(states : FormStateCollection) {
 
         is DialogType.ImageCaptureDialog -> {
             val stateId = (dialogType as DialogType.ImageCaptureDialog).stateId
-            Log.e("TAG", "FeatureFormDialog: id is $stateId", )
             val contentType = (dialogType as DialogType.ImageCaptureDialog).contentType
             val state = states[stateId]!! as AttachmentElementState
             ImageCapture { uri ->

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -18,20 +18,26 @@ package com.arcgismaps.toolkit.featureforms.internal.utils
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.window.core.layout.WindowSizeClass
 import androidx.window.layout.WindowMetricsCalculator
 import com.arcgismaps.toolkit.featureforms.R
-import com.arcgismaps.toolkit.featureforms.internal.components.attachment.ImagePicker
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentElementState
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.ImageCapture
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.ImagePicker
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.getNewAttachmentNameForContentType
+import com.arcgismaps.toolkit.featureforms.internal.components.base.FormStateCollection
 import com.arcgismaps.toolkit.featureforms.internal.components.codedvalue.CodedValueFieldState
 import com.arcgismaps.toolkit.featureforms.internal.components.codedvalue.ComboBoxDialog
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.DateTimeFieldState
@@ -42,6 +48,7 @@ import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.r
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import java.time.Instant
 
 /**
@@ -87,16 +94,19 @@ internal sealed class DialogType {
      *
      * @param state The [CodedValueFieldState] to use for the dialog.
      */
-    data class ComboBoxDialog(val state: CodedValueFieldState) : DialogType()
+    data class ComboBoxDialog(val stateId: Int) : DialogType()
 
     /**
      * Indicates a [DateTimePicker].
      *
      * @param state The [DateTimeFieldState] to use for the dialog.
      */
-    data class DateTimeDialog(val state: DateTimeFieldState) : DialogType()
+    data class DateTimeDialog(val stateId : Int) : DialogType()
 
-    data class ImageCaptureDialog(val onImage: (Uri) -> Unit) : DialogType()
+    data class ImageCaptureDialog(
+        val stateId : Int,
+        val contentType : String
+    ) : DialogType()
 
     data class ImagePickerDialog(
         val onSelection: (Uri) -> Unit
@@ -107,13 +117,16 @@ internal sealed class DialogType {
  * Shows the appropriate dialogs as requested by the [LocalDialogRequester].
  */
 @Composable
-internal fun FeatureFormDialog() {
+internal fun FeatureFormDialog(states : FormStateCollection) {
     val focusManager = LocalFocusManager.current
     val dialogRequester = LocalDialogRequester.current
     val dialogType by dialogRequester.requestFlow.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     when (dialogType) {
         is DialogType.ComboBoxDialog -> {
-            val state = (dialogType as DialogType.ComboBoxDialog).state
+            val stateId = (dialogType as DialogType.ComboBoxDialog).stateId
+            val state = states[stateId]!! as CodedValueFieldState
             ComboBoxDialog(
                 initialValue = state.value.value.data,
                 values = state.codedValues.associateBy({ it.code }, { it.name }),
@@ -135,7 +148,8 @@ internal fun FeatureFormDialog() {
         }
 
         is DialogType.DateTimeDialog -> {
-            val state = (dialogType as DialogType.DateTimeDialog).state
+            val stateId = (dialogType as DialogType.DateTimeDialog).stateId
+            val state = states[stateId]!! as DateTimeFieldState
             val shouldShowTime = remember {
                 state.shouldShowTime
             }
@@ -160,6 +174,7 @@ internal fun FeatureFormDialog() {
                 onDismissRequest = { dialogRequester.dismissDialog() },
                 onCancelled = { dialogRequester.dismissDialog() },
                 onConfirmed = {
+                    Log.e("TAG", "FeatureFormDialog: ${state.hashCode()}", )
                     state.onValueChanged(pickerState.selectedDateTimeMillis?.let {
                         Instant.ofEpochMilli(it)
                     })
@@ -169,10 +184,20 @@ internal fun FeatureFormDialog() {
         }
 
         is DialogType.ImageCaptureDialog -> {
-            val onImage = (dialogType as DialogType.ImageCaptureDialog).onImage
-            ImageCapture {
-                onImage(it)
-                dialogRequester.dismissDialog()
+            val stateId = (dialogType as DialogType.ImageCaptureDialog).stateId
+            Log.e("TAG", "FeatureFormDialog: id is $stateId", )
+            val contentType = (dialogType as DialogType.ImageCaptureDialog).contentType
+            val state = states[stateId]!! as AttachmentElementState
+            ImageCapture { uri ->
+                scope.launch {
+                    context.readBytes(uri)?.let { data ->
+                        val name = state.attachments.getNewAttachmentNameForContentType(
+                            contentType
+                        )
+                        state.addAttachment(name, contentType, data)
+                    }
+                    dialogRequester.dismissDialog()
+                }
             }
         }
 
@@ -192,6 +217,9 @@ internal fun FeatureFormDialog() {
         }
     }
 }
+
+internal fun Context.readBytes(uri: Uri): ByteArray? =
+    contentResolver.openInputStream(uri)?.use { it.buffered().readBytes() }
 
 /**
  * Computes the [WindowSizeClass] of the device.


### PR DESCRIPTION
### Summary of changes

- `DialogRequester` saves the references to the states that it is passed when a field requests a dialog. In case of a configuration change, new states are created but the `DialogRequester` is still referencing the old state.
- This PR fixes this issue by making the `DialogRequester` accept a `stateId` instead of the state object. This `stateId` can then be used to fetch the actual state from the `FormStateCollection`.
- The `stateId` mechanism is relying in the `FormElement.hashCode()` implementation which ensures that even after an orientation change the `hashCode()` will not change because the underlying core object is the same.