### PR TITLE
Add offset and rotate offset

### DIFF
--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/MainScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/MainScreen.kt
@@ -70,8 +70,8 @@ fun MainScreen(viewModel: MapViewModel) {
         },
         content = if (mapPoint != null) {
             {
-//                Callout(location = mapPoint, offset = DoubleXY(200.0, 0.0), rotateOffsetWithGeoView = true){
-                Callout(location = mapPoint, offset = DpOffset(200.0D, 0.0), rotateOffsetWithGeoView = true){
+                Callout(location = mapPoint, offset = DoubleXY(200.0, 0.0), rotateOffsetWithGeoView = true){
+//                Callout(location = mapPoint, offset = DpOffset(200.0, 0.0), rotateOffsetWithGeoView = true){
                     Text(
                         "Hello, World!",
                         color = Color.Green

--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/MainScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/MainScreen.kt
@@ -22,56 +22,23 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.DpOffset
 import com.arcgismaps.toolkit.geoviewcompose.Callout
 import com.arcgismaps.toolkit.geoviewcompose.MapView
-import com.arcgismaps.mapping.view.DoubleXY
-import com.arcgismaps.mapping.view.Graphic
-import com.arcgismaps.mapping.view.GraphicsOverlay
-import com.arcgismaps.mapping.symbology.SimpleMarkerSymbol
-import com.arcgismaps.mapping.symbology.SimpleMarkerSymbolStyle
 
 @Composable
 fun MainScreen(viewModel: MapViewModel) {
-
-    val graphicsOverlay = GraphicsOverlay()
-    val graphicsOverlays by remember {
-        mutableStateOf(
-            listOf(
-                graphicsOverlay
-            )
-        )
-    }
 
     val mapPoint = viewModel.mapPoint.collectAsState().value
 
     MapView(
         modifier = Modifier.fillMaxSize(),
         arcGISMap = viewModel.arcGISMap,
-        graphicsOverlays = graphicsOverlays,
-        onSingleTapConfirmed = {
-            graphicsOverlay.graphics.clear()
-            viewModel.setMapPoint(it)
-            val simpleGraphic =
-                Graphic(
-                    it.mapPoint,
-//                    mapPoint,
-                    SimpleMarkerSymbol(
-                        style = SimpleMarkerSymbolStyle.Circle,
-                        color = com.arcgismaps.Color.black
-                    )
-                )
-            graphicsOverlay.graphics.add(simpleGraphic)
-        },
+        onSingleTapConfirmed = viewModel::setMapPoint,
         content = if (mapPoint != null) {
             {
-                Callout(location = mapPoint, offset = DoubleXY(200.0, 0.0), rotateOffsetWithGeoView = true){
-//                Callout(location = mapPoint, offset = DpOffset(200.0, 0.0), rotateOffsetWithGeoView = true){
+                Callout(location = mapPoint) {
                     Text(
                         "Hello, World!",
                         color = Color.Green

--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/MainScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/MainScreen.kt
@@ -22,23 +22,56 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import com.arcgismaps.toolkit.geoviewcompose.Callout
 import com.arcgismaps.toolkit.geoviewcompose.MapView
+import com.arcgismaps.mapping.view.DoubleXY
+import com.arcgismaps.mapping.view.Graphic
+import com.arcgismaps.mapping.view.GraphicsOverlay
+import com.arcgismaps.mapping.symbology.SimpleMarkerSymbol
+import com.arcgismaps.mapping.symbology.SimpleMarkerSymbolStyle
 
 @Composable
 fun MainScreen(viewModel: MapViewModel) {
+
+    val graphicsOverlay = GraphicsOverlay()
+    val graphicsOverlays by remember {
+        mutableStateOf(
+            listOf(
+                graphicsOverlay
+            )
+        )
+    }
 
     val mapPoint = viewModel.mapPoint.collectAsState().value
 
     MapView(
         modifier = Modifier.fillMaxSize(),
         arcGISMap = viewModel.arcGISMap,
-        onSingleTapConfirmed = viewModel::setMapPoint,
+        graphicsOverlays = graphicsOverlays,
+        onSingleTapConfirmed = {
+            graphicsOverlay.graphics.clear()
+            viewModel.setMapPoint(it)
+            val simpleGraphic =
+                Graphic(
+                    it.mapPoint,
+//                    mapPoint,
+                    SimpleMarkerSymbol(
+                        style = SimpleMarkerSymbolStyle.Circle,
+                        color = com.arcgismaps.Color.black
+                    )
+                )
+            graphicsOverlay.graphics.add(simpleGraphic)
+        },
         content = if (mapPoint != null) {
             {
-                Callout(location = mapPoint) {
+//                Callout(location = mapPoint, offset = DoubleXY(200.0, 0.0), rotateOffsetWithGeoView = true){
+                Callout(location = mapPoint, offset = DpOffset(200.0D, 0.0), rotateOffsetWithGeoView = true){
                     Text(
                         "Hello, World!",
                         color = Color.Green

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
@@ -17,6 +17,7 @@
 
 package com.arcgismaps.toolkit.geoviewcompose
 
+import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -31,9 +32,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.LoadStatus
+import com.arcgismaps.geometry.AngularUnit
 import com.arcgismaps.geometry.Point
+import com.arcgismaps.mapping.ViewpointType
+import com.arcgismaps.mapping.view.DoubleXY
+import com.arcgismaps.mapping.view.GeoView
 import com.arcgismaps.mapping.view.MapView
+import com.arcgismaps.mapping.view.SceneLocationVisibility
+import com.arcgismaps.mapping.view.SceneView
 import com.arcgismaps.mapping.view.ScreenCoordinate
+import com.arcgismaps.mapping.view.zero
+import kotlin.math.cos
+import kotlin.math.sin
 
 /**
  * The receiver class of the MapView content lambda.
@@ -57,25 +67,118 @@ public class MapViewScope(internal val mapView: MapView)
 @Composable
 public fun MapViewScope.Callout(location: Point,
                                 modifier: Modifier = Modifier,
+                                offset: DoubleXY = DoubleXY.zero,
+//                                offset: DpOffset = DpOffset(0.dp, 0.dp),
+                                rotateOffsetWithGeoView: Boolean = false,
                                 content: @Composable BoxScope.() -> Unit) {
 
     if (mapView.map?.loadStatus?.collectAsState()?.value == LoadStatus.Loaded) {
-        val calloutScreenCoordinate: ScreenCoordinate = mapView.locationToScreen(location)
-        Box(
-            modifier = Modifier
-                .graphicsLayer {
-                    translationX = calloutScreenCoordinate.x.toFloat()
-                    translationY = calloutScreenCoordinate.y.toFloat()
-                }
-                .wrapContentSize()
-                .background(Color.White)
-                .border(
-                    border = BorderStroke(2.dp, Color.LightGray),
-                    shape = MaterialTheme.shapes.medium
-                )
+
+//        val mapViewRotation = mapView.mapRotation.collectAsState().value
+//        Log.d("***Callout test", "mapViewRotation: $mapViewRotation")
+
+        val leaderLocation = getLeaderScreenCoordinate(
+            mapView,
+            location,
+            offset,
+            rotateOffsetWithGeoView,
+//            mapViewRotation
         )
-        {
-            this.content()
+        Log.d("***Callout test", "leaderLocation: $leaderLocation")
+//        val calloutScreenCoordinate: ScreenCoordinate = mapView.locationToScreen(location)
+        leaderLocation?.let {
+            Box(
+                modifier = Modifier
+                    .graphicsLayer {
+                        translationX = leaderLocation.x.toFloat()
+                        translationY = leaderLocation.y.toFloat()
+                    }
+                    .wrapContentSize()
+                    .background(Color.White)
+                    .border(
+                        border = BorderStroke(2.dp, Color.LightGray),
+                        shape = MaterialTheme.shapes.medium
+                    )
+            )
+            {
+                this.content()
+            }
         }
     }
+}
+
+
+    /**
+     * Returns the ScreenCoordinate for the location [Point] on [GeoView].
+     *
+     * @param geoView the GeoView
+     * @return A [ScreenCoordinate] for the screen in pixels or null if the location is not visible
+     * @since 200.2.0
+     */
+    private fun getLeaderScreenCoordinate(
+        geoView: GeoView,
+        location: Point,
+        offset: DoubleXY = DoubleXY.zero,
+        rotateOffsetWithGeoView: Boolean = false,
+//        geoViewRotation: Double = 0.0
+    ): ScreenCoordinate? {
+        val geoViewRotation = geoView.rotation()
+        val locationToScreen = if (geoView is MapView) {
+             geoView.locationToScreen(location)
+        } else {
+            // geoView is a SceneView
+            val locationToScreenResult = (geoView as SceneView).locationToScreen(location)
+            if (locationToScreenResult?.visibility == SceneLocationVisibility.Visible) {
+                return locationToScreenResult.screenPoint
+            }
+            null
+        }
+        return locationToScreen?.let { screenCoordinate ->
+            if (rotateOffsetWithGeoView && geoViewRotation != 0.0) {
+                val angle = AngularUnit.degrees.convertTo(AngularUnit.radians, -geoViewRotation)
+                screenCoordinate.offset(offset).rotate(angle, screenCoordinate)
+            } else {
+                screenCoordinate.offset(offset)
+            }
+        }
+    }
+
+private fun GeoView.rotation(): Double {
+    return if (this is SceneView) {
+        getCurrentViewpoint(ViewpointType.CenterAndScale)?.rotation ?: 0.0
+    } else {
+        val mapViewRotation = (this as MapView).mapRotation.value
+        Log.d("***Callout test", "mapViewRotation: $mapViewRotation")
+        mapViewRotation
+//        (this as MapView).mapRotation.value
+    }
+}
+
+/**
+ * Returns a [DoubleXY] which is the result of offsetting this [DoubleXY] by the specified value.
+ *
+ * @param offset the offset to he applied
+ * @return the new [DoubleXY] offset point
+ * @since 200.2.0
+ */
+private fun DoubleXY.offset(offset: DoubleXY): DoubleXY {
+    return this + offset
+}
+
+/**
+ * Returns a [DoubleXY] which is the result of rotating this [DoubleXY] by an angle around a center.
+ *
+ * @param rotateByAngle angle in Radians where a positive value is counter clockwise
+ * @param center the center around which the resulting point will be rotated
+ * @return the resulting [DoubleXY] that has been rotated
+ * @since 200.2.0
+ */
+private fun DoubleXY.rotate(rotateByAngle: Double, center: DoubleXY = DoubleXY.zero): DoubleXY {
+    val x1 = x - center.x
+    val y1 = y - center.y
+
+    val x2 = x1 * cos(rotateByAngle) - y1 * sin(rotateByAngle)
+    val y2 = x1 * sin(rotateByAngle) + y1 * cos(rotateByAngle)
+
+    return DoubleXY(x2 + center.x, y2 + center.y)
 }

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
@@ -124,15 +124,15 @@ private fun getLeaderScreenCoordinate(
     rotateOffsetWithGeoView: Boolean
 ): ScreenCoordinate? {
     val geoViewRotation = geoView.rotation()
-    val locationToScreen = if (geoView is MapView) {
-        geoView.locationToScreen(location)
-    } else {
-        // geoView is a SceneView
-        val locationToScreenResult = (geoView as SceneView).locationToScreen(location)
-        if (locationToScreenResult?.visibility == SceneLocationVisibility.Visible) {
-            return locationToScreenResult.screenPoint
+    val locationToScreen = when (geoView) {
+        is MapView -> geoView.locationToScreen(location)
+        is SceneView -> {
+            val locationToScreenResult = geoView.locationToScreen(location)
+            if (locationToScreenResult?.visibility == SceneLocationVisibility.Visible) {
+                locationToScreenResult.screenPoint
+            }
+            null
         }
-        null
     }
     return locationToScreen?.let { screenCoordinate ->
         if (rotateOffsetWithGeoView && geoViewRotation != 0.0) {
@@ -144,12 +144,9 @@ private fun getLeaderScreenCoordinate(
     }
 }
 
-private fun GeoView.rotation(): Double {
-    return if (this is SceneView) {
-        getCurrentViewpoint(ViewpointType.CenterAndScale)?.rotation ?: 0.0
-    } else {
-        (this as MapView).mapRotation.value
-    }
+private fun GeoView.rotation(): Double = when (this) {
+    is SceneView -> getCurrentViewpoint(ViewpointType.CenterAndScale)?.rotation ?: 0.0
+    is MapView -> mapRotation.value
 }
 
 /**


### PR DESCRIPTION
- Add support for offset and rotate offset to Callout()
```Kotlin
public fun MapViewScope.Callout(
    location: Point,
    modifier: Modifier = Modifier,
    offset: Offset = Offset.Zero,
    rotateOffsetWithGeoView: Boolean = false,
    content: @Composable BoxScope.() -> Unit
) {
 ```   