### PR TITLE
Configure aggregated local tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Please see the [package structure](doc/general/developer_setup.md#package-struct
 
 ### Testing
 
-In order to run *local* tests of all modules and get an aggregated test report, run the following at the root folder of the project:
+In order to run *local* (non-instrumented) tests of all modules and get an aggregated test report, run the following at the root folder of the project:
 ```
 ./gradlew testAggregatedReport
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ The template and TemplateApp modules are for bootstrapping new modules.
 
 Please see the [package structure](doc/general/developer_setup.md#package-structure) documentation for more details.
 
+### Testing
+
+In order to run *local* tests of all modules and get an aggregated test report, run the following at the root folder of the project:
+```
+./gradlew testAggregatedReport
+```
+The test report for local tests can be located under `arcgis-maps-sdk-kotlin-toolkit/build/reports`.
+
 ## Licensing
 
 Copyright 2019-2022 Esri

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+
 /*
  *
  *  Copyright 2023 Esri
@@ -27,6 +28,7 @@ plugins {
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.gmazzo.test.aggregation)
 }
 
 buildscript {
@@ -38,3 +40,38 @@ buildscript {
         classpath(libs.dokka.versioning)
     }
 }
+
+/**
+ * Configures the [gmazzo test aggregation plugin](https://github.com/gmazzo/gradle-android-test-aggregation-plugin)
+ * with all local tests to be aggregated into a single test report.
+ * Note: This works only for local tests, not for connected tests.
+ * To run aggregated local tests:
+ * ```
+ * ./gradlew testAggregatedReport
+ * ```
+ * Test report to be found under `arcgis-maps-sdk-kotlin-toolkit/build/reports`.
+ */
+testAggregation {
+    getModules(
+        "bom",
+        "kdoc",
+        "microapps-lib",
+        "template",
+        "template-app",
+        "composable-map").forEach {
+        this.modules.include(project(":$it"))
+    }
+}
+
+/**
+ * Returns all modules in this project, except the ones specified by [modulesToExclude].
+ */
+fun getModules(vararg modulesToExclude: String): List<String> =
+    with(File("$rootDir/settings.gradle.kts")) {
+        readLines()
+            .filter { it.startsWith("include") }
+            .map {
+                it.removePrefix("include(\":").removeSuffix("\")")
+            }
+            .filter { !modulesToExclude.contains(it) } // exclude specified modules
+    }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-
 /*
  *
  *  Copyright 2023 Esri

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ buildscript {
  * Test report to be found under `arcgis-maps-sdk-kotlin-toolkit/build/reports`.
  */
 testAggregation {
-    getModules(
+    getModulesExcept(
         "bom",
         "kdoc",
         "microapps-lib",
@@ -65,7 +65,7 @@ testAggregation {
 /**
  * Returns all modules in this project, except the ones specified by [modulesToExclude].
  */
-fun getModules(vararg modulesToExclude: String): List<String> =
+fun getModulesExcept(vararg modulesToExclude: String): List<String> =
     with(File("$rootDir/settings.gradle.kts")) {
         readLines()
             .filter { it.startsWith("include") }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ buildscript {
  * Configures the [gmazzo test aggregation plugin](https://github.com/gmazzo/gradle-android-test-aggregation-plugin)
  * with all local tests to be aggregated into a single test report.
  * Note: This works only for local tests, not for connected tests.
- * To run aggregated local tests:
+ * To run aggregated local tests, run the following at the root folder of the project:
  * ```
  * ./gradlew testAggregatedReport
  * ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,6 +81,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 gradle-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version = "2.0.1"}
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+gmazzo-test-aggregation = { id = "io.github.gmazzo.test.aggregation.results", version = "2.2.0" }
 
 [bundles]
 core = [


### PR DESCRIPTION
issue: https://devtopia.esri.com/runtime/kotlin/issues/3991

### Description

Applies and configures the [gmazzo test aggregation plugin](https://github.com/gmazzo/gradle-android-test-aggregation-plugin) to get an aggregated test report of all the local tests in all the modules of this project.

Note:
- This plugin does not work for Android connected tests. For connected tests there will be a follow up PR that handles test reports of connected tests differently.
- I tried to use Gradle's [Test Report Aggregation Plugin](https://docs.gradle.org/current/userguide/test_report_aggregation_plugin.html), but it doesn't work in combination with the Android Gradle Plugin :(
- Some modules such as `bom`, `kdoc` etc have been excluded from test aggregation.
- To run aggregated local tests:
```
./gradlew testAggregatedReport
```
Test report will be in `arcgis-maps-sdk-kotlin-toolkit/build/reports`.