### PR TITLE
Fix for the rotation bug

### DIFF
--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,13 +34,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
-import com.arcgismaps.LoadStatus
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.mapping.view.DrawStatus
 import com.arcgismaps.mapping.view.MapView
 import com.arcgismaps.mapping.view.ScreenCoordinate
 import kotlinx.coroutines.flow.transformWhile
-import kotlinx.coroutines.launch
 
 /**
  * The receiver class of the MapView content lambda.

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
@@ -252,9 +252,7 @@ public fun MapView(
     )
 
     val mapViewScope = remember(mapView) { MapViewScope(mapView) }
-    if (content != null) {
-        mapViewScope.content()
-    }
+    content?.let { mapViewScope.it() }
 }
 
 /**

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
@@ -17,13 +17,11 @@
 
 package com.arcgismaps.toolkit.geoviewcompose
 
-import android.util.Log
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -171,7 +169,6 @@ public fun MapView(
     val context = LocalContext.current
     val mapView = remember { MapView(context) }
     val layoutDirection = LocalLayoutDirection.current
-    Log.d("MapView****", "MapView content: $content")
 
     AndroidView(
         modifier = modifier.semantics { contentDescription = "MapView" },

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
@@ -17,6 +17,7 @@
 
 package com.arcgismaps.toolkit.geoviewcompose
 
+import android.util.Log
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -170,7 +171,7 @@ public fun MapView(
     val context = LocalContext.current
     val mapView = remember { MapView(context) }
     val layoutDirection = LocalLayoutDirection.current
-    var refreshCalloutPosition by rememberSaveable { mutableStateOf(false) }
+    Log.d("MapView****", "MapView content: $content")
 
     AndroidView(
         modifier = modifier.semantics { contentDescription = "MapView" },
@@ -194,19 +195,6 @@ public fun MapView(
                 }
             }
         })
-
-    LaunchedEffect(Unit) {
-        mapView.viewpointChanged.collect {
-            refreshCalloutPosition = !refreshCalloutPosition
-        }
-    }
-
-    val mapViewScope = remember(mapView) { MapViewScope(mapView) }
-    if (content != null) {
-        key(refreshCalloutPosition, content) {
-            mapViewScope.content()
-        }
-    }
 
     DisposableEffect(Unit) {
         lifecycleOwner.lifecycle.addObserver(mapView)
@@ -265,6 +253,11 @@ public fun MapView(
         onViewpointChangedForBoundingGeometry = onViewpointChangedForBoundingGeometry,
         onVisibleAreaChanged = onVisibleAreaChanged
     )
+
+    val mapViewScope = remember(mapView) { MapViewScope(mapView) }
+    if (content != null) {
+        mapViewScope.content()
+    }
 }
 
 /**


### PR DESCRIPTION
- Add logic to only initialize the Callout when the MapView is done with initial draw
- Move the onViewPointChanged listener from MapView to Callout to prevent unnecessary MapView recompositions.
- Move invocation of the Content lambda after all the MapViewEventHandlers and ViewPointHandlers are set