### PR TITLE
Configure connected tests to be output to a centralized location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .externalNativeBuild
 build/
 
+# test artifacts
+connectedTestReports/
+
 # Local configuration file (sdk path, etc)
 /local.properties
 .gradle

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The test report for local tests can be located under `arcgis-maps-sdk-kotlin-too
 
 In order to run *connected* (instrumented) tests of all modules and get the test reports in a centralized folder, run the following at the root folder of the project:
 ```
-./gradlew testAggregatedReport --continue
+./gradlew connectedDebugAndroidTest --continue
 ```
 The test reports for connected tests can be located under `arcgis-maps-sdk-kotlin-toolkit/connectedTestReports`.
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,21 @@ Please see the [package structure](doc/general/developer_setup.md#package-struct
 
 ### Testing
 
+#### Running Local Tests
+
 In order to run *local* (non-instrumented) tests of all modules and get an aggregated test report, run the following at the root folder of the project:
 ```
 ./gradlew testAggregatedReport --continue
 ```
 The test report for local tests can be located under `arcgis-maps-sdk-kotlin-toolkit/build/reports`.
+
+#### Running Connected Tests
+
+In order to run *connected* (instrumented) tests of all modules and get the test reports in a centralized folder, run the following at the root folder of the project:
+```
+./gradlew testAggregatedReport --continue
+```
+The test reports for connected tests can be located under `arcgis-maps-sdk-kotlin-toolkit/connectedTestReports`.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Please see the [package structure](doc/general/developer_setup.md#package-struct
 
 In order to run *local* (non-instrumented) tests of all modules and get an aggregated test report, run the following at the root folder of the project:
 ```
-./gradlew testAggregatedReport
+./gradlew testAggregatedReport --continue
 ```
 The test report for local tests can be located under `arcgis-maps-sdk-kotlin-toolkit/build/reports`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,9 @@ buildscript {
     }
 }
 
+// Path to the centralized folder in root directory where test reports for connected tests end up
+val connectedTestReportsPath by extra("${rootDir}/connectedTestReports")
+
 /**
  * Configures the [gmazzo test aggregation plugin](https://github.com/gmazzo/gradle-android-test-aggregation-plugin)
  * with all local tests to be aggregated into a single test report.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ buildscript {
  * Note: This works only for local tests, not for connected tests.
  * To run aggregated local tests, run the following at the root folder of the project:
  * ```
- * ./gradlew testAggregatedReport
+ * ./gradlew testAggregatedReport --continue
  * ```
  * Test report to be found under `arcgis-maps-sdk-kotlin-toolkit/build/reports`.
  */

--- a/microapps/AuthenticationApp/app/build.gradle.kts
+++ b/microapps/AuthenticationApp/app/build.gradle.kts
@@ -72,6 +72,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 dependencies {

--- a/microapps/AuthenticationApp/app/build.gradle.kts
+++ b/microapps/AuthenticationApp/app/build.gradle.kts
@@ -78,7 +78,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/CompassApp/app/build.gradle.kts
+++ b/microapps/CompassApp/app/build.gradle.kts
@@ -70,6 +70,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 //https://youtrack.jetbrains.com/issue/KTIJ-21063

--- a/microapps/CompassApp/app/build.gradle.kts
+++ b/microapps/CompassApp/app/build.gradle.kts
@@ -76,7 +76,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -70,6 +70,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 //https://youtrack.jetbrains.com/issue/KTIJ-21063

--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -76,7 +76,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/FloorFilterApp/app/build.gradle.kts
+++ b/microapps/FloorFilterApp/app/build.gradle.kts
@@ -59,7 +59,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/FloorFilterApp/app/build.gradle.kts
+++ b/microapps/FloorFilterApp/app/build.gradle.kts
@@ -53,6 +53,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/MapViewGeometryEditorApp/app/build.gradle.kts
+++ b/microapps/MapViewGeometryEditorApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/MapViewGeometryEditorApp/app/build.gradle.kts
+++ b/microapps/MapViewGeometryEditorApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/MapViewIdentifyApp/app/build.gradle.kts
+++ b/microapps/MapViewIdentifyApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/MapViewIdentifyApp/app/build.gradle.kts
+++ b/microapps/MapViewIdentifyApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/MapViewInsetsApp/app/build.gradle.kts
+++ b/microapps/MapViewInsetsApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/MapViewInsetsApp/app/build.gradle.kts
+++ b/microapps/MapViewInsetsApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/MapViewLocationDisplayApp/app/build.gradle.kts
+++ b/microapps/MapViewLocationDisplayApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/MapViewLocationDisplayApp/app/build.gradle.kts
+++ b/microapps/MapViewLocationDisplayApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/MapViewSetViewpointApp/app/build.gradle.kts
+++ b/microapps/MapViewSetViewpointApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/MapViewSetViewpointApp/app/build.gradle.kts
+++ b/microapps/MapViewSetViewpointApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/SceneViewAnalysisOverlayApp/app/build.gradle.kts
+++ b/microapps/SceneViewAnalysisOverlayApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/SceneViewAnalysisOverlayApp/app/build.gradle.kts
+++ b/microapps/SceneViewAnalysisOverlayApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/SceneViewCameraControllerApp/app/build.gradle.kts
+++ b/microapps/SceneViewCameraControllerApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/SceneViewCameraControllerApp/app/build.gradle.kts
+++ b/microapps/SceneViewCameraControllerApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/SceneViewLightingOptionsApp/app/build.gradle.kts
+++ b/microapps/SceneViewLightingOptionsApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/SceneViewLightingOptionsApp/app/build.gradle.kts
+++ b/microapps/SceneViewLightingOptionsApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/SceneViewSetViewpointApp/app/build.gradle.kts
+++ b/microapps/SceneViewSetViewpointApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/SceneViewSetViewpointApp/app/build.gradle.kts
+++ b/microapps/SceneViewSetViewpointApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/microapps/TemplateApp/app/build.gradle.kts
+++ b/microapps/TemplateApp/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/microapps/TemplateApp/app/build.gradle.kts
+++ b/microapps/TemplateApp/app/build.gradle.kts
@@ -71,6 +71,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 // context receivers are not experimental anymore, but AS thinks they are.

--- a/toolkit/authentication/build.gradle.kts
+++ b/toolkit/authentication/build.gradle.kts
@@ -60,6 +60,14 @@ android {
             kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 dependencies {

--- a/toolkit/authentication/build.gradle.kts
+++ b/toolkit/authentication/build.gradle.kts
@@ -66,7 +66,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/toolkit/compass/build.gradle.kts
+++ b/toolkit/compass/build.gradle.kts
@@ -60,6 +60,14 @@ android {
             kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 dependencies {

--- a/toolkit/compass/build.gradle.kts
+++ b/toolkit/compass/build.gradle.kts
@@ -66,7 +66,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -73,7 +73,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -67,6 +67,14 @@ android {
             kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 apiValidation {

--- a/toolkit/geoview-compose/build.gradle.kts
+++ b/toolkit/geoview-compose/build.gradle.kts
@@ -60,6 +60,14 @@ android {
             kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 dependencies {

--- a/toolkit/geoview-compose/build.gradle.kts
+++ b/toolkit/geoview-compose/build.gradle.kts
@@ -66,7 +66,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/toolkit/indoors/build.gradle.kts
+++ b/toolkit/indoors/build.gradle.kts
@@ -48,7 +48,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/toolkit/indoors/build.gradle.kts
+++ b/toolkit/indoors/build.gradle.kts
@@ -42,6 +42,14 @@ android {
             kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 dependencies {

--- a/toolkit/template/build.gradle.kts
+++ b/toolkit/template/build.gradle.kts
@@ -65,7 +65,8 @@ android {
      * folder in the project's root directory.
      */
     testOptions {
-        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+        val connectedTestReportsPath: String by project
+        reportDir = "$connectedTestReportsPath/${project.name}"
     }
 }
 

--- a/toolkit/template/build.gradle.kts
+++ b/toolkit/template/build.gradle.kts
@@ -59,6 +59,14 @@ android {
             kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
         }
     }
+
+    /**
+     * Configures the test report for connected (instrumented) tests to be copied to a central
+     * folder in the project's root directory.
+     */
+    testOptions {
+        reportDir = "${rootDir}/connectedTestReports/${project.name}"
+    }
 }
 
 dependencies {

--- a/toolkit/template/src/androidTest/java/com/arcgismaps/toolkit/template/ExampleInstrumentedTest.kt
+++ b/toolkit/template/src/androidTest/java/com/arcgismaps/toolkit/template/ExampleInstrumentedTest.kt
@@ -35,6 +35,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.arcgismaps.toolkit.authentication.test", appContext.packageName)
+        assertEquals("com.arcgismaps.toolkit.template.test", appContext.packageName)
     }
 }


### PR DESCRIPTION
issue: https://devtopia.esri.com/runtime/kotlin/issues/3992

### Description:

For local tests we have a way to aggregate the test reports of all modules into a single test report, see [this PR](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/pull/427). However, for connected tests this currently doesn't seem to be supported through the AGP. So instead of aggregating into a single test report, we are going to copy the connected test reports of all modules into a centralized location. Our CI framework will then link to that centralized folder and test reports will need to be inspected individually. This is somewhat a compromise but still better than trying to hack Gradle to get an aggregated report. Hopefully Google will provide support for test report aggregation through the AGP at some point. Watch [this google issue](https://issuetracker.google.com/issues/222730176?pli=1) for any updates.

With these changes, connected test reports can be run by:
```
./gradlew connectedDebugAndroidTest --continue
```
Test reports will appear in the root folder as follows:
```
- arcgis-maps-sdk-kotlin-toolkit
   |- connectedTestReports
      |- authentication
      |- authentication-app
      |- compass
      |- compass-app
      |- ...
```

Details:
- Added a `testOptions` configuration to all modules that configures the output location of connected test reports, including micro apps. 
- Also added the `testOptions` configuration to the `template` and `templateApp` modules, so that new modules being added are automatically configured.