### PR TITLE
Test scripts for CI

### DIFF
--- a/ci/test/build.sh
+++ b/ci/test/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+cd ${runtime_path}/arcgis-maps-sdk-kotlin-toolkit
+function _build() {
+  _log "Run the gradle assembleRelease task to pre-build the Kotlin Toolkit"
+  if ! ./gradlew assembleRelease; then
+    echo "error: Running the assembleRelease gradle task failed"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------
+# start script
+# ---------------------------------------------
+
+_build

--- a/ci/test/build.sh
+++ b/ci/test/build.sh
@@ -3,8 +3,6 @@
 source $(dirname ${BASH_SOURCE})/../common.sh
 
 cd ${apps_path}/arcgis-maps-sdk-kotlin-toolkit
-echo "$(pwd)"
-echo ${apps_path}
 function _build() {
   _log "Run the gradle assembleRelease task to pre-build the Kotlin Toolkit"
   # This is useful because if gradle returns a non-zero exit code it means we are not even able to build the API. In that

--- a/ci/test/build.sh
+++ b/ci/test/build.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-cd ${runtime_path}/arcgis-maps-sdk-kotlin-toolkit
+source $(dirname ${BASH_SOURCE})/../common.sh
+
+cd ${apps_path}/arcgis-maps-sdk-kotlin-toolkit
+echo "$(pwd)"
+echo ${apps_path}
 function _build() {
   _log "Run the gradle assembleRelease task to pre-build the Kotlin Toolkit"
   if ! ./gradlew assembleRelease; then

--- a/ci/test/build.sh
+++ b/ci/test/build.sh
@@ -7,6 +7,9 @@ echo "$(pwd)"
 echo ${apps_path}
 function _build() {
   _log "Run the gradle assembleRelease task to pre-build the Kotlin Toolkit"
+  # This is useful because if gradle returns a non-zero exit code it means we are not even able to build the API. In that
+  # case, we can fail the test job without having to pull the test data (which could potentially take a long time).
+  # See https://devtopia.esri.com/runtime/kotlin/pull/775#discussion_r801362
   if ! ./gradlew assembleRelease; then
     echo "error: Running the assembleRelease gradle task failed"
     exit 1

--- a/ci/test/common_test.sh
+++ b/ci/test/common_test.sh
@@ -21,7 +21,7 @@ function _reboot_device() {
   _log "Restarting test device"
   ${adb} reboot
 
-  # wait-for-any-device typically doesn't wait long eough for the device to be truly
+  # wait-for-any-device typically doesn't wait long enough for the device to be truly
   # ready e.g. to be able to delete files from the sdcard with `adb shell rm`.
   ${adb} wait-for-any-device
 

--- a/ci/test/common_test.sh
+++ b/ci/test/common_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Contains common variables and helper functions used by the jenkins scripts for Kotlin Toolkit
+
+# global constants
+adb="${HOME}/Library/Android/Sdk/platform-tools/adb"
+archive_folder_root="/net/apps-data.esri.com/data/api/kotlin"
+
+# global variables
+integration_reports_path="${runtime_path}/arcgis-maps-sdk-kotlin-toolkit/connectedTestReports"
+unit_reports_path="${runtime_path}/arcgis-maps-sdk-kotlin-toolkit/build/reports/tests/unit-test/aggregated-results"
+
+# helper functions
+function _reboot_device() {
+  # Check for adb executable
+  if [ ! -f "${adb}" ]; then
+    echo "error: Couldn't find the adb executable. Please verify android sdk tools installation"
+    exit 1
+  fi
+  _log "Restarting test device"
+  ${adb} reboot
+
+  # wait-for-any-device typically doesn't wait long eough for the device to be truly
+  # ready e.g. to be able to delete files from the sdcard with `adb shell rm`.
+  ${adb} wait-for-any-device
+
+  # Once wait-for-any-device completes, we can then poll the boot animation system property,
+  # which has the value "running" when the system startup animations are happening and "stopped"
+  # when they have completed.
+  # See here: https://stackoverflow.com/a/14604886
+  while [[ "$( (${adb} shell getprop init.svc.bootanim | tr -d '\r' ) 2> /dev/null )" != "stopped" ]]; do sleep 1; done
+
+  # The above call can end prematurely on some devices, possibly because they have two boot animations -- the usual one
+  # and a second one that says "phone starting" or similar.
+  # Wait a few seconds for the second animation to start and then wait on that one too.
+  sleep 3
+  while [[ "$( (${adb} shell getprop init.svc.bootanim | tr -d '\r' ) 2> /dev/null )" != "stopped" ]]; do sleep 1; done
+
+  # Despite the fact that the boot animation should be completed now,
+  # this typically still isn't long enough to be able to run commands like `rm` on the remote
+  # device (but it's consistently almost long enough). There doesn't seem to be any other adb
+  # commands to use or any other system properties to wait on that indicate whether such an operation
+  # will succeed, so just sleep for 3 more seconds instead. After that things are usually working.
+  sleep 3
+}

--- a/ci/test/common_test.sh
+++ b/ci/test/common_test.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # Contains common variables and helper functions used by the jenkins scripts for Kotlin Toolkit
 
+source $(dirname ${BASH_SOURCE})/../common.sh
+
 # global constants
 adb="${HOME}/Library/Android/Sdk/platform-tools/adb"
 archive_folder_root="/net/apps-data.esri.com/data/api/kotlin"
 
 # global variables
-integration_reports_path="${runtime_path}/arcgis-maps-sdk-kotlin-toolkit/connectedTestReports"
-unit_reports_path="${runtime_path}/arcgis-maps-sdk-kotlin-toolkit/build/reports/tests/unit-test/aggregated-results"
+integration_reports_path="${apps_path}/arcgis-maps-sdk-kotlin-toolkit/connectedTestReports"
+unit_reports_path="${apps_path}/arcgis-maps-sdk-kotlin-toolkit/build/reports/tests/unit-test/aggregated-results"
 
 # helper functions
 function _reboot_device() {

--- a/ci/test/readme.md
+++ b/ci/test/readme.md
@@ -1,0 +1,38 @@
+# Test
+
+The test folder contains the scripts that build and run the tests on the Jenkins CI environment. 
+Every Jenkins job will have a build id and environmental variables set before running the scripts that can be
+used to get specific data, such as the release version, build numbers and workspaces.
+
+## Common
+
+The [common_test.sh](common_test.sh) script contains all of the global variables, such as the avd device name, test environment
+variables and helper functions that will be available to all test scripts.
+
+## Daily/Dev runs
+
+The daily/dev runs get triggered once the build server is done building the daily and dev Kotlin Toolkit setups. The triggers for
+the jobs will propagate the following environment variables:
+
+* RELEASE_VERSION - The current release version of the toolkit build
+* BUILD_NUM - The current build number
+* DEV_HOUR - (Optional) The dev build hour
+
+The following pipeline steps will then use these variables to find the right workspace and then clone the arcgis-maps-sdk-kotlin-toolkit repo
+using the ${RELEASE_VERSION}.${BUILD_NUM}.${DEV_HOUR} tag and then run the following scripts in each job.
+
+1. [setup.sh](setup.sh) - Setup the daily test run's environment by cloning tags passed in by Jenkins and cleaning the
+   environment
+2. [build.sh](build.sh) - Build the gradle `assembleRelease` task and only proceed to run tests if this succeeds
+3. [test.sh](test.sh) - Build and run the tests. The script will expect an input name for the type of tests running:
+   * unit
+   * integration
+
+After all tests are done running, a `clean` job will run that will remove caches and reboot the device in order to ready
+the environment for the next test run.
+
+## vTest
+
+The vTest runs are on-demand developer builds that use custom branches to run tests.
+
+- [vtest.sh](vtest.sh) - Sets up, builds and runs selected tests

--- a/ci/test/setup.sh
+++ b/ci/test/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Setup the daily test run's environment 
+
+# TODO: setup toolkit lfs data
+#_log "Pulling all the kotlin toolkit test data using gitlfs"
+#cd ${runtime_path}/arcgis-maps-sdk-kotlin-toolkit
+#if ! git lfs pull --exclude=""; then
+#  echo "error: Failed to pull the kotlin toolkit lfs test data"
+#  exit 1
+#fi

--- a/ci/test/setup.sh
+++ b/ci/test/setup.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Setup the daily test run's environment 
 
+source $(dirname ${BASH_SOURCE})/../common.sh
+
 # TODO: setup toolkit lfs data
 #_log "Pulling all the kotlin toolkit test data using gitlfs"
-#cd ${runtime_path}/arcgis-maps-sdk-kotlin-toolkit
+#cd ${apps_path}/arcgis-maps-sdk-kotlin-toolkit
 #if ! git lfs pull --exclude=""; then
 #  echo "error: Failed to pull the kotlin toolkit lfs test data"
 #  exit 1

--- a/ci/test/test.sh
+++ b/ci/test/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build and run the tests
+# Build and run the Kotlin Toolkit tests
 
 source $(dirname ${BASH_SOURCE})/common_test.sh
 

--- a/ci/test/test.sh
+++ b/ci/test/test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Build and run the tests
+
+source $(dirname ${BASH_SOURCE})/common_test.sh
+
+test_project="${1}"
+if [[ "${test_project}" != "integration" && "${test_project}" != "unit" ]]; then
+  echo "error: Unknown test project: ${test_project}"
+  exit 1
+fi
+
+gradle_task=""
+reports_path=""
+results_path=""
+if [ "${test_project}" == "integration"]; then
+  gradle_task="connectedDebugAndroidTest --continue"
+  reports_path="${integration_reports_path}"
+elif [ "${test_project}" == "unit"]; then
+  gradle_task="testAggregatedReport --continue"
+  reports_path="${unit_reports_path}"
+else
+  echo "error: Unknown test project: ${test_project}"
+  exit 1
+fi
+
+# Restart device before test runs to ensure the device is in pristine state
+# Skip device reboot for unit-tests, since they do not require tests to be run against devices
+if [ "${test_project}" != "unit" ]; then
+  _reboot_device
+fi
+
+_log "Building and running the ${test_project} tests"
+if ! ${runtime_path}/arcgis-maps-sdk-kotlin-toolkit/gradlew "${gradle_task}"; then
+  success="false"
+fi
+
+# TODO: pull IC output once we have IC tests set up for the toolkit
+# pull the ic-output out of the device if the integration test failed
+#if [[ "${test_project}" == "integration" && "${success}" == "false" ]]; then
+#  _log "Pulling any failed test images from the device"
+#  if ! ${runtime_path}/kotlin/scripts/run_gradle_task.sh -t "${ic_output_gradle_task}"; then
+#    echo "error: Pulling failed test images failed"
+#  fi
+#  if [ -d ${runtime_path}/kotlin/ic-output ]; then
+#    cp -r ${runtime_path}/kotlin/ic-output ${WORKSPACE}/
+#  fi
+#fi
+
+# copy results to the job workspace so Jenkins can find them
+mkdir ${WORKSPACE}/reports ${WORKSPACE}/test-results
+if [ -d ${reports_path} ]; then
+  cp -r ${reports_path} ${WORKSPACE}/reports/
+fi
+if [ -d ${results_path} ]; then
+  cp -r ${results_path} ${WORKSPACE}/test-results/
+fi
+
+# copy the WORKSPACE to a network share so raw results and images can be kept
+archive_folder="${archive_folder_root}/daily_dev/${RELEASE_VERSION}.${BUILD_NUM}"
+if [ -n "${DEV_HOUR}" ]; then
+  archive_folder+=".${DEV_HOUR}"
+fi
+archive_url="https://runtime-zip.esri.com/userContent/${archive_folder/\/net\//}" # convert /net location to https
+mkdir -p ${archive_folder}
+_log "Copying all test results, reports and ic-output output to"
+echo "Archive URL: ${archive_url}"
+cp -r ${WORKSPACE}/* ${archive_folder}
+
+if [ "${success}" == "false" ]; then
+  echo "error: Building and running the ${test_project} failed"
+  exit 1
+fi

--- a/ci/test/test.sh
+++ b/ci/test/test.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Build and run the Kotlin Toolkit tests
 
+source $(dirname ${BASH_SOURCE})/../common.sh
 source $(dirname ${BASH_SOURCE})/common_test.sh
 
 test_project="${1}"
-if [[ "${test_project}" != "integration" && "${test_project}" != "unit" ]]; then
+if [ "${test_project}" != "integration" ] && [ "${test_project}" != "unit" ]; then
   echo "error: Unknown test project: ${test_project}"
   exit 1
 fi
@@ -12,10 +13,10 @@ fi
 gradle_task=""
 reports_path=""
 results_path=""
-if [ "${test_project}" == "integration"]; then
+if [ "${test_project}" == "integration" ]; then
   gradle_task="connectedDebugAndroidTest --continue"
   reports_path="${integration_reports_path}"
-elif [ "${test_project}" == "unit"]; then
+elif [ "${test_project}" == "unit" ]; then
   gradle_task="testAggregatedReport --continue"
   reports_path="${unit_reports_path}"
 else
@@ -30,7 +31,8 @@ if [ "${test_project}" != "unit" ]; then
 fi
 
 _log "Building and running the ${test_project} tests"
-if ! ${runtime_path}/arcgis-maps-sdk-kotlin-toolkit/gradlew "${gradle_task}"; then
+cd ${apps_path}/arcgis-maps-sdk-kotlin-toolkit
+if ! ./gradlew "${gradle_task}"; then
   success="false"
 fi
 

--- a/ci/test/test.sh
+++ b/ci/test/test.sh
@@ -32,7 +32,7 @@ fi
 
 _log "Building and running the ${test_project} tests"
 cd ${apps_path}/arcgis-maps-sdk-kotlin-toolkit
-if ! ./gradlew "${gradle_task}"; then
+if ! ./gradlew $gradle_task; then
   success="false"
 fi
 
@@ -50,13 +50,13 @@ fi
 
 # copy results to the job workspace so Jenkins can find them
 _log "Copying results to the job workspace to:"
-echo "Workspace folder: ${WORKSPACE}"
-mkdir ${WORKSPACE}/reports ${WORKSPACE}/test-results
+echo "Workspace folder: ${apps_path}"
+mkdir ${apps_path}/reports ${apps_path}/test-results
 if [ -d ${reports_path} ]; then
-  cp -r ${reports_path} ${WORKSPACE}/reports/
+  cp -r ${reports_path} ${apps_path}/reports/
 fi
 if [ -d ${results_path} ]; then
-  cp -r ${results_path} ${WORKSPACE}/test-results/
+  cp -r ${results_path} ${apps_path}/test-results/
 fi
 
 # copy the WORKSPACE to a network share so raw results and images can be kept
@@ -68,7 +68,7 @@ archive_url="https://runtime-zip.esri.com/userContent/${archive_folder/\/net\//}
 mkdir -p ${archive_folder}
 _log "Copying all test results, reports and ic-output output to"
 echo "Archive URL: ${archive_url}"
-cp -r ${WORKSPACE}/* ${archive_folder}
+cp -r ${apps_path}/* ${archive_folder}
 
 if [ "${success}" == "false" ]; then
   echo "error: Building and running the ${test_project} failed"

--- a/ci/test/test.sh
+++ b/ci/test/test.sh
@@ -49,6 +49,8 @@ fi
 #fi
 
 # copy results to the job workspace so Jenkins can find them
+_log "Copying results to the job workspace to:"
+echo "Workspace folder: ${WORKSPACE}"
 mkdir ${WORKSPACE}/reports ${WORKSPACE}/test-results
 if [ -d ${reports_path} ]; then
   cp -r ${reports_path} ${WORKSPACE}/reports/

--- a/ci/test/vtest.sh
+++ b/ci/test/vtest.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# set -xv # uncomment for debugging
+# Sets up, builds and runs selected vtests
+
+source $(dirname ${BASH_SOURCE})/../common.sh
+source $(dirname ${BASH_SOURCE})/common_test.sh
+
+# Environment
+if [ "${Verbose}" == "true" ]; then
+  verbose="-v"
+fi
+
+cd ${apps_path}/arcgis-maps-sdk-kotlin-toolkit
+
+# Setup
+# nothing to set up yet
+
+# Build
+
+# assembleRelease
+_log "Run the gradle assembleRelease task to pre-build the Kotlin Toolkit"
+# This is useful because if gradle returns a non-zero exit code it means we are not even able to build the API. In that
+# case, we can fail the test job without having to pull the test data (which could potentially take a long time).
+# See https://devtopia.esri.com/runtime/kotlin/pull/775#discussion_r801362
+if ! ./gradlew assembleRelease; then
+   echo "error: Running the assembleRelease gradle task failed"
+   exit 1
+fi
+
+# Test Data
+# TODO: setup toolkit lfs data
+#_log "Pulling all the kotlin toolkit test data using gitlfs"
+#cd ${apps_path}/arcgis-maps-sdk-kotlin-toolkit
+#if ! git lfs pull --exclude=""; then
+#  echo "error: Failed to pull the kotlin toolkit lfs test data"
+#  exit 1
+#fi
+
+# Test
+for test_project in integration unit; do
+  if [ "${!test_project}" != "true" ]; then
+    # only run tests that were checked by looking up the value of what !test_project is set to; i.e ${unit}
+    continue
+  fi
+  # find the right test tasks and results and reports path
+  gradle_task=""
+  reports_path=""
+  results_path=""
+  if [ "${test_project}" == "integration" ]; then
+    gradle_task="connectedDebugAndroidTest --continue"
+    reports_path="${integration_reports_path}"
+  elif [ "${test_project}" == "unit" ]; then
+    gradle_task="testAggregatedReport --continue"
+    reports_path="${unit_reports_path}"
+  else
+    echo "error: Unknown test project: ${test_project}"
+    exit 1
+  fi
+
+  # Restart device before test runs to ensure the device is in pristine state
+  # Skip device reboot for unit-tests, since they do not require tests to be run against devices
+  if [ "${test_project}" != "unit" ]; then
+    _reboot_device
+  fi
+
+  _log "Building and running the ${test_project} tests"
+  cd ${apps_path}/arcgis-maps-sdk-kotlin-toolkit
+  if ! ./gradlew $gradle_task; then
+    echo "error: Building and running the ${test_project} failed"
+    success="false"
+  fi
+
+  # TODO: pull IC output once we have IC tests set up for the toolkit
+  # pull the ic-output out of the device if the integration test failed
+  #if [[ "${test_project}" == "integration" && "${success}" == "false" ]]; then
+  #  _log "Pulling any failed test images from the device"
+  #  if ! ${apps_path}/kotlin/scripts/run_gradle_task.sh -t "${ic_output_gradle_task}"; then
+  #    echo "error: Pulling failed test images failed"
+  #  fi
+  #  if [ -d ${apps_path}/kotlin/ic-output ]; then
+  #    cp -r ${apps_path}/kotlin/ic-output ${WORKSPACE}/
+  #  fi
+  #fi
+
+  # copy results to the job workspace so Jenkins can find them
+  _log "Copying results to the job workspace to:"
+  echo "Workspace folder: ${apps_path}"
+  mkdir ${apps_path}/reports ${apps_path}/test-results
+  if [ -d ${reports_path} ]; then
+    cp -r ${reports_path} ${apps_path}/reports/
+  fi
+  if [ -d ${results_path} ]; then
+    cp -r ${results_path} ${apps_path}/test-results/
+  fi
+done
+
+# Archive
+# Use the Build_name in order to archive all test results, reports and ic-output to a network archive
+# delete whitespace for the variable, turn \ to /, change to all lower-case and use iconv to remove unicode to sanitize the location
+Build_name=${Build_name// /}
+Build_name=${Build_name//\\//}
+echo "${Build_name}" | tr '[:upper:]' '[:lower:]' >/tmp/build_name
+Build_name=$(iconv -c -f utf-8 -t ascii /tmp/build_name)
+archive_folder="${archive_folder_root}/vtest/${Build_name}"
+archive_url="https://runtime-zip.esri.com/userContent/${archive_folder/\/net\//}" # convert /net location to https
+mkdir -p ${archive_folder}
+_log "Copying all test results, reports, ic-output to"
+echo "Archive URL: ${archive_url}"
+
+for test_artifact in ${WORKSPACE}/ic-output ${WORKSPACE}/reports ${WORKSPACE}/test-results; do
+  if [ -d "${test_artifact}" ]; then
+    cp -r ${test_artifact} ${archive_folder}/
+  fi
+done
+
+if [ "${success}" == "false" ]; then
+  echo "error: One of the test tasks returned a non zero exit code"
+  exit 1
+fi

--- a/ci/test/vtest.sh
+++ b/ci/test/vtest.sh
@@ -107,7 +107,7 @@ mkdir -p ${archive_folder}
 _log "Copying all test results, reports, ic-output to"
 echo "Archive URL: ${archive_url}"
 
-for test_artifact in ${WORKSPACE}/ic-output ${WORKSPACE}/reports ${WORKSPACE}/test-results; do
+for test_artifact in ${apps_path}/ic-output ${apps_path}/reports ${apps_path}/test-results; do
   if [ -d "${test_artifact}" ]; then
     cp -r ${test_artifact} ${archive_folder}/
   fi


### PR DESCRIPTION
[Tracking issue](https://devtopia.esri.com/runtime/kotlin/issues/4014)

### Description:

Sets up scripts to build & run tests on the Jenkins CI environment. This follows closely the pattern applied to runing Kotlin SDK tests on Jenkins, i.e. have a `ci/test` folder with scripts for set up, build, test and vTest.

### Changes:
- Introduced new `test` folder under `ci`
- added `common_test.sh`, `setup.sh`, `build.sh`, `test.sh` and `vtest.sh`
- added readme
