### PR TITLE
Callout leader

### DIFF
--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
@@ -147,8 +147,7 @@ public fun MapViewScope.Callout(
                         calloutContentPadding = properties.calloutContentPadding,
                         leaderWidth = with(localDensity) { properties.leaderSize.width.toPx() },
                         leaderHeight = with(localDensity) { properties.leaderSize.height.toPx() },
-                        minSize = properties.minSize,
-                        calloutScreenCoordinate = localLeaderScreenCoordinate,
+                        minSize = properties.minSize
                     )
             )
             {
@@ -232,8 +231,8 @@ private fun DoubleXY.rotate(rotateByAngle: Double, center: DoubleXY = DoubleXY.z
 
 /**
  * Analogue of Layout which allows to sub-compose the Callout content during the measuring stage,
- * and place the content at the given [screenCoordinate].
- *
+ * and place the content at the given screenCoordinate.
+ * @param screenCoordinate Represents the x,y coordinate for the location on GeoView
  * @since 200.5.0
  */
 @Composable
@@ -287,7 +286,6 @@ private fun SubComposableLayout(
  * @param leaderWidth Width of the Callout leader in px.
  * @param leaderHeight Height of the Callout leader in px.
  * @param minSize Minimum size the of the Callout shape.
- * @param calloutScreenCoordinate Represents the x,y coordinate of the Callout leader.
  * @since 200.5.0
  */
 @Composable
@@ -299,8 +297,7 @@ private fun Modifier.drawCalloutContainer(
     calloutContentPadding: PaddingValues,
     leaderWidth: Float,
     leaderHeight: Float,
-    minSize: DpSize,
-    calloutScreenCoordinate: ScreenCoordinate,
+    minSize: DpSize
 ) = then(
     sizeIn(minWidth = minSize.width, minHeight = minSize.height)
         // Set bottom padding to ensure the leader is visible

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/Callout.kt
@@ -224,7 +224,7 @@ private fun DoubleXY.rotate(rotateByAngle: Double, center: DoubleXY = DoubleXY.z
 
 /**
  * Analogue of Layout which allows to sub-compose the Callout container during the measuring stage,
- * and anchor the Callout leader at the given screenCoordinate. The callout is drawn using a Box
+ * and anchor the Callout leader at the given screenCoordinate. The Callout is drawn using a Box
  * and by default it is anchored to its top left corner. In order to anchor the Callout at the tip
  * of the leader we need to determine the size of its content to calculate the anchor point's
  * location before drawing the Callout on the screen.
@@ -264,10 +264,10 @@ private fun CalloutSubComposeLayout(
                 maxHeight = layoutHeight
             )
         )
-        // the default (0,0) value is on the top-left edge of the callout container,
-        // this moves the anchor to the bottom-middle point using X,Y offsets.
-        // and ensures the anchor leader always represents the tapped location point,
-        // in this case, the bottom-middle leader position.
+        // The default (0,0) value is on the top-left edge of the callout container.
+        // This moves the anchor to the bottom-middle point using X,Y offsets,
+        // and ensures that the leader's anchor point always represents the tapped location,
+        // in this case the bottom-middle leader position.
         val calloutOffsetX = leaderScreenCoordinate.x.toInt() - (calloutContainerPlaceable.width / 2)
         val calloutOffsetY = leaderScreenCoordinate.y.toInt() - calloutContainerPlaceable.height
         // place the callout in the layout


### PR DESCRIPTION
PR to use a `SubcomposeLayout` to sub-compose the Callout content during the measuring stage, and place the content at the leader anchor point, using the given screenCoordinate.