### PR TITLE
`Forms` : Optimize thumbnail loading for Attachments

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -19,6 +19,10 @@ package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.Bitmap.CompressFormat
+import android.media.ThumbnailUtils
+import android.os.Build
+import android.util.Size
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AudioFile
@@ -38,8 +42,6 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
@@ -62,9 +64,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.util.Objects
+
 
 /**
  * Represents the state of an [AttachmentFormElement]
@@ -282,15 +286,20 @@ internal class FormAttachmentState(
     val formAttachment: FormAttachment? = null
 ) : Loadable {
 
+    /**
+     * The name of the attachment.
+     */
     var name by mutableStateOf(name)
         private set
 
-    private val _thumbnail: MutableState<ImageBitmap?> = mutableStateOf(null)
-
     /**
-     * The thumbnail of the attachment. This is `null` until [load] is called.
+     * A unique ID for the attachment.
      */
-    val thumbnail: State<ImageBitmap?> = _thumbnail
+    val id by lazy {
+        formAttachment?.attachment?.let {
+            "${it.id}_${it.name}"
+        } ?: name
+    }
 
     private val _loadStatus: MutableStateFlow<LoadStatus> = MutableStateFlow(LoadStatus.NotLoaded)
     override val loadStatus = _loadStatus.asStateFlow()
@@ -301,6 +310,13 @@ internal class FormAttachmentState(
     var filePath: String = ""
         private set
 
+    private var _thumbnailUri: MutableState<String> = mutableStateOf("")
+
+    /**
+     * The URI of the thumbnail image. This is empty until [load] is called.
+     */
+    val thumbnailUri: State<String> = _thumbnailUri
+
     /**
      * The directory where the attachments are stored as defined in the [AttachmentsFileProvider].
      */
@@ -309,7 +325,7 @@ internal class FormAttachmentState(
     /**
      * The size of the thumbnail image.
      */
-    private val thumbnailSize = Pair(368, 300)
+    private val thumbnailSize = Size(368, 300)
 
     /**
      * Loads the attachment and its thumbnail in the coroutine scope of the state object that
@@ -347,14 +363,11 @@ internal class FormAttachmentState(
                 }.onSuccess {
                     val data = formAttachment.attachment?.fetchData()?.getOrNull()
                     if (data != null) {
-                        formAttachment.createThumbnail(thumbnailSize.first, thumbnailSize.second)
-                            .onSuccess {
-                                _thumbnail.value = it.bitmap.asImageBitmap()
-                            }
                         // write the data to disk only if the file does not exist
                         if (!File(filePath).exists()) {
                             writeDataToDisk(data)
                         }
+                        createThumbnail()
                     } else {
                         result = Result.failure(Exception("Failed to load attachment data"))
                     }
@@ -385,7 +398,7 @@ internal class FormAttachmentState(
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(name, size, type)
+        return Objects.hash(id, name, size, type)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -394,6 +407,7 @@ internal class FormAttachmentState(
 
         other as FormAttachmentState
 
+        if (id != other.id) return false
         if (name != other.name) return false
         if (size != other.size) return false
         if (type != other.type) return false
@@ -404,13 +418,55 @@ internal class FormAttachmentState(
     private suspend fun writeDataToDisk(data: ByteArray) = withContext(Dispatchers.IO) {
         val directory = File(filesDir, attachmentsDir)
         directory.mkdirs()
-        // write the data to disk
-        val file = File(directory, name)
+        // write the data to disk using the attachment id as the file name
+        val file = File(directory, id)
         file.createNewFile()
         FileOutputStream(file).use {
             it.write(data)
         }
         filePath = file.absolutePath
+    }
+
+    private suspend fun createThumbnail() = withContext(Dispatchers.IO) {
+        if (formAttachment == null) {
+            return@withContext
+        }
+        val directory = File(filesDir, attachmentsDir)
+        directory.mkdirs()
+        val file = File(directory, "thumb_$id")
+        if (file.exists()) {
+            _thumbnailUri.value = file.absolutePath
+            return@withContext
+        }
+        file.createNewFile()
+        val bitmap = try {
+            when (type) {
+                is FormAttachmentType.Image -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        ThumbnailUtils.createImageThumbnail(File(filePath), thumbnailSize, null)
+                    } else {
+                        ThumbnailUtils.createImageThumbnail(filePath, 1)
+                    }
+                }
+
+                FormAttachmentType.Video -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        ThumbnailUtils.createVideoThumbnail(File(filePath), thumbnailSize, null)
+                    } else {
+                        ThumbnailUtils.createVideoThumbnail(filePath, 1)
+                    }
+                }
+
+                else -> null
+            }
+        } catch (ex: Exception) {
+            null
+        } ?: return@withContext
+
+        BufferedOutputStream(FileOutputStream(file)).use { bos ->
+            bitmap.compress(CompressFormat.JPEG, 85, bos)
+        }
+        _thumbnailUri.value = file.absolutePath
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -438,7 +438,6 @@ internal class FormAttachmentState(
             _thumbnailUri.value = file.absolutePath
             return@withContext
         }
-        file.createNewFile()
         val bitmap = try {
             when (type) {
                 is FormAttachmentType.Image -> {
@@ -463,6 +462,8 @@ internal class FormAttachmentState(
             null
         } ?: return@withContext
 
+        // create and write to the thumbnail file if the bitmap is not null
+        file.createNewFile()
         BufferedOutputStream(FileOutputStream(file)).use { bos ->
             bitmap.compress(CompressFormat.JPEG, 85, bos)
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -295,11 +295,10 @@ internal class FormAttachmentState(
     /**
      * A unique ID for the attachment.
      */
-    val id by lazy {
-        formAttachment?.attachment?.let {
+    val id: String
+        get() = formAttachment?.attachment?.let {
             "${it.id}_${it.name}"
         } ?: name
-    }
 
     private val _loadStatus: MutableStateFlow<LoadStatus> = MutableStateFlow(LoadStatus.NotLoaded)
     override val loadStatus = _loadStatus.asStateFlow()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -69,8 +69,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -18,6 +18,7 @@ package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 import android.content.Intent
 import android.text.format.Formatter
+import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -70,6 +71,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -89,6 +91,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import coil.compose.AsyncImage
 import com.arcgismaps.LoadStatus
 import com.arcgismaps.mapping.featureforms.FormAttachmentType
 import com.arcgismaps.toolkit.featureforms.R
@@ -105,8 +108,8 @@ internal fun AttachmentTile(
     state: FormAttachmentState
 ) {
     val loadStatus by state.loadStatus.collectAsState()
-    val thumbnail by state.thumbnail
     val interactionSource = remember { MutableInteractionSource() }
+    val thumbnailUri by state.thumbnailUri
     val configuration = LocalViewConfiguration.current
     val haptic = LocalHapticFeedback.current
     var showContextMenu by remember { mutableStateOf(false) }
@@ -130,7 +133,7 @@ internal fun AttachmentTile(
                 LoadStatus.Loaded -> LoadedView(
                     title = state.name,
                     type = state.type,
-                    thumbnail = thumbnail
+                    thumbnailUri = thumbnailUri
                 )
 
                 LoadStatus.Loading -> DefaultView(
@@ -249,19 +252,20 @@ internal fun AttachmentTile(
 private fun LoadedView(
     title: String,
     type: FormAttachmentType,
-    thumbnail: ImageBitmap?,
+    thumbnailUri: String,
     modifier: Modifier = Modifier
 ) {
     Box(
         modifier = modifier
             .fillMaxSize()
     ) {
-        if (thumbnail != null) {
-            Image(
-                bitmap = thumbnail,
+        Log.e("TAG", "LoadedView: $thumbnailUri", )
+        if (thumbnailUri.isNotEmpty()) {
+            AsyncImage(
+                model = thumbnailUri,
                 contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
             )
         } else {
             Icon(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -18,7 +18,6 @@ package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 import android.content.Intent
 import android.text.format.Formatter
-import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -259,7 +258,6 @@ private fun LoadedView(
         modifier = modifier
             .fillMaxSize()
     ) {
-        Log.e("TAG", "LoadedView: $thumbnailUri", )
         if (thumbnailUri.isNotEmpty()) {
             AsyncImage(
                 model = thumbnailUri,


### PR DESCRIPTION
### Issue

https://devtopia.esri.com/runtime/apollo/issues/691

### Summary of changes

- Uses platform methods to generate thumbnails which offers correct orientation compared to the sdk method. This also generates thumbnails for videos.
- The actual attachment and thumbnail files are now prefixed with the `attachment.id` so that the file names are unique. The `id` parameter also participates in `hashCode` and `equals` for the `FormAttachmentState`.
- Optimized how the thumbnails are loaded:
    - Instead of loading all thumbnails into memory by storing them as a state object, they are instead serialized into a file.
    - Coil's `AsyncImage` is then used to load these thumbnails from file offloading the overhead to coil which is more optimized.
    - This reduces the memory footprint of the component.