### PR TITLE
popup media element and media image thumbnail support

### DIFF
--- a/toolkit/popup/build.gradle.kts
+++ b/toolkit/popup/build.gradle.kts
@@ -76,6 +76,8 @@ apiValidation {
 
 dependencies {
     api(arcgis.mapsSdk)
+    implementation(platform(libs.coil.bom))
+    implementation(libs.coil.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
@@ -46,8 +46,9 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.arcgismaps.mapping.popup.FieldsPopupElement
 import com.arcgismaps.mapping.popup.AttachmentsPopupElement
+import com.arcgismaps.mapping.popup.FieldsPopupElement
+import com.arcgismaps.mapping.popup.MediaPopupElement
 import com.arcgismaps.mapping.popup.Popup
 import com.arcgismaps.mapping.popup.TextPopupElement
 import com.arcgismaps.toolkit.popup.internal.element.attachment.AttachmentsElementState
@@ -56,6 +57,9 @@ import com.arcgismaps.toolkit.popup.internal.element.attachment.rememberAttachme
 import com.arcgismaps.toolkit.popup.internal.element.fieldselement.FieldsElementState
 import com.arcgismaps.toolkit.popup.internal.element.fieldselement.FieldsPopupElement
 import com.arcgismaps.toolkit.popup.internal.element.fieldselement.rememberFieldsElementState
+import com.arcgismaps.toolkit.popup.internal.element.media.MediaElementState
+import com.arcgismaps.toolkit.popup.internal.element.media.MediaPopupElement
+import com.arcgismaps.toolkit.popup.internal.element.media.rememberMediaElementState
 import com.arcgismaps.toolkit.popup.internal.element.state.PopupElementStateCollection
 import com.arcgismaps.toolkit.popup.internal.element.state.mutablePopupElementStateCollection
 import com.arcgismaps.toolkit.popup.internal.element.textelement.TextElementState
@@ -165,6 +169,12 @@ private fun PopupBody(popupState: PopupState) {
                         )
                     }
 
+                    is MediaPopupElement -> {
+                        MediaPopupElement(
+                            entry.state as MediaElementState
+                        )
+                    }
+
                     else -> {
                         // other popup elements are not created
                     }
@@ -225,6 +235,13 @@ internal fun rememberStates(
                 states.add(
                     element,
                     rememberFieldsElementState(element = element, popup = popup)
+                )
+            }
+
+            is MediaPopupElement -> {
+                states.add(
+                    element,
+                    rememberMediaElementState(element = element, popup = popup)
                 )
             }
 

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementDefaults.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementDefaults.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.popup.internal.element.media
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * A central place for theming values. To be promoted to a public theme type.
+ */
+internal object MediaElementDefaults {
+    @Composable
+    fun shapes(): MediaElementShapes = MediaElementShapes(
+        borderThickness = 1.dp,
+        containerShape = RoundedCornerShape(5.dp),
+        tileShape = RoundedCornerShape(8.dp),
+        galleryPadding = 15.dp,
+        tileStrokeWidth = 0.5.dp,
+        tileWidth = 92.dp,
+        tileHeight = 75.dp
+    )
+
+    @Suppress("unused")
+    @Composable
+    fun colors() : MediaElementColors = MediaElementColors(
+        containerColor = MaterialTheme.colorScheme.background,
+        galleryContainerColor = MaterialTheme.colorScheme.onBackground,
+        borderColor = MaterialTheme.colorScheme.outline,
+        tileBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.6f)
+    )
+}
+
+internal data class MediaElementShapes(
+    val borderThickness: Dp,
+    val containerShape: RoundedCornerShape,
+    val tileShape: RoundedCornerShape,
+    val galleryPadding: Dp,
+    val tileStrokeWidth: Dp,
+    val tileWidth: Dp,
+    val tileHeight: Dp
+)
+
+internal data class MediaElementColors(
+    val containerColor : Color,
+    val galleryContainerColor: Color,
+    val tileBorderColor : Color,
+    val borderColor : Color
+)

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementDefaults.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementDefaults.kt
@@ -34,8 +34,8 @@ internal object MediaElementDefaults {
         tileShape = RoundedCornerShape(8.dp),
         galleryPadding = 15.dp,
         tileStrokeWidth = 0.5.dp,
-        tileWidth = 92.dp,
-        tileHeight = 75.dp
+        tileWidth = 276.dp,
+        tileHeight = 225.dp
     )
 
     @Suppress("unused")

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementDefaults.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementDefaults.kt
@@ -44,7 +44,9 @@ internal object MediaElementDefaults {
         containerColor = MaterialTheme.colorScheme.background,
         galleryContainerColor = MaterialTheme.colorScheme.onBackground,
         borderColor = MaterialTheme.colorScheme.outline,
-        tileBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.6f)
+        tileBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.6f),
+        tileTextBackgroundColor = MaterialTheme.colorScheme.onBackground,
+        tileTextColor = MaterialTheme.colorScheme.background
     )
 }
 
@@ -62,5 +64,7 @@ internal data class MediaElementColors(
     val containerColor : Color,
     val galleryContainerColor: Color,
     val tileBorderColor : Color,
-    val borderColor : Color
+    val borderColor : Color,
+    val tileTextBackgroundColor: Color,
+    val tileTextColor: Color
 )

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.popup.internal.element.media
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BarChart
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.arcgismaps.mapping.popup.MediaPopupElement
+import com.arcgismaps.mapping.popup.Popup
+import com.arcgismaps.mapping.popup.PopupMedia
+import com.arcgismaps.mapping.popup.PopupMediaType
+import com.arcgismaps.mapping.popup.PopupMediaValue
+import com.arcgismaps.toolkit.popup.internal.element.state.PopupElementState
+
+/**
+ * Represents the state of an [MediaPopupElement]
+ */
+@Immutable
+internal class MediaElementState(
+    val description: String,
+    val title: String,
+    val media: List<PopupMediaState>,
+    override val id : Int = createId(),
+) : PopupElementState() {
+
+    constructor(mediaPopupElement: MediaPopupElement): this(
+        description = mediaPopupElement.description,
+        title = mediaPopupElement.title,
+        media = mediaPopupElement.media
+            .filter { it.type is PopupMediaType.Image }
+            .map { PopupMediaState(it) }
+    )
+
+    companion object {
+        fun Saver(
+            element: MediaPopupElement
+        ): Saver<MediaElementState, Any> = Saver(
+            save = { null },
+            restore = {
+                MediaElementState(
+                    element
+                )
+            }
+        )
+
+    }
+}
+
+@Composable
+internal fun rememberMediaElementState(
+    element: MediaPopupElement,
+    popup: Popup
+): MediaElementState {
+    return rememberSaveable(
+        inputs = arrayOf(popup, element),
+        saver = MediaElementState.Saver(element)
+    ) {
+        MediaElementState(
+            element
+        )
+    }
+}
+
+/**
+ * Represents the state of a [PopupMedia value].
+ */
+internal class PopupMediaState(
+    val title: String,
+    val caption: String,
+    val refreshInterval: Long,
+    val media: PopupMediaValue,
+    val type: PopupMediaType
+) {
+    constructor(media: PopupMedia) : this(
+        title = media.title,
+        caption = media.caption,
+        refreshInterval = media.imageRefreshInterval,
+        media = media.value!!,
+        type = media.type
+    )
+}
+
+@Composable
+internal fun PopupMediaType.getIcon(): ImageVector = when (this) {
+    PopupMediaType.Image -> Icons.Outlined.Image
+    else -> Icons.Outlined.BarChart
+}

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
@@ -16,19 +16,14 @@
 
 package com.arcgismaps.toolkit.popup.internal.element.media
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.BarChart
-import androidx.compose.material.icons.outlined.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.graphics.vector.ImageVector
 import com.arcgismaps.mapping.popup.MediaPopupElement
 import com.arcgismaps.mapping.popup.Popup
 import com.arcgismaps.mapping.popup.PopupMedia
 import com.arcgismaps.mapping.popup.PopupMediaType
-import com.arcgismaps.mapping.popup.PopupMediaValue
 import com.arcgismaps.toolkit.popup.internal.element.state.PopupElementState
 
 /**
@@ -86,21 +81,17 @@ internal fun rememberMediaElementState(
 internal class PopupMediaState(
     val title: String,
     val caption: String,
-    val refreshInterval: Long,
-    val media: PopupMediaValue,
+    @Suppress("unused") val refreshInterval: Long,
+    @Suppress("unused") val linkUrl: String,
+    val sourceUrl: String,
     val type: PopupMediaType
 ) {
     constructor(media: PopupMedia) : this(
         title = media.title,
         caption = media.caption,
         refreshInterval = media.imageRefreshInterval,
-        media = media.value!!,
+        linkUrl = media.value?.linkUrl ?: "",
+        sourceUrl = media.value?.sourceUrl ?: "",
         type = media.type
     )
-}
-
-@Composable
-internal fun PopupMediaType.getIcon(): ImageVector = when (this) {
-    PopupMediaType.Image -> Icons.Outlined.Image
-    else -> Icons.Outlined.BarChart
 }

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaPopupElement.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaPopupElement.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.popup.PopupMediaType
-import com.arcgismaps.mapping.popup.PopupMediaValue
 import com.arcgismaps.toolkit.popup.internal.ui.ExpandableCard
 
 @Composable
@@ -87,9 +86,9 @@ private fun MediaPopupElementPreview() {
                 "Photo 1.jpg",
                 "caption",
                 1234L,
-                PopupMediaValue().apply { sourceUrl = "https://i.postimg.cc/65yws9mR/Screenshot-2024-02-02-at-6-20-49-PM.png" },
+                linkUrl = "",
+                sourceUrl = "https://i.postimg.cc/65yws9mR/Screenshot-2024-02-02-at-6-20-49-PM.png",
                 PopupMediaType.Image,
-
             )
         )
     )

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaPopupElement.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaPopupElement.kt
@@ -38,7 +38,7 @@ internal fun MediaPopupElement(
         title = state.title,
         description = state.description,
         stateId = state.id,
-        Media = state.media
+        media = state.media
     )
 }
 
@@ -47,7 +47,7 @@ private fun MediaPopupElement(
     description: String,
     title: String,
     @Suppress("UNUSED_PARAMETER") stateId: Int,
-    Media: List<PopupMediaState>
+    media: List<PopupMediaState>
 ) {
     ExpandableCard(
         title = title,
@@ -57,7 +57,7 @@ private fun MediaPopupElement(
             modifier = Modifier.padding(MediaElementDefaults.shapes().galleryPadding)
         ) {
             val listState = rememberLazyListState()
-            MediaGallery(listState, Media)
+            MediaGallery(listState, media)
         }
     }
 }
@@ -81,7 +81,7 @@ private fun MediaPopupElementPreview() {
         title = "Media",
         description = "description of Media",
         stateId = 1,
-        Media = listOf(
+        media = listOf(
             PopupMediaState(
                 "Photo 1.jpg",
                 "caption",

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaPopupElement.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaPopupElement.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.popup.internal.element.media
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.arcgismaps.mapping.popup.PopupMediaType
+import com.arcgismaps.mapping.popup.PopupMediaValue
+import com.arcgismaps.toolkit.popup.internal.ui.ExpandableCard
+
+@Composable
+internal fun MediaPopupElement(
+    state: MediaElementState
+) {
+    MediaPopupElement(
+        title = state.title,
+        description = state.description,
+        stateId = state.id,
+        Media = state.media
+    )
+}
+
+@Composable
+private fun MediaPopupElement(
+    description: String,
+    title: String,
+    @Suppress("UNUSED_PARAMETER") stateId: Int,
+    Media: List<PopupMediaState>
+) {
+    ExpandableCard(
+        title = title,
+        description = description
+    ) {
+        Column(
+            modifier = Modifier.padding(MediaElementDefaults.shapes().galleryPadding)
+        ) {
+            val listState = rememberLazyListState()
+            MediaGallery(listState, Media)
+        }
+    }
+}
+
+@Composable
+private fun MediaGallery(state: LazyListState, media: List<PopupMediaState>) {
+    LazyRow(
+        state = state,
+        horizontalArrangement = Arrangement.spacedBy(15.dp),
+    ) {
+        items(media, key = { it.title + it.type + it.caption }) {
+            MediaTile(it)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun MediaPopupElementPreview() {
+    MediaPopupElement(
+        title = "Media",
+        description = "description of Media",
+        stateId = 1,
+        Media = listOf(
+            PopupMediaState(
+                "Photo 1.jpg",
+                "caption",
+                1234L,
+                PopupMediaValue().apply { sourceUrl = "https://i.postimg.cc/65yws9mR/Screenshot-2024-02-02-at-6-20-49-PM.png" },
+                PopupMediaType.Image,
+
+            )
+        )
+    )
+}

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
@@ -17,25 +17,46 @@
 package com.arcgismaps.toolkit.popup.internal.element.media
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Image
+import androidx.compose.material.icons.outlined.BarChart
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.vector.VectorPainter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.popup.PopupMediaType
-import com.arcgismaps.mapping.popup.PopupMediaValue
-import com.arcgismaps.toolkit.popup.internal.util.MediaImage
-import com.arcgismaps.toolkit.popup.internal.util.RemoteImageGetter
+import com.arcgismaps.toolkit.popup.internal.util.PopupMediaImageLoader
+import com.arcgismaps.toolkit.popup.internal.util.RemoteImageLoader
 
 @Composable
 internal fun MediaTile(
@@ -57,9 +78,140 @@ internal fun MediaTile(
             }
     ) {
 
-        val placeholder = rememberVectorPainter(image = Icons.Rounded.Image)
-        val getter by remember(state.media) { mutableStateOf(RemoteImageGetter(placeholder, state.media.sourceUrl!!)) }
-        MediaImage(imageGetter = getter, contentDescription = "foo")
+        val placeholder = state.type.rememberPlaceholder()
+        val getter by remember(state.sourceUrl) {
+            mutableStateOf(
+                RemoteImageLoader(
+                    placeholder,
+                    state.sourceUrl
+                )
+            )
+        }
+        MediaView(
+            mediaImageLoader = getter,
+            title = state.title,
+            caption = state.caption
+        )
+    }
+}
+
+/**
+ * Loads an image asynchronously using the [PopupMediaImageLoader].
+ */
+@Composable
+private fun MediaImage(
+    mediaImageLoader: PopupMediaImageLoader,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.FillBounds,
+    contentDescription: String = " ",
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null
+) {
+    val context = LocalContext.current
+    LaunchedEffect(mediaImageLoader) {
+        mediaImageLoader.get(context)
+    }
+    val painter = mediaImageLoader.image.value
+    Image(
+        painter = painter,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter
+    )
+}
+
+@Composable
+private fun Title(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    style: TextStyle = MaterialTheme.typography.labelMedium
+) {
+    Text(
+        text = text,
+        color = color,
+        style = style,
+        textAlign = TextAlign.Start,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        modifier = modifier.padding(vertical = 1.dp)
+    )
+}
+
+@Composable
+private fun Caption(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    style: TextStyle = MaterialTheme.typography.labelSmall
+) {
+    Text(
+        text = text,
+        color = color,
+        style = style,
+        textAlign = TextAlign.Start,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        modifier = modifier
+    )
+}
+
+@Composable
+internal fun MediaView(
+    title: String,
+    caption: String,
+    mediaImageLoader: PopupMediaImageLoader,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+    ) {
+        MediaImage(
+            mediaImageLoader = mediaImageLoader,
+            contentDescription = title,
+            modifier = Modifier.fillMaxSize()
+        )
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(
+                    if (title.isNotEmpty() && caption.isNotEmpty()) {
+                        40.dp
+                    } else if (title.isNotEmpty() || caption.isNotEmpty()) {
+                        20.dp
+                    } else {
+                        0.dp
+                    }
+                )
+                .background(
+                    MaterialTheme.colorScheme.onBackground.copy(
+                        alpha = 0.7f
+                    )
+                ),
+            verticalArrangement = Arrangement.Center
+        ) {
+            Title(
+                text = title,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 5.dp),
+                color = MaterialTheme.colorScheme.background
+            )
+            Caption(
+                text = caption,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 5.dp),
+                color = MaterialTheme.colorScheme.background.copy(alpha = 0.7f)
+            )
+
+        }
     }
 }
 
@@ -71,8 +223,16 @@ internal fun PreviewMediaTile() {
             title = "Some attachment",
             caption = "foo",
             refreshInterval = 1234L,
-            media = PopupMediaValue().apply { sourceUrl = "https://i.postimg.cc/65yws9mR/Screenshot-2024-02-02-at-6-20-49-PM.png"},
+            sourceUrl = "https://i.postimg.cc/65yws9mR/Screenshot-2024-02-02-at-6-20-49-PM.png",
+            linkUrl = "",
             type = PopupMediaType.Image
         )
     )
 }
+
+@Composable
+private fun PopupMediaType.rememberPlaceholder(): VectorPainter = when (this) {
+    PopupMediaType.Image -> rememberVectorPainter(image = Icons.Outlined.Image)
+    else -> rememberVectorPainter(image = Icons.Outlined.BarChart)
+}
+

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
@@ -77,7 +77,6 @@ internal fun MediaTile(
                 // TODO open media viewer here
             }
     ) {
-
         val placeholder = state.type.rememberPlaceholder()
         val getter by remember(state.sourceUrl) {
             mutableStateOf(
@@ -138,7 +137,7 @@ private fun Title(
         textAlign = TextAlign.Start,
         overflow = TextOverflow.Ellipsis,
         maxLines = 1,
-        modifier = modifier.padding(vertical = 1.dp)
+        modifier = modifier
     )
 }
 
@@ -171,6 +170,9 @@ internal fun MediaView(
         modifier = modifier
             .fillMaxSize()
     ) {
+        val defaults = MediaElementDefaults.colors()
+        val backgroundColor = defaults.tileTextBackgroundColor
+        val textColor = defaults.tileTextColor
         MediaImage(
             mediaImageLoader = mediaImageLoader,
             contentDescription = title,
@@ -190,7 +192,7 @@ internal fun MediaView(
                     }
                 )
                 .background(
-                    MaterialTheme.colorScheme.onBackground.copy(
+                    backgroundColor.copy(
                         alpha = 0.7f
                     )
                 ),
@@ -200,15 +202,15 @@ internal fun MediaView(
                 text = title,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 5.dp),
-                color = MaterialTheme.colorScheme.background
+                    .padding(horizontal = 5.dp, vertical = 1.dp),
+                color = textColor
             )
             Caption(
                 text = caption,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 5.dp),
-                color = MaterialTheme.colorScheme.background.copy(alpha = 0.7f)
+                color = textColor
             )
 
         }

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.popup.internal.element.media
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.tooling.preview.Preview
+import com.arcgismaps.mapping.popup.PopupMediaType
+import com.arcgismaps.mapping.popup.PopupMediaValue
+import com.arcgismaps.toolkit.popup.internal.util.MediaImage
+import com.arcgismaps.toolkit.popup.internal.util.RemoteImageGetter
+
+@Composable
+internal fun MediaTile(
+    state: PopupMediaState
+) {
+    val colors = MediaElementDefaults.colors()
+    val shapes = MediaElementDefaults.shapes()
+    Box(
+        modifier = Modifier
+            .width(shapes.tileWidth)
+            .height(shapes.tileHeight)
+            .clip(shape = shapes.tileShape)
+            .border(
+                border = BorderStroke(shapes.tileStrokeWidth, colors.tileBorderColor),
+                shape = shapes.tileShape
+            )
+            .clickable {
+                // TODO open media viewer here
+            }
+    ) {
+
+        val placeholder = rememberVectorPainter(image = Icons.Rounded.Image)
+        val getter by remember(state.media) { mutableStateOf(RemoteImageGetter(placeholder, state.media.sourceUrl!!)) }
+        MediaImage(imageGetter = getter, contentDescription = "foo")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun PreviewMediaTile() {
+    MediaTile(
+        state = PopupMediaState(
+            title = "Some attachment",
+            caption = "foo",
+            refreshInterval = 1234L,
+            media = PopupMediaValue().apply { sourceUrl = "https://i.postimg.cc/65yws9mR/Screenshot-2024-02-02-at-6-20-49-PM.png"},
+            type = PopupMediaType.Image
+        )
+    )
+}

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/util/AsyncImage.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/util/AsyncImage.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.popup.internal.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil.imageLoader
+import coil.request.ImageRequest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Loads an image asynchronously using the [ImageGetter].
+ */
+@Composable
+internal fun MediaImage(
+    imageGetter: ImageGetter,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    contentDescription: String,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null
+) {
+    val context = LocalContext.current
+    LaunchedEffect(imageGetter) {
+        imageGetter.get(context)
+    }
+    val painter = imageGetter.image.value
+    Image(
+        painter = painter,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter
+    )
+}
+
+/**
+ * A model to asynchronously load the image. Once the loading is complete
+ * the loaded image is presented via [image] State.
+ *
+ * @param placeholder the placeholder image to show until the loading is complete.
+ * @param getter a suspending lambda to get the image
+ */
+internal open class ImageGetter(
+    placeholder: Painter,
+    private val getter: suspend (Context) -> Bitmap
+) {
+    private val _image: MutableState<Painter> = mutableStateOf(placeholder)
+    val image: State<Painter> = _image
+
+    suspend fun get(context: Context) {
+        _image.value = BitmapPainter(getter(context).asImageBitmap())
+    }
+}
+
+internal class RemoteImageGetter(
+    placeholder: Painter,
+    private val url: String
+): ImageGetter(placeholder, getter = { context ->
+    withContext(Dispatchers.IO) {
+        val request = ImageRequest.Builder(context)
+            .data(url)
+            .crossfade(true)
+            .build()
+        (context.imageLoader.execute(request).drawable as? BitmapDrawable)?.bitmap
+            ?: throw IllegalStateException("couldn't load image at $url")
+    }
+})
+
+//
+//internal class ChartImageGetter(
+//    media: PopupMedia,
+//    chartParameters: ChartImageParameters,
+//    placeholder: Painter,
+//    private val url: String
+//): ImageGetter(placeholder, getter = { _ ->
+//    media.generateChartAsync(chartParameters).getOrThrow().image
+//})

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/util/PopupMediaImageLoader.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/util/PopupMediaImageLoader.kt
@@ -19,63 +19,26 @@ package com.arcgismaps.toolkit.popup.internal.util
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
-import androidx.compose.foundation.Image
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.DefaultAlpha
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import coil.imageLoader
 import coil.request.ImageRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * Loads an image asynchronously using the [ImageGetter].
- */
-@Composable
-internal fun MediaImage(
-    imageGetter: ImageGetter,
-    modifier: Modifier = Modifier,
-    alignment: Alignment = Alignment.Center,
-    contentScale: ContentScale = ContentScale.Fit,
-    contentDescription: String,
-    alpha: Float = DefaultAlpha,
-    colorFilter: ColorFilter? = null
-) {
-    val context = LocalContext.current
-    LaunchedEffect(imageGetter) {
-        imageGetter.get(context)
-    }
-    val painter = imageGetter.image.value
-    Image(
-        painter = painter,
-        contentDescription = contentDescription,
-        modifier = modifier,
-        alignment = alignment,
-        contentScale = contentScale,
-        alpha = alpha,
-        colorFilter = colorFilter
-    )
-}
-
-/**
- * A model to asynchronously load the image. Once the loading is complete
- * the loaded image is presented via [image] State.
+ * A model to asynchronously acquire a Popup Media image. This class provides an abstraction layer
+ * above Chart and remote URL images. Once the target image is acquired it is presented via [image]
+ * State.
  *
- * @param placeholder the placeholder image to show until the loading is complete.
- * @param getter a suspending lambda to get the image
+ * @param placeholder the placeholder image to show until the intended image is acquired.
+ * @param getter a suspending lambda to acquire the image
  */
-internal open class ImageGetter(
+internal sealed class PopupMediaImageLoader(
     placeholder: Painter,
     private val getter: suspend (Context) -> Bitmap
 ) {
@@ -87,10 +50,10 @@ internal open class ImageGetter(
     }
 }
 
-internal class RemoteImageGetter(
+internal class RemoteImageLoader(
     placeholder: Painter,
     private val url: String
-): ImageGetter(placeholder, getter = { context ->
+): PopupMediaImageLoader(placeholder, getter = { context ->
     withContext(Dispatchers.IO) {
         val request = ImageRequest.Builder(context)
             .data(url)
@@ -102,11 +65,10 @@ internal class RemoteImageGetter(
 })
 
 //
-//internal class ChartImageGetter(
+//internal class ChartImageLoader(
 //    media: PopupMedia,
 //    chartParameters: ChartImageParameters,
-//    placeholder: Painter,
-//    private val url: String
+//    placeholder: Painter
 //): ImageGetter(placeholder, getter = { _ ->
 //    media.generateChartAsync(chartParameters).getOrThrow().image
 //})


### PR DESCRIPTION
This PR provides a MediaPopupElement composable and support for PopupMedia of type Image (Charts will be supported next).

Coil is used for image loading though it is abstracted to support asynchronous loading of charts through core, so the use of coil is a bit indirect relative to what might be expected.

Images are displayed at 276x225 with title and caption overlaid.