### PR TITLE
`Forms`: Fix crash on open attachment

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -16,8 +16,10 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.text.format.Formatter
+import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -236,7 +238,12 @@ internal fun AttachmentTile(
                                 state.contentType
                             )
                             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                            context.startActivity(intent)
+                            try {
+                                context.startActivity(intent)
+                            } catch (e: ActivityNotFoundException) {
+                                // show a toast if there is no app to open the file type
+                                Toast.makeText(context, R.string.no_app_found, Toast.LENGTH_SHORT).show()
+                            }
                         }
                     }
                 }

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -97,4 +97,5 @@
     <string name="name">Name</string>
     <string name="add_file">Add From Files</string>
     <string name="attachment_error">Error Adding Attachment</string>
+    <string name="no_app_found">No application found to open this file type.</string>
 </resources>


### PR DESCRIPTION
### Summary of changes

- Wraps the `startActivity` in a try-catch to catch an exception when no app is found when the attachment is found.