### PR TITLE
`Forms` : Consume latest api

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,4 +54,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.5.0
-sdkBuildNumber=4244
+sdkBuildNumber=4253

--- a/gradle.properties
+++ b/gradle.properties
@@ -54,4 +54,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.5.0
-sdkBuildNumber=4253
+sdkBuildNumber=4259

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -180,17 +180,17 @@ class MapViewModel @Inject constructor(
         }
         // set the state to committing with the errors if any
         _uiState.value = UIState.Committing(
-            featureForm = state.featureForm,
+            featureForm = featureForm,
             errors = errors
         )
         // if there are no errors then update the feature
         return if (errors.isEmpty()) {
-            val feature = state.featureForm.feature
+            val feature = featureForm.feature
             val serviceFeatureTable =
                 feature.featureTable as? ServiceFeatureTable ?: return Result.failure(
                     IllegalStateException("cannot save feature edit without a ServiceFeatureTable")
                 )
-            val result = serviceFeatureTable.updateFeature(feature).map {
+            val result = featureForm.finishEditing().map {
                 serviceFeatureTable.serviceGeodatabase?.let { database ->
                     return@let if (database.serviceInfo?.canUseServiceGeodatabaseApplyEdits == true) {
                         database.applyEdits()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -360,6 +360,10 @@ internal fun rememberStates(
             else -> {}
         }
     }
+    if (form.defaultAttachmentsElement != null) {
+        val state = rememberAttachmentElementState(form, form.defaultAttachmentsElement!!)
+        states.add(form.defaultAttachmentsElement!!, state)
+    }
     return states
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -276,7 +276,7 @@ internal class FormAttachmentState(
 
     /**
      * The name of the attachment. Setting the name will update the [FormAttachment.name] property.
-     * This is backed by a [MutableState] and can be observed by the composable.
+     * This is backed by a [MutableState] and can be observed by the composition.
      */
     var name : String
         get() = _name.value

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -17,6 +17,7 @@
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 import android.net.Uri
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -26,6 +27,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -39,11 +41,13 @@ import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.Photo
 import androidx.compose.material.icons.rounded.PhotoCamera
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -58,12 +62,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import com.arcgismaps.mapping.featureforms.FormAttachmentType
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
@@ -372,7 +378,8 @@ internal fun GalleryPicker(
 @Composable
 internal fun FilePicker(
     allowedMimeTypes: List<String>,
-    onFileSelected: (Uri?) -> Unit
+    onFileSelected: (Uri?) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     var hasLaunched by rememberSaveable {
         mutableStateOf(false)
@@ -380,11 +387,18 @@ internal fun FilePicker(
     val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
         onFileSelected(it)
     }
+    Log.e("TAG", "FilePicker: back", )
+//    Surface(modifier = modifier.fillMaxSize(), color = Color.Green) {
+//        CircularProgressIndicator()
+//    }
+    Dialog(onDismissRequest = { /*TODO*/ }) {
+        CircularProgressIndicator()
+    }
     LaunchedEffect(Unit) {
-        if (!hasLaunched) {
-            hasLaunched = true
-            launcher.launch(allowedMimeTypes.toTypedArray())
-        }
+//        if (!hasLaunched) {
+//            hasLaunched = true
+//            launcher.launch(allowedMimeTypes.toTypedArray())
+//        }
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -17,7 +17,6 @@
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 import android.net.Uri
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -27,7 +26,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -41,13 +39,11 @@ import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.Photo
 import androidx.compose.material.icons.rounded.PhotoCamera
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -62,14 +58,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import com.arcgismaps.mapping.featureforms.FormAttachmentType
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
@@ -378,8 +372,7 @@ internal fun GalleryPicker(
 @Composable
 internal fun FilePicker(
     allowedMimeTypes: List<String>,
-    onFileSelected: (Uri?) -> Unit,
-    modifier: Modifier = Modifier
+    onFileSelected: (Uri?) -> Unit
 ) {
     var hasLaunched by rememberSaveable {
         mutableStateOf(false)
@@ -387,18 +380,11 @@ internal fun FilePicker(
     val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
         onFileSelected(it)
     }
-    Log.e("TAG", "FilePicker: back", )
-//    Surface(modifier = modifier.fillMaxSize(), color = Color.Green) {
-//        CircularProgressIndicator()
-//    }
-    Dialog(onDismissRequest = { /*TODO*/ }) {
-        CircularProgressIndicator()
-    }
     LaunchedEffect(Unit) {
-//        if (!hasLaunched) {
-//            hasLaunched = true
-//            launcher.launch(allowedMimeTypes.toTypedArray())
-//        }
+        if (!hasLaunched) {
+            hasLaunched = true
+            launcher.launch(allowedMimeTypes.toTypedArray())
+        }
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -196,7 +196,7 @@ internal fun AttachmentTile(
                     ),
                     onClick = {
                         showContextMenu = false
-                        scope.launch { state.deleteAttachment() }
+                        state.deleteAttachment()
                     })
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -209,10 +209,8 @@ internal fun AttachmentTile(
                     delay(configuration.longPressTimeoutMillis)
                     wasALongPress = true
                     // handle long press
-                    if (loadStatus is LoadStatus.Loaded) {
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        showContextMenu = true
-                    }
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    showContextMenu = true
                 }
 
                 is PressInteraction.Release -> {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -61,7 +61,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -99,7 +98,6 @@ import com.arcgismaps.toolkit.featureforms.internal.utils.DialogType
 import com.arcgismaps.toolkit.featureforms.internal.utils.LocalDialogRequester
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import java.io.File
 
 @Composable
@@ -113,7 +111,6 @@ internal fun AttachmentTile(
     val haptic = LocalHapticFeedback.current
     var showContextMenu by remember { mutableStateOf(false) }
     val dialogRequester = LocalDialogRequester.current
-    val scope = rememberCoroutineScope()
     val context = LocalContext.current
     Surface(
         onClick = {},

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/AttachmentsFileProvider.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/AttachmentsFileProvider.kt
@@ -27,15 +27,16 @@ internal class AttachmentsFileProvider :
     companion object {
 
         private const val AUTHORITY_BASE = "com.arcgismaps.toolkit.featureforms.attachmentsfileprovider"
-        private const val FILE_PROVIDER_PATH = "feature_forms_attachments"
 
         fun createTempFileWithUri(prefix: String, suffix: String, context: Context): Uri {
             // authority is unique, which uses the package name + base authority name
             // to avoid conflicts with other apps using the same library
             val authority = "${context.packageName}.$AUTHORITY_BASE"
-            val directory = File(context.cacheDir, FILE_PROVIDER_PATH)
+            val directory = File(context.cacheDir.absolutePath)
             directory.mkdirs()
             val file =  File.createTempFile(prefix, suffix, directory)
+            // delete the temp file when no process is using it
+            file.deleteOnExit()
             return getUriForFile(
                 context,
                 authority,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -52,12 +52,10 @@ import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.D
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerInput
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerStyle
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.rememberDateTimePickerState
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.time.Instant
 
 /**
@@ -303,7 +301,7 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
             }
             FilePicker(allowedMimeTypes = allowedMimeTypes) { uri ->
                 if (uri != null) {
-                    scope.launch(Dispatchers.IO) {
+                    scope.launch {
                         val contentType = context.contentResolver.getType(uri) ?: run {
                             Toast.makeText(context, R.string.attachment_error, Toast.LENGTH_SHORT)
                                 .show()
@@ -315,18 +313,16 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
                         var name =
                             "${state.attachments.getNewAttachmentNameForContentType(contentType)}.$extension"
                         context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-                                cursor.moveToFirst()
-                                val nameIndex =
-                                    cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                                // use the name from the uri if available
-                                cursor.getStringOrNull(nameIndex)?.let {
-                                    name = it
-                                }
+                            cursor.moveToFirst()
+                            val nameIndex =
+                                cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                            // use the name from the uri if available
+                            cursor.getStringOrNull(nameIndex)?.let {
+                                name = it
                             }
+                        }
                         context.readBytes(uri)?.let { data ->
-                            withContext(Dispatchers.Main) {
-                                state.addAttachment(name, contentType, data)
-                            }
+                            state.addAttachment(name, contentType, data)
                         }
                     }
                 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -301,16 +301,12 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
                 dialogRequester.dismissDialog()
                 return
             }
-            FilePicker(allowedMimeTypes = allowedMimeTypes)
-            { uri ->
+            FilePicker(allowedMimeTypes = allowedMimeTypes) { uri ->
                 if (uri != null) {
                     scope.launch(Dispatchers.IO) {
                         val contentType = context.contentResolver.getType(uri) ?: run {
-                            Toast.makeText(
-                                context,
-                                R.string.attachment_error,
-                                Toast.LENGTH_SHORT
-                            ).show()
+                            Toast.makeText(context, R.string.attachment_error, Toast.LENGTH_SHORT)
+                                .show()
                             return@launch
                         }
                         val extension =
@@ -318,8 +314,7 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
                         // use a default name
                         var name =
                             "${state.attachments.getNewAttachmentNameForContentType(contentType)}.$extension"
-                        context.contentResolver.query(uri, null, null, null, null)
-                            ?.use { cursor ->
+                        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
                                 cursor.moveToFirst()
                                 val nameIndex =
                                     cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
@@ -334,8 +329,8 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
                             }
                         }
                     }
-                    dialogRequester.dismissDialog()
                 }
+                dialogRequester.dismissDialog()
             }
         }
 

--- a/toolkit/featureforms/src/main/res/xml/feature_forms_attachments.xml
+++ b/toolkit/featureforms/src/main/res/xml/feature_forms_attachments.xml
@@ -19,5 +19,5 @@
 <paths>
     <cache-path
         name="feature_forms_attachments"
-        path="feature_forms_attachments/" />
+        path="." />
 </paths>


### PR DESCRIPTION
https://devtopia.esri.com/runtime/apollo/issues/707

## Summary

- `FeatureForm.defaultAttachmentsElement` is used to show an `AttachmentsFormElement` if the feature supports attachments. This is to support attachments outside the form authoring experience.
-  Updated add, delete and rename attachment to be non-suspending functions.
- Rename now happens through the `FormAttachment.name` property and hence the `FormAttachmentState.name` is now an observable property backed by a `MutableState`.
- Loading an attachment now doesn't need to write the data into a new file. Instead, the `FormAttachment.filePath` is used directly to view the file. To support this, the `cacheDir` is used in the `FileProvider` since this is where core stores the loaded attachements.
- Rename and Delete context menu can now be triggered with a long press without having to load the attachment.
- Discarding and submitting attachments now works with the use of the new `FeatureForm.finishEditsAsync` call.
- Loading progress animation is now visible when trying to add an attachment via a file picker or the gallery.