### PR TITLE
`Forms` Add attachment limit

### DIFF
--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -98,4 +98,5 @@
     <string name="add_file">Add From Files</string>
     <string name="attachment_error">Error Adding Attachment</string>
     <string name="no_app_found">No application found to open this file type.</string>
+    <string name="attachment_too_large">The File is too large. Please add a file less than 50 MB.</string>
 </resources>


### PR DESCRIPTION
### Issue

https://devtopia.esri.com/runtime/apollo/issues/706

### Summary of changes

- Limits attachment size to 50 MB to avoid any out of memory errors.
- Guards against `OutOfMemoryError` as a last resort in case the application memory allocation is full and no new memory can be allocated to load and add an attachment. A recovery is not guaranteed in case of this error.