### PR TITLE
`Forms` : Fix FormStateCollection get operator

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
@@ -91,9 +91,10 @@ private class MutableFormStateCollectionImpl : MutableFormStateCollection {
         entries.add(EntryImpl(formElement, state))
     }
 
-    override operator fun get(formElement: FormElement): FormElementState? = get(formElement.hashCode())
+    override operator fun get(formElement: FormElement): FormElementState? =
+        get(formElement.hashCode())
 
-    override fun get(id: Int): FormElementState? {
+    override operator fun get(id: Int): FormElementState? {
         entries.forEach { entry ->
             when (entry.state) {
                 is BaseGroupState -> {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
@@ -60,14 +60,6 @@ internal interface MutableFormStateCollection : FormStateCollection {
      * @param state the [FormElementState] to add.
      */
     fun add(formElement: FormElement, state: FormElementState)
-
-    /**
-     * Provides the bracket operator to the collection.
-     *
-     * @param formElement the search for in the collection
-     * @return the [FormElementState] associated with the formElement, or null if none.
-     */
-    override operator fun get(formElement: FormElement): FormElementState?
 }
 
 /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
@@ -91,11 +91,27 @@ private class MutableFormStateCollectionImpl : MutableFormStateCollection {
         entries.add(EntryImpl(formElement, state))
     }
 
-    override operator fun get(formElement: FormElement): FormElementState? =
-        entries.firstOrNull { it.formElement == formElement }?.state
+    override operator fun get(formElement: FormElement): FormElementState? = get(formElement.hashCode())
 
-    override fun get(id: Int): FormElementState? =
-        entries.firstOrNull { it.formElement.hashCode() == id }?.state
+    override fun get(id: Int): FormElementState? {
+        entries.forEach { entry ->
+            when (entry.state) {
+                is BaseGroupState -> {
+                    val groupState = entry.state as? BaseGroupState
+                    groupState?.fieldStates?.forEach { childEntry ->
+                        if (childEntry.state.id == id) {
+                            return childEntry.state
+                        }
+                    }
+                }
+
+                else -> if (entry.state.id == id) {
+                    return entry.state
+                }
+            }
+        }
+        return null
+    }
 
     /**
      * Default implementation for a [FormStateCollection.Entry].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FormStateCollection.kt
@@ -90,8 +90,8 @@ private class MutableFormStateCollectionImpl : MutableFormStateCollection {
         entries.forEach { entry ->
             when (entry.state) {
                 is BaseGroupState -> {
-                    val groupState = entry.state as? BaseGroupState
-                    groupState?.fieldStates?.forEach { childEntry ->
+                    val groupState = entry.state as BaseGroupState
+                    groupState.fieldStates.forEach { childEntry ->
                         if (childEntry.state.id == id) {
                             return childEntry.state
                         }


### PR DESCRIPTION
### Summary of changes

The `FormStateCollection.get(id : Int)` operator function does not check if the `id` is part of a `BaseGroupState.fieldStates`. Hence, if a `FieldFormElement` and its `BaseFieldState` are part of a `GroupFormElement`, then the get operator returns null.

This PR fixes the above bug.