### PR TITLE
`Popup:` Fixes TextPopupElement composable shifting in size when coming back into visibility

### DIFF
--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
@@ -153,6 +153,7 @@ private fun PopupBody(popupState: PopupState, onFileClicked: (ViewableFile?) -> 
             val element = entry.popupElement
             when (element) {
                 is TextPopupElement -> {
+                    // a contentType is needed to reuse the TextPopupElement composable inside a LazyColumn
                     item(contentType = TextPopupElement::class.java) {
                         TextPopupElement(
                             entry.state as TextElementState

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
@@ -18,6 +18,7 @@
 
 package com.arcgismaps.toolkit.popup
 
+import android.webkit.WebView
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -150,35 +151,42 @@ private fun PopupBody(popupState: PopupState, onFileClicked: (ViewableFile?) -> 
     ) {
         states.forEach { entry ->
             val element = entry.popupElement
-            item {
-                when (element) {
-                    is TextPopupElement -> {
+            when (element) {
+                is TextPopupElement -> {
+                    item(contentType = TextPopupElement::class.java) {
                         TextPopupElement(
                             entry.state as TextElementState
                         )
                     }
+                }
 
-                    is AttachmentsPopupElement -> {
+                is AttachmentsPopupElement -> {
+                    item(contentType = AttachmentsPopupElement::class.java) {
                         AttachmentsPopupElement(
                             state = entry.state as AttachmentsElementState,
-                            onFileClicked)
+                            onFileClicked
+                        )
                     }
+                }
 
-                    is FieldsPopupElement -> {
+                is FieldsPopupElement -> {
+                    item(contentType = FieldsPopupElement::class.java) {
                         FieldsPopupElement(
                             entry.state as FieldsElementState,
                         )
                     }
+                }
 
-                    is MediaPopupElement -> {
+                is MediaPopupElement -> {
+                    item(contentType = MediaPopupElement::class.java) {
                         MediaPopupElement(
                             entry.state as MediaElementState
                         )
                     }
+                }
 
-                    else -> {
-                        // other popup elements are not created
-                    }
+                else -> {
+                    // other popup elements are not created
                 }
             }
         }

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/textelement/TextPopupElement.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/textelement/TextPopupElement.kt
@@ -81,7 +81,9 @@ private fun HTML(content: String) {
             val completeHtml = "$header$headStyle<html>${content.trim()}</html>"
             loadDataWithBaseURL(null, completeHtml, "text/html", "UTF-8", null)
         }
-    })
+    },
+        onReset = {}
+    )
 }
 
 /**

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/textelement/TextPopupElement.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/textelement/TextPopupElement.kt
@@ -82,6 +82,9 @@ private fun HTML(content: String) {
             loadDataWithBaseURL(null, completeHtml, "text/html", "UTF-8", null)
         }
     },
+        // By default, AndroidViews aren't reused in a lazy list. This means that the `HTML` composable instance will
+        // get discarded and recreated every time. By defining an `onReset` lambda, we can ensure tha the AndroidView will
+        // be reused when the composition hierarchy changes.
         onReset = {}
     )
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

<!-- link to design, if applicable -->

### Description:
- When a TextPopupElement is scrolled out of view and back into view, its width is recalculated multiple times and it can cause it to push other elements out of view.