### PR TITLE
Update TapLocation screen

### DIFF
--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
@@ -27,11 +27,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetValue
@@ -48,8 +49,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.geoviewcompose.Callout
@@ -139,37 +138,66 @@ fun CalloutOptions(
             )
         }
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceAround) {
-            OutlinedTextField(
+            OffsetDropDownMenu(
                 modifier = Modifier.weight(1f),
-                value = offset.x.toString(),
-                onValueChange = { value ->
-                    viewModel.setOffset(Offset(value.toFloat(), offset.y))
-                },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Decimal,
-                    imeAction = ImeAction.Done
-                ),
-                label = { Text("X-Axis offset") },
-                textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.End)
+                offsetValue = offset.x,
+                offsetName = "X-Axis offset",
+                onOffsetSelected = { xOffset ->
+                    viewModel.setOffset(Offset(xOffset, offset.y))
+                }
             )
             Spacer(modifier = Modifier.size(10.dp))
-            OutlinedTextField(
+            OffsetDropDownMenu(
                 modifier = Modifier.weight(1f),
-                value = offset.y.toString(),
-                onValueChange = { value ->
-                    viewModel.setOffset(Offset(offset.x, value.toFloat()))
-                },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Decimal,
-                    imeAction = ImeAction.Done
-                ),
-                label = { Text("Y-Axis offset") },
-                textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.End)
+                offsetValue = offset.y,
+                offsetName = "Y-Axis offset",
+                onOffsetSelected = { yOffset ->
+                    viewModel.setOffset(Offset(offset.x, yOffset))
+                }
             )
         }
 
         Button(onClick = viewModel::clearMapPoint) {
             Text(text = "Clear Tap Location")
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OffsetDropDownMenu(
+    modifier: Modifier,
+    offsetValue: Float,
+    offsetName: String,
+    onOffsetSelected: (Float) -> Unit,
+) {
+    val offsetsItems = listOf(-100.0, -50.0, -25.0, 0.0, 25.0, 50.0, 100.0)
+    var isXOffsetsExpanded by rememberSaveable { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        modifier = modifier,
+        expanded = isXOffsetsExpanded,
+        onExpandedChange = { isXOffsetsExpanded = !isXOffsetsExpanded }
+    ) {
+        OutlinedTextField(
+            modifier = Modifier.menuAnchor(),
+            value = offsetValue.toString(),
+            readOnly = true,
+            onValueChange = { },
+            label = { Text(offsetName) },
+            textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.End)
+        )
+        ExposedDropdownMenu(
+            expanded = isXOffsetsExpanded,
+            onDismissRequest = { isXOffsetsExpanded = false }
+        ) {
+            offsetsItems.forEach {
+                DropdownMenuItem(
+                    text = { Text(it.toString()) },
+                    onClick = {
+                        onOffsetSelected(it.toFloat())
+                        isXOffsetsExpanded = false
+                    })
+            }
         }
     }
 }

--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
@@ -171,12 +171,12 @@ fun OffsetDropDownMenu(
     offsetName: String,
     onOffsetSelected: (Float) -> Unit,
 ) {
-    val offsetsItems = listOf(-100.0, -50.0, -25.0, 0.0, 25.0, 50.0, 100.0)
-    var isXOffsetsExpanded by rememberSaveable { mutableStateOf(false) }
+    val offsetItems = listOf(-100.0, -50.0, -25.0, 0.0, 25.0, 50.0, 100.0)
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
     ExposedDropdownMenuBox(
         modifier = modifier,
-        expanded = isXOffsetsExpanded,
-        onExpandedChange = { isXOffsetsExpanded = !isXOffsetsExpanded }
+        expanded = isExpanded,
+        onExpandedChange = { isExpanded = !isExpanded }
     ) {
         OutlinedTextField(
             modifier = Modifier.menuAnchor(),
@@ -187,15 +187,15 @@ fun OffsetDropDownMenu(
             textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.End)
         )
         ExposedDropdownMenu(
-            expanded = isXOffsetsExpanded,
-            onDismissRequest = { isXOffsetsExpanded = false }
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false }
         ) {
-            offsetsItems.forEach {
+            offsetItems.forEach {
                 DropdownMenuItem(
                     text = { Text(it.toString()) },
                     onClick = {
                         onOffsetSelected(it.toFloat())
-                        isXOffsetsExpanded = false
+                        isExpanded = false
                     })
             }
         }

--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.input.ImeAction
@@ -81,17 +82,11 @@ fun TapLocationScreen(viewModel: MapViewModel) {
                 calloutVisibility = calloutVisibility,
                 isCalloutRotationEnabled = rotateOffsetWithGeoView,
                 offset = offset,
+                viewModel = viewModel,
                 onVisibilityToggled = { calloutVisibility = !calloutVisibility },
                 onCalloutOffsetRotationToggled = {
                     rotateOffsetWithGeoView = !rotateOffsetWithGeoView
                 },
-                onXAxisOffsetChanged = {
-                    viewModel.setOffset(Offset(it, offset.y))
-                },
-                onYAxisOffsetChanged = {
-                    viewModel.setOffset(Offset(offset.x, it))
-                },
-                onClearTapLocation = viewModel::clearMapPoint
             )
         },
         scaffoldState = bottomSheetScaffoldState,
@@ -124,13 +119,11 @@ fun CalloutOptions(
     calloutVisibility: Boolean,
     isCalloutRotationEnabled: Boolean,
     offset: Offset,
+    viewModel: MapViewModel,
     onVisibilityToggled: () -> Unit,
     onCalloutOffsetRotationToggled: () -> Unit,
-    onXAxisOffsetChanged: (Float) -> Unit,
-    onYAxisOffsetChanged: (Float) -> Unit,
-    onClearTapLocation: () -> Unit
 ) {
-    Column(Modifier.padding(8.dp)) {
+    Column(Modifier.padding(8.dp), horizontalAlignment = Alignment.CenterHorizontally) {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             Text(text = "Show Callout")
             Checkbox(
@@ -145,13 +138,12 @@ fun CalloutOptions(
                 onCheckedChange = { onCalloutOffsetRotationToggled() }
             )
         }
-
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceAround) {
             OutlinedTextField(
                 modifier = Modifier.weight(1f),
                 value = offset.x.toString(),
                 onValueChange = { value ->
-                    onXAxisOffsetChanged(value.toFloat())
+                    viewModel.setOffset(Offset(value.toFloat(), offset.y))
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Decimal,
@@ -165,7 +157,7 @@ fun CalloutOptions(
                 modifier = Modifier.weight(1f),
                 value = offset.y.toString(),
                 onValueChange = { value ->
-                    onYAxisOffsetChanged(value.toFloat())
+                    viewModel.setOffset(Offset(offset.x, value.toFloat()))
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Decimal,
@@ -176,7 +168,7 @@ fun CalloutOptions(
             )
         }
 
-        Button(onClick =  onClearTapLocation) {
+        Button(onClick = viewModel::clearMapPoint) {
             Text(text = "Clear Tap Location")
         }
     }

--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalTextStyle
@@ -76,7 +77,7 @@ fun TapLocationScreen(viewModel: MapViewModel) {
 
     BottomSheetScaffold(
         sheetContent = {
-            CalloutOptionsBox(
+            CalloutOptions(
                 calloutVisibility = calloutVisibility,
                 isCalloutRotationEnabled = rotateOffsetWithGeoView,
                 offset = offset,
@@ -89,7 +90,8 @@ fun TapLocationScreen(viewModel: MapViewModel) {
                 },
                 onYAxisOffsetChanged = {
                     viewModel.setOffset(Offset(offset.x, it))
-                }
+                },
+                onClearTapLocation = viewModel::clearMapPoint
             )
         },
         scaffoldState = bottomSheetScaffoldState,
@@ -99,7 +101,6 @@ fun TapLocationScreen(viewModel: MapViewModel) {
             arcGISMap = viewModel.arcGISMap,
             graphicsOverlays = remember { listOf(viewModel.tapLocationGraphicsOverlay) },
             onSingleTapConfirmed = viewModel::setMapPoint,
-            onLongPress = { viewModel.clearMapPoint() },
             content = if (mapPoint != null && calloutVisibility) {
                 {
                     Callout(
@@ -119,14 +120,15 @@ fun TapLocationScreen(viewModel: MapViewModel) {
 }
 
 @Composable
-fun CalloutOptionsBox(
+fun CalloutOptions(
     calloutVisibility: Boolean,
     isCalloutRotationEnabled: Boolean,
     offset: Offset,
     onVisibilityToggled: () -> Unit,
     onCalloutOffsetRotationToggled: () -> Unit,
     onXAxisOffsetChanged: (Float) -> Unit,
-    onYAxisOffsetChanged: (Float) -> Unit
+    onYAxisOffsetChanged: (Float) -> Unit,
+    onClearTapLocation: () -> Unit
 ) {
     Column(Modifier.padding(8.dp)) {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
@@ -172,6 +174,10 @@ fun CalloutOptionsBox(
                 label = { Text("Y-Axis offset") },
                 textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.End)
             )
+        }
+
+        Button(onClick =  onClearTapLocation) {
+            Text(text = "Clear Tap Location")
         }
     }
 }

--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/TapLocationScreen.kt
@@ -27,12 +27,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetValue
@@ -49,6 +48,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.geoviewcompose.Callout
@@ -138,66 +139,37 @@ fun CalloutOptions(
             )
         }
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceAround) {
-            OffsetDropDownMenu(
+            OutlinedTextField(
                 modifier = Modifier.weight(1f),
-                offsetValue = offset.x,
-                offsetName = "X-Axis offset",
-                onOffsetSelected = { xOffset ->
-                    viewModel.setOffset(Offset(xOffset, offset.y))
-                }
+                value = offset.x.toString(),
+                onValueChange = { value ->
+                    viewModel.setOffset(Offset(value.toFloat(), offset.y))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Decimal,
+                    imeAction = ImeAction.Done
+                ),
+                label = { Text("X-Axis offset (px)") },
+                textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.End)
             )
             Spacer(modifier = Modifier.size(10.dp))
-            OffsetDropDownMenu(
+            OutlinedTextField(
                 modifier = Modifier.weight(1f),
-                offsetValue = offset.y,
-                offsetName = "Y-Axis offset",
-                onOffsetSelected = { yOffset ->
-                    viewModel.setOffset(Offset(offset.x, yOffset))
-                }
+                value = offset.y.toString(),
+                onValueChange = { value ->
+                    viewModel.setOffset(Offset(offset.x, value.toFloat()))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Decimal,
+                    imeAction = ImeAction.Done
+                ),
+                label = { Text("Y-Axis offset (px)") },
+                textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.End)
             )
         }
 
         Button(onClick = viewModel::clearMapPoint) {
             Text(text = "Clear Tap Location")
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun OffsetDropDownMenu(
-    modifier: Modifier,
-    offsetValue: Float,
-    offsetName: String,
-    onOffsetSelected: (Float) -> Unit,
-) {
-    val offsetItems = listOf(-100.0, -50.0, -25.0, 0.0, 25.0, 50.0, 100.0)
-    var isExpanded by rememberSaveable { mutableStateOf(false) }
-    ExposedDropdownMenuBox(
-        modifier = modifier,
-        expanded = isExpanded,
-        onExpandedChange = { isExpanded = !isExpanded }
-    ) {
-        OutlinedTextField(
-            modifier = Modifier.menuAnchor(),
-            value = offsetValue.toString(),
-            readOnly = true,
-            onValueChange = { },
-            label = { Text(offsetName) },
-            textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.End)
-        )
-        ExposedDropdownMenu(
-            expanded = isExpanded,
-            onDismissRequest = { isExpanded = false }
-        ) {
-            offsetItems.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.toString()) },
-                    onClick = {
-                        onOffsetSelected(it.toFloat())
-                        isExpanded = false
-                    })
-            }
         }
     }
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: `kotlin/issues/4115`

<!-- link to design, if applicable -->

### Description:

Update the TapLocationScreen to place the `CalloutOptionsBox` in a dismissable BottomSheet

### Summary of changes:

- Added a bottom sheet container
- Updated the calloutVisibility to be set to `true` by default
- Optimized the CalloutOptionsBox layout to take up less space 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  