### PR TITLE
`Forms` : Validation for calculated fields

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -167,7 +167,7 @@ class MapViewModel @Inject constructor(
         featureForm.validationErrors.value.forEach { entry ->
             entry.value.forEach { error ->
                 featureForm.elements.getFormElement(entry.key)?.let { formElement ->
-                    if (formElement.isEditable.value) {
+                    if (formElement.isEditable.value || formElement.hasValueExpression) {
                         errors.add(
                             ErrorInfo(
                                 formElement.label,

--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -133,7 +133,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/FeatureFormDefaults
 	public final fun groupElementTypography (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lcom/arcgismaps/toolkit/featureforms/theme/GroupElementTypography;
 	public final fun radioButtonFieldColors-oq7We08 (JJJJJJJJLandroidx/compose/runtime/Composer;II)Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldColors;
 	public final fun radioButtonFieldTypography (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldTypography;
-	public final fun readOnlyFieldColors-RGew2ao (JJJLandroidx/compose/runtime/Composer;II)Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;
+	public final fun readOnlyFieldColors-ro_MJ88 (JJJJLandroidx/compose/runtime/Composer;II)Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;
 	public final fun readOnlyFieldTypography (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldTypography;
 	public final fun typography (Lcom/arcgismaps/toolkit/featureforms/theme/EditableTextFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/GroupElementTypography;Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldTypography;Landroidx/compose/runtime/Composer;II)Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;
 }
@@ -223,9 +223,11 @@ public final class com/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors
 	public final fun component1-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
 	public final fun component3-0d7_KjU ()J
-	public final fun copy-ysEtTa8 (JJJ)Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;
-	public static synthetic fun copy-ysEtTa8$default (Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;JJJILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;
+	public final fun component4-0d7_KjU ()J
+	public final fun copy-jRlVdoo (JJJJ)Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;
+	public static synthetic fun copy-jRlVdoo$default (Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;JJJJILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorSupportingTextColor-0d7_KjU ()J
 	public final fun getLabelColor-0d7_KjU ()J
 	public final fun getSupportingTextColor-0d7_KjU ()J
 	public final fun getTextColor-0d7_KjU ()J

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -82,7 +82,8 @@ apiValidation {
         "com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.ComposableSingletons\$DateTimePickerKt",
         "com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.date.ComposableSingletons\$DatePickerKt",
         "com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.time.ComposableSingletons\$TimePickerKt",
-        "com.arcgismaps.toolkit.featureforms.internal.components.formelement.ComposableSingletons\$AttachmentFormElementKt",
+        "com.arcgismaps.toolkit.featureforms.internal.components.attachment.ComposableSingletons\$AttachmentFormElementKt",
+        "com.arcgismaps.toolkit.featureforms.internal.components.attachment.ComposableSingletons\$AttachmentTileKt",
         "com.arcgismaps.toolkit.featureforms.internal.components.formelement.ComposableSingletons\$GroupElementKt"
     )
     

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/CalculatedFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/CalculatedFieldTests.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertContentDescriptionContains
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.arcgismaps.ArcGISEnvironment
+import com.arcgismaps.data.ArcGISFeature
+import com.arcgismaps.data.QueryParameters
+import com.arcgismaps.mapping.ArcGISMap
+import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.layers.FeatureLayer
+import junit.framework.TestCase
+import kotlinx.coroutines.test.runTest
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+
+class CalculatedFieldTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /**
+     * Test case 9.1:
+     * Given a `FieldFormElement` with `hasValueExpression` set to `true` and validation errors
+     * When the `FeatureForm` is displayed
+     * Then the appropriate validation error messages are displayed
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-91-test-validation-on-elements-with-expressions
+     */
+    @Test
+    fun testValidationForCalculatedFields() = runTest {
+        composeTestRule.setContent {
+            MaterialTheme {
+                FeatureForm(featureForm = featureForm)
+            }
+        }
+        val contentDescription = "calculated field"
+        var field = composeTestRule.onNodeWithText("singleCharacterString")
+        field.assertIsDisplayed()
+        field.assertTextContains("Value must be 1 character")
+        field.assertContentDescriptionContains(contentDescription)
+
+        field = composeTestRule.onNodeWithText("lengthRangeString")
+        field.assertIsDisplayed()
+        field.assertTextContains("Value must be 2 to 5 characters")
+        field.assertContentDescriptionContains(contentDescription)
+
+        field = composeTestRule.onNodeWithText("maxExceededString")
+        field.assertIsDisplayed()
+        field.assertTextContains("Maximum 5 characters")
+        field.assertContentDescriptionContains(contentDescription)
+
+        field = composeTestRule.onNodeWithText("numericalRange")
+        field.assertIsDisplayed()
+        field.assertTextContains("Value must be from 2 to 5")
+        field.assertContentDescriptionContains(contentDescription)
+    }
+
+    companion object {
+        private lateinit var featureForm: FeatureForm
+
+        @BeforeClass
+        @JvmStatic
+        fun setupClass() = runTest {
+            ArcGISEnvironment.authenticationManager.arcGISAuthenticationChallengeHandler =
+                FeatureFormsTestChallengeHandler(
+                    BuildConfig.webMapUser,
+                    BuildConfig.webMapPassword
+                )
+            val map =
+                ArcGISMap("https://runtimecoretest.maps.arcgis.com/apps/mapviewer/index.html?webmap=5f71b243b37e43a5ace3190241db0ac9")
+            map.load().onFailure { TestCase.fail("failed to load webmap with ${it.message}") }
+            val featureLayer = map.operationalLayers.first() as? FeatureLayer
+            featureLayer?.let { layer ->
+                layer.load().onFailure { TestCase.fail("failed to load layer with ${it.message}") }
+                val featureFormDefinition = layer.featureFormDefinition!!
+                val parameters = QueryParameters().also {
+                    it.objectIds.add(1L)
+                    it.maxFeatures = 1
+                }
+                layer.featureTable?.queryFeatures(parameters)?.onSuccess { featureQueryResult ->
+                    val feature = featureQueryResult.find {
+                        it is ArcGISFeature
+                    } as? ArcGISFeature
+                    if (feature == null) TestCase.fail("failed to fetch feature")
+                    feature?.load()?.onFailure {
+                        TestCase.fail("failed to load feature with ${it.message}")
+                    }
+                    featureForm = FeatureForm(feature!!, featureFormDefinition)
+                    featureForm.evaluateExpressions()
+                }?.onFailure {
+                    TestCase.fail("failed to query features on layer's featuretable with ${it.message}")
+                }
+            }
+        }
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
@@ -69,6 +69,7 @@ internal abstract class BaseFieldState<T>(
     id: Int,
     properties: FieldProperties<T>,
     initialValue: T = properties.value.value,
+    val hasValueExpression : Boolean,
     private val scope: CoroutineScope,
     private val updateValue: (Any?) -> Unit,
     private val evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
@@ -59,6 +59,7 @@ internal data class Value<T>(
  * @param properties the [FieldProperties] associated with this state.
  * @param initialValue optional initial value to set for this field. It is set to the value of
  * [FieldProperties.value] by default.
+ * @property hasValueExpression a flag to indicate if the field has a value expression.
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param updateValue a function that is invoked when the user edits result in a change of value. This
  * is called in [BaseFieldState.onValueChanged].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
@@ -69,7 +69,7 @@ internal abstract class BaseFieldState<T>(
     id: Int,
     properties: FieldProperties<T>,
     initialValue: T = properties.value.value,
-    val hasValueExpression : Boolean,
+    val hasValueExpression: Boolean,
     private val scope: CoroutineScope,
     private val updateValue: (Any?) -> Unit,
     private val evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>,
@@ -218,10 +218,12 @@ internal abstract class BaseFieldState<T>(
      * @return A single validation error
      */
     private fun filterErrors(errors: List<ValidationErrorState>): ValidationErrorState {
-        // if editable
-        return if (errors.isNotEmpty() && isEditable.value) {
-            // if it has been focused
-            if (wasFocused) {
+        // if editable or has a value expression
+        return if (errors.isNotEmpty() && (hasValueExpression || isEditable.value)) {
+            // if it has a value expression, show the first error
+            if (hasValueExpression) {
+                errors.first()
+            } else if (wasFocused) { // if it has been focused
                 // if not in focus
                 if (!isFocused.value) {
                     // show a required error if it is present

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Clear
+import androidx.compose.material.icons.rounded.Code
 import androidx.compose.material.icons.rounded.TextFields
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -43,6 +44,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -106,6 +108,7 @@ internal fun BaseTextField(
     singleLine: Boolean,
     modifier: Modifier = Modifier,
     readOnly: Boolean = !isEditable,
+    hasValueExpression: Boolean,
     showCharacterCount: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Ascii,
     trailingIcon: ImageVector? = null,
@@ -213,7 +216,8 @@ internal fun BaseTextField(
             ReadOnlyTextField(
                 label = label,
                 text = text,
-                supportingText = supportingText
+                supportingText = supportingText,
+                hasValueExpression = hasValueExpression
             )
         }
     }
@@ -256,31 +260,46 @@ private fun ReadOnlyTextField(
     text: String,
     modifier: Modifier = Modifier,
     supportingText: String,
+    hasValueExpression: Boolean
 ) {
     val colors = LocalColorScheme.current.readOnlyFieldColors
     val typography = LocalTypography.current.readOnlyFieldTypography
-    Column(modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = label,
-            overflow = TextOverflow.Ellipsis,
-            maxLines = 1,
-            color = colors.labelColor,
-            style = typography.labelStyle
-        )
-        SelectionContainer(
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
-        ) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = modifier
+            .fillMaxWidth()
+            .weight(1f)) {
             Text(
-                text = text.ifEmpty { "--" },
-                color = colors.textColor,
-                style = typography.textStyle
+                text = label,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                color = colors.labelColor,
+                style = typography.labelStyle
             )
+            SelectionContainer(
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = text.ifEmpty { "--" },
+                    color = colors.textColor,
+                    style = typography.textStyle
+                )
+            }
+            if (supportingText.isNotEmpty()) {
+                Text(
+                    text = supportingText,
+                    color = colors.supportingTextColor,
+                    style = typography.supportingTextStyle
+                )
+            }
         }
-        if (supportingText.isNotEmpty()) {
-            Text(
-                text = supportingText,
-                color = colors.supportingTextColor,
-                style = typography.supportingTextStyle
+        if (hasValueExpression) {
+            Icon(
+                imageVector = Icons.Rounded.Code,
+                contentDescription = "calculated field icon",
+                modifier = Modifier.padding(horizontal = 8.dp)
             )
         }
     }
@@ -358,6 +377,7 @@ private fun ReadOnlyTextFieldPreview() {
             isRequired = true,
             singleLine = false,
             trailingIcon = Icons.Rounded.TextFields,
+            hasValueExpression = true
         )
     }
 }
@@ -377,6 +397,7 @@ private fun BaseTextFieldPreview() {
             isRequired = true,
             singleLine = false,
             trailingIcon = Icons.Rounded.TextFields,
+            hasValueExpression = false
         )
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
@@ -88,7 +88,7 @@ import com.arcgismaps.toolkit.featureforms.theme.LocalTypography
  * @param readOnly controls the editable state of the text field. When true, the text field cannot
  * be modified. However, a user can focus it and copy text from it.
  * @param hasValueExpression if true, a special icon will be displayed at the end of the text field
- * in addition to being read-only.
+ * if [readOnly] is also true.
  * @param showCharacterCount if true shows the current character count of the [text].
  * @param keyboardType the keyboard type to use depending on the FormFieldElement input type.
  * @param trailingIcon the icon to be displayed at the end of the text field container.
@@ -269,11 +269,11 @@ private fun ReadOnlyTextField(
     val colors = LocalColorScheme.current.readOnlyFieldColors
     val typography = LocalTypography.current.readOnlyFieldTypography
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.Top
     ) {
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
         ) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
@@ -269,7 +269,10 @@ private fun ReadOnlyTextField(
     val colors = LocalColorScheme.current.readOnlyFieldColors
     val typography = LocalTypography.current.readOnlyFieldTypography
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            // merge descendants semantics to make them part of the parent node
+            .semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.Top
     ) {
         Column(
@@ -308,7 +311,7 @@ private fun ReadOnlyTextField(
         if (hasValueExpression) {
             Icon(
                 imageVector = Icons.Rounded.Code,
-                contentDescription = "calculated field icon",
+                contentDescription = "calculated field",
                 modifier = Modifier.padding(horizontal = 8.dp)
             )
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
@@ -87,6 +87,7 @@ import com.arcgismaps.toolkit.featureforms.theme.LocalTypography
  * @param modifier a [Modifier] for this text field.
  * @param readOnly controls the editable state of the text field. When true, the text field cannot
  * be modified. However, a user can focus it and copy text from it.
+ * @param hasValueExpression if true, a special icon will be displayed at the end of the text field
  * @param showCharacterCount if true shows the current character count of the [text].
  * @param keyboardType the keyboard type to use depending on the FormFieldElement input type.
  * @param trailingIcon the icon to be displayed at the end of the text field container.
@@ -268,7 +269,7 @@ private fun ReadOnlyTextField(
     val typography = LocalTypography.current.readOnlyFieldTypography
     Row(
         modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.Top
     ) {
         Column(
             modifier = modifier

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
@@ -88,6 +88,7 @@ import com.arcgismaps.toolkit.featureforms.theme.LocalTypography
  * @param readOnly controls the editable state of the text field. When true, the text field cannot
  * be modified. However, a user can focus it and copy text from it.
  * @param hasValueExpression if true, a special icon will be displayed at the end of the text field
+ * in addition to being read-only.
  * @param showCharacterCount if true shows the current character count of the [text].
  * @param keyboardType the keyboard type to use depending on the FormFieldElement input type.
  * @param trailingIcon the icon to be displayed at the end of the text field container.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
@@ -88,7 +88,7 @@ import com.arcgismaps.toolkit.featureforms.theme.LocalTypography
  * @param readOnly controls the editable state of the text field. When true, the text field cannot
  * be modified. However, a user can focus it and copy text from it.
  * @param hasValueExpression if true, a special icon will be displayed at the end of the text field
- * if [readOnly] is also true.
+ * given that [readOnly] is also set to true.
  * @param showCharacterCount if true shows the current character count of the [text].
  * @param keyboardType the keyboard type to use depending on the FormFieldElement input type.
  * @param trailingIcon the icon to be displayed at the end of the text field container.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseTextField.kt
@@ -217,6 +217,7 @@ internal fun BaseTextField(
                 label = label,
                 text = text,
                 supportingText = supportingText,
+                isError = isError,
                 hasValueExpression = hasValueExpression
             )
         }
@@ -260,6 +261,7 @@ private fun ReadOnlyTextField(
     text: String,
     modifier: Modifier = Modifier,
     supportingText: String,
+    isError: Boolean,
     hasValueExpression: Boolean
 ) {
     val colors = LocalColorScheme.current.readOnlyFieldColors
@@ -268,9 +270,11 @@ private fun ReadOnlyTextField(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(modifier = modifier
-            .fillMaxWidth()
-            .weight(1f)) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .weight(1f)
+        ) {
             Text(
                 text = label,
                 overflow = TextOverflow.Ellipsis,
@@ -290,7 +294,11 @@ private fun ReadOnlyTextField(
             if (supportingText.isNotEmpty()) {
                 Text(
                     text = supportingText,
-                    color = colors.supportingTextColor,
+                    color = if (!isError) {
+                        colors.supportingTextColor
+                    } else {
+                        colors.errorSupportingTextColor
+                    },
                     style = typography.supportingTextStyle
                 )
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
@@ -19,6 +19,7 @@ package com.arcgismaps.toolkit.featureforms.internal.components.base
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.arcgismaps.toolkit.featureforms.R
 
@@ -64,10 +65,11 @@ internal sealed class ValidationErrorState(
 
             is ExactCharConstraint -> {
                 val hasValueExpression = formatArgs.last() as Boolean
+                val length = formatArgs.first() as Int
                 if (hasValueExpression) {
-                    stringResource(R.string.value_must_be_n_characters, *formatArgs)
+                    pluralStringResource(id = R.plurals.value_must_be_n_characters, length, length)
                 } else {
-                    stringResource(id = R.string.enter_n_chars, *formatArgs)
+                    pluralStringResource(id = R.plurals.enter_n_chars, length, length)
                 }
             }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
@@ -28,12 +28,12 @@ internal sealed class ValidationErrorState(
 ) {
     data object NoError : ValidationErrorState()
     data object Required : ValidationErrorState()
-    class MinMaxCharConstraint(min: Int, max: Int) : ValidationErrorState(min, max)
-    class ExactCharConstraint(length: Int) : ValidationErrorState(length)
+    class MinMaxCharConstraint(min: Int, max: Int, hasValueExpression : Boolean) : ValidationErrorState(min, max, hasValueExpression)
+    class ExactCharConstraint(length: Int, hasValueExpression: Boolean) : ValidationErrorState(length, hasValueExpression)
     class MaxCharConstraint(max: Int) : ValidationErrorState(max)
     class MinNumericConstraint(min: String) : ValidationErrorState(min)
     class MaxNumericConstraint(max: String) : ValidationErrorState(max)
-    class MinMaxNumericConstraint(min: String, max: String) : ValidationErrorState(min, max)
+    class MinMaxNumericConstraint(min: String, max: String, hasValueExpression: Boolean) : ValidationErrorState(min, max, hasValueExpression)
     class MinDatetimeConstraint(min: String) : ValidationErrorState(min)
     class MaxDatetimeConstraint(max: String) : ValidationErrorState(max)
     data object NotANumber : ValidationErrorState()
@@ -54,11 +54,21 @@ internal sealed class ValidationErrorState(
             }
 
             is MinMaxCharConstraint -> {
-                stringResource(id = R.string.enter_min_to_max_chars, *formatArgs)
+                val hasValueExpression = formatArgs.last() as Boolean
+                if (hasValueExpression) {
+                    stringResource(id = R.string.value_must_be_from_to_characters, *formatArgs)
+                } else {
+                    stringResource(id = R.string.enter_min_to_max_chars, *formatArgs)
+                }
             }
 
             is ExactCharConstraint -> {
-                stringResource(id = R.string.enter_n_chars, *formatArgs)
+                val hasValueExpression = formatArgs.last() as Boolean
+                if (hasValueExpression) {
+                    stringResource(R.string.value_must_be_n_characters, *formatArgs)
+                } else {
+                    stringResource(id = R.string.enter_n_chars, *formatArgs)
+                }
             }
 
             is MaxCharConstraint -> {
@@ -74,7 +84,12 @@ internal sealed class ValidationErrorState(
             }
 
             is MinMaxNumericConstraint -> {
-                stringResource(id = R.string.numeric_range_helper_text, *formatArgs)
+                val hasValueExpression = formatArgs.last() as Boolean
+                if (hasValueExpression) {
+                    stringResource(R.string.value_must_be_from_to, *formatArgs)
+                } else {
+                    stringResource(id = R.string.numeric_range_helper_text, *formatArgs)
+                }
             }
 
             is MinDatetimeConstraint -> {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
@@ -159,9 +159,20 @@ private fun createValidationErrorStates(
                     }
                     if (min > 0 && max > 0) {
                         if (min == max) {
-                            add(ValidationErrorState.ExactCharConstraint(min))
+                            add(
+                                ValidationErrorState.ExactCharConstraint(
+                                    min,
+                                    formElement.hasValueExpression
+                                )
+                            )
                         } else {
-                            add(ValidationErrorState.MinMaxCharConstraint(min, max))
+                            add(
+                                ValidationErrorState.MinMaxCharConstraint(
+                                    min,
+                                    max,
+                                    formElement.hasValueExpression
+                                )
+                            )
                         }
                     } else {
                         add(ValidationErrorState.MaxCharConstraint(max))
@@ -182,7 +193,8 @@ private fun createValidationErrorStates(
                         add(
                             ValidationErrorState.MinMaxNumericConstraint(
                                 min.format(),
-                                max.format()
+                                max.format(),
+                                formElement.hasValueExpression
                             )
                         )
                     } else if (min != null) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
@@ -51,6 +51,7 @@ internal open class CodedValueFieldProperties(
  * @param properties the [CodedValueFieldProperties] associated with this state.
  * @param initialValue optional initial value to set for this field. It is set to the value of
  * [TextFieldProperties.value] by default.
+ * @param hasValueExpression a flag to indicate if the field has a value expression.
  * @param scope a [CoroutineScope] to start [StateFlow] collectors on.
  * @param updateValue a function that is invoked when the user edits result in a change of value. This
  * is called in [BaseFieldState.onValueChanged].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
@@ -61,6 +61,7 @@ internal abstract class CodedValueFieldState(
     id : Int,
     properties: CodedValueFieldProperties,
     initialValue: Any? = properties.value.value,
+    hasValueExpression : Boolean,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
@@ -69,6 +70,7 @@ internal abstract class CodedValueFieldState(
     properties = properties,
     scope = scope,
     initialValue = initialValue,
+    hasValueExpression = hasValueExpression,
     updateValue = updateValue,
     evaluateExpressions = evaluateExpressions
 ) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
@@ -134,7 +134,8 @@ internal fun ComboBoxField(
             {
                 Icon(imageVector = Icons.AutoMirrored.Outlined.List, contentDescription = "field icon")
             }
-        } else null
+        } else null,
+        hasValueExpression = state.hasValueExpression
     )
 
     LaunchedEffect(interactionSource) {
@@ -365,6 +366,7 @@ private fun ComboBoxPreview() {
             showNoValueOption = FormInputNoValueOption.Show,
             noValueLabel = "No value"
         ),
+        hasValueExpression = false,
         scope = scope,
         id = 1,
         updateValue = {},

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxFieldState.kt
@@ -35,10 +35,11 @@ internal class ComboBoxFieldState(
     id : Int,
     properties: CodedValueFieldProperties,
     initialValue: Any? = properties.value.value,
+    hasValueExpression : Boolean,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
-) : CodedValueFieldState(id, properties, initialValue, scope, updateValue, evaluateExpressions) {
+) : CodedValueFieldState(id, properties, initialValue, hasValueExpression, scope, updateValue, evaluateExpressions) {
 
     companion object {
         /**
@@ -75,6 +76,7 @@ internal class ComboBoxFieldState(
                         fieldType = formElement.fieldType
                     ),
                     initialValue = list[0],
+                    hasValueExpression = formElement.hasValueExpression,
                     scope = scope,
                     updateValue = formElement::updateValue,
                     evaluateExpressions = form::evaluateExpressions
@@ -112,6 +114,7 @@ internal fun rememberComboBoxFieldState(
             noValueLabel = input.noValueLabel,
             fieldType = field.fieldType
         ),
+        hasValueExpression = field.hasValueExpression,
         scope = scope,
         updateValue = field::updateValue,
         evaluateExpressions = form::evaluateExpressions

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonField.kt
@@ -83,7 +83,8 @@ internal fun RadioButtonField(
             supportingText = state.description,
             isError = false,
             isRequired = required,
-            singleLine = true
+            singleLine = true,
+            hasValueExpression = state.hasValueExpression
         )
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonFieldState.kt
@@ -33,6 +33,7 @@ internal class RadioButtonFieldState(
     id : Int,
     properties: RadioButtonFieldProperties,
     initialValue: Any? = properties.value.value,
+    hasValueExpression : Boolean,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
@@ -40,6 +41,7 @@ internal class RadioButtonFieldState(
     id,
     properties = properties,
     initialValue = initialValue,
+    hasValueExpression = hasValueExpression,
     scope = scope,
     updateValue = updateValue,
     evaluateExpressions = evaluateExpressions
@@ -91,6 +93,7 @@ internal class RadioButtonFieldState(
                         noValueLabel = input.noValueLabel
                     ),
                     initialValue = list[0],
+                    hasValueExpression = formElement.hasValueExpression,
                     scope = scope,
                     updateValue = formElement::updateValue,
                     evaluateExpressions = form::evaluateExpressions
@@ -126,6 +129,7 @@ internal fun rememberRadioButtonFieldState(
             showNoValueOption = input.noValueOption,
             noValueLabel = input.noValueLabel
         ),
+        hasValueExpression = field.hasValueExpression,
         scope = scope,
         updateValue = field::updateValue,
         evaluateExpressions = form::evaluateExpressions

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchField.kt
@@ -52,7 +52,8 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
         isError = false,
         isRequired = false,
         singleLine = true,
-        interactionSource = interactionSource
+        interactionSource = interactionSource,
+        hasValueExpression = state.hasValueExpression
     ) {
         Switch(
             checked = checkedState,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchFieldState.kt
@@ -83,6 +83,7 @@ internal class SwitchFieldState(
     id : Int,
     properties: SwitchFieldProperties,
     val initialValue: Any? = properties.value.value,
+    hasValueExpression : Boolean,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
@@ -91,6 +92,7 @@ internal class SwitchFieldState(
     properties = properties,
     scope = scope,
     initialValue = initialValue,
+    hasValueExpression = hasValueExpression,
     updateValue = updateValue,
     evaluateExpressions = evaluateExpressions
 ) {
@@ -146,6 +148,7 @@ internal class SwitchFieldState(
                         noValueLabel = noValueString
                     ),
                     initialValue = list[0],
+                    hasValueExpression = formElement.hasValueExpression,
                     scope = scope,
                     updateValue = formElement::updateValue,
                     evaluateExpressions = form::evaluateExpressions
@@ -190,6 +193,7 @@ internal fun rememberSwitchFieldState(
                 FormInputNoValueOption.Hide,
             noValueLabel = noValueString
         ),
+        hasValueExpression = field.hasValueExpression,
         scope = scope,
         updateValue = field::updateValue,
         evaluateExpressions = form::evaluateExpressions

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
@@ -88,7 +88,8 @@ internal fun DateTimeField(
             }
         } else {
             null
-        }
+        },
+        hasValueExpression = state.hasValueExpression
     )
 
     LaunchedEffect(interactionSource) {
@@ -123,6 +124,7 @@ private fun DateTimeFieldPreview() {
                 maxEpochMillis = null,
                 shouldShowTime = true
             ),
+            hasValueExpression = false,
             scope = scope,
             updateValue = {},
             id = 1,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeFieldState.kt
@@ -67,6 +67,7 @@ internal class DateTimeFieldState(
     id : Int,
     properties: DateTimeFieldProperties,
     initialValue: Instant? = properties.value.value,
+    hasValueExpression : Boolean,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
@@ -74,6 +75,7 @@ internal class DateTimeFieldState(
     id = id,
     properties = properties,
     initialValue = initialValue,
+    hasValueExpression = hasValueExpression,
     scope = scope,
     updateValue = updateValue,
     evaluateExpressions = evaluateExpressions
@@ -113,6 +115,7 @@ internal class DateTimeFieldState(
                         shouldShowTime = input.includeTime
                     ),
                     initialValue = list[0] as Instant?,
+                    hasValueExpression = field.hasValueExpression,
                     scope = scope,
                     updateValue = field::updateValue,
                     evaluateExpressions = form::evaluateExpressions
@@ -155,6 +158,7 @@ internal fun rememberDateTimeFieldState(
             maxEpochMillis = maxEpochMillis,
             shouldShowTime = shouldShowTime
         ),
+        hasValueExpression = field.hasValueExpression,
         scope = scope,
         updateValue = field::updateValue,
         evaluateExpressions = form::evaluateExpressions

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextField.kt
@@ -57,6 +57,7 @@ internal fun FormTextField(
         singleLine = state.singleLine,
         keyboardType = if (state.fieldType.isNumeric) KeyboardType.Number else KeyboardType.Ascii,
         showCharacterCount = showCharacterCount,
-        onFocusChange = state::onFocusChanged
+        onFocusChange = state::onFocusChanged,
+        hasValueExpression = state.hasValueExpression
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
@@ -72,6 +72,7 @@ internal class FormTextFieldState(
     id : Int,
     properties: TextFieldProperties,
     initialValue: String = properties.value.value,
+    hasValueExpression : Boolean,
     scope: CoroutineScope,
     updateValue: (Any?) -> Unit,
     evaluateExpressions: suspend () -> Result<List<FormExpressionEvaluationError>>
@@ -79,6 +80,7 @@ internal class FormTextFieldState(
     id = id,
     properties = properties,
     initialValue = initialValue,
+    hasValueExpression = hasValueExpression,
     scope = scope,
     updateValue = updateValue,
     evaluateExpressions = evaluateExpressions
@@ -152,6 +154,7 @@ internal class FormTextFieldState(
                         maxLength = maxLength.toInt()
                     ),
                     initialValue = list[0] as String,
+                    hasValueExpression = formElement.hasValueExpression,
                     scope = scope,
                     updateValue = formElement::updateValue,
                     evaluateExpressions = form::evaluateExpressions
@@ -192,6 +195,7 @@ internal fun rememberFormTextFieldState(
             minLength = minLength,
             maxLength = maxLength
         ),
+        hasValueExpression = field.hasValueExpression,
         scope = scope,
         updateValue = field::updateValue,
         evaluateExpressions = form::evaluateExpressions,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/theme/DefaultThemeTokens.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/theme/DefaultThemeTokens.kt
@@ -87,7 +87,8 @@ internal object DefaultThemeTokens {
         readOnlyFieldColors = ReadOnlyFieldColors(
             labelColor = Color.Unspecified,
             textColor = Color.Unspecified,
-            supportingTextColor = Color.Unspecified
+            supportingTextColor = Color.Unspecified,
+            errorSupportingTextColor = ColorTokens.Error
         ),
         groupElementColors = GroupElementColors(
             labelColor = Color.Unspecified,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/theme/FeatureFormDefaults.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/theme/FeatureFormDefaults.kt
@@ -167,18 +167,21 @@ public object FeatureFormDefaults {
      * @param labelColor the color used for the label of this field
      * @param textColor the color used for the text of this field
      * @param supportingTextColor the color used for the supporting text of this field
+     * @param errorSupportingTextColor the color used for the supporting text of this field when in error state
      * @since 200.5.0
      */
     @Composable
     public fun readOnlyFieldColors(
         labelColor: Color = Color.Unspecified,
         textColor: Color = Color.Unspecified,
-        supportingTextColor: Color = Color.Unspecified
+        supportingTextColor: Color = Color.Unspecified,
+        errorSupportingTextColor : Color = MaterialTheme.colorScheme.error
     ): ReadOnlyFieldColors {
         return ReadOnlyFieldColors(
             labelColor = labelColor,
             textColor = textColor,
-            supportingTextColor = supportingTextColor
+            supportingTextColor = supportingTextColor,
+            errorSupportingTextColor = errorSupportingTextColor
         )
     }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/theme/FeatureFormTheme.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/theme/FeatureFormTheme.kt
@@ -221,13 +221,15 @@ public data class EditableTextFieldColors internal constructor(
  * @property labelColor the color used for the label of this field
  * @property textColor the color used for the text of this field
  * @property supportingTextColor the color used for the supporting text of this field
+ * @property errorSupportingTextColor the color used for the supporting text of this field when in error state
  * @since 200.5.0
  */
 @Immutable
 public data class ReadOnlyFieldColors internal constructor(
     public val labelColor: Color,
     public val textColor: Color,
-    public val supportingTextColor: Color
+    public val supportingTextColor: Color,
+    public val errorSupportingTextColor : Color
 )
 
 /**

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -99,7 +99,6 @@
     <string name="ff_time_picker_period_toggle_description">Select AM or PM</string>
     <string name="ff_time_picker_pm">PM</string>
 
-
     <string name="take_photo">Take Photo</string>
     <string name="add_from_gallery">Add From Gallery</string>
     <string name="rename">Rename</string>

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -18,7 +18,9 @@
 
 <resources>
     <string name="enter_n_chars">Enter %1$d characters</string>
+    <string name="value_must_be_n_characters">Value must be %1$d characters</string>
     <string name="enter_min_to_max_chars">Enter %1$d to %2$d characters</string>
+    <string name="value_must_be_from_to_characters">Value must be %1$d to %2$d characters</string>
     <string name="maximum_n_chars">Maximum %1$d characters</string>
     <string name="no_value">No value</string>
     <string name="enter_value">Enter Value</string>
@@ -30,6 +32,7 @@
     <string name="done">Done</string>
     <string name="filter">Filter %1$s</string>
     <string name="numeric_range_helper_text">Enter value from %1$s to %2$s</string>
+    <string name="value_must_be_from_to">Value must be %1$s to %2$s</string>
     <string name="less_than_min_value">Less than minimum value %1$s</string>
     <string name="exceeds_max_value">Exceeds maximum value %1$s</string>
     <string name="value_must_be_a_whole_number">Value must be a whole number</string>
@@ -89,6 +92,8 @@
     <string name="ff_time_picker_minute_text_field">for minutes</string>
     <string name="ff_time_picker_period_toggle_description">Select AM or PM</string>
     <string name="ff_time_picker_pm">PM</string>
+
+
     <string name="take_photo">Take Photo</string>
     <string name="add_from_gallery">Add From Gallery</string>
     <string name="rename">Rename</string>

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -17,8 +17,14 @@
   -->
 
 <resources>
-    <string name="enter_n_chars">Enter %1$d characters</string>
-    <string name="value_must_be_n_characters">Value must be %1$d characters</string>
+    <plurals name="enter_n_chars">
+        <item quantity="one">Enter %1$d character</item>
+        <item quantity="other">Enter %1$d characters</item>
+    </plurals>
+    <plurals name="value_must_be_n_characters">
+        <item quantity="one">Value must be %1$d character</item>
+        <item quantity="other">Value must be %1$d characters</item>
+    </plurals>
     <string name="enter_min_to_max_chars">Enter %1$d to %2$d characters</string>
     <string name="value_must_be_from_to_characters">Value must be %1$d to %2$d characters</string>
     <string name="maximum_n_chars">Maximum %1$d characters</string>
@@ -32,7 +38,7 @@
     <string name="done">Done</string>
     <string name="filter">Filter %1$s</string>
     <string name="numeric_range_helper_text">Enter value from %1$s to %2$s</string>
-    <string name="value_must_be_from_to">Value must be %1$s to %2$s</string>
+    <string name="value_must_be_from_to">Value must be from %1$s to %2$s</string>
     <string name="less_than_min_value">Less than minimum value %1$s</string>
     <string name="exceeds_max_value">Exceeds maximum value %1$s</string>
     <string name="value_must_be_a_whole_number">Value must be a whole number</string>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [apollo/issues/615](https://devtopia.esri.com/runtime/apollo/issues/615)

<!-- link to design, if applicable -->

### Description: 

Updates the design and validation behavior of a `FieldFormElement` if its `hasValueExpression` is true. 
The `hasValueExpression` can only be true, if the `FieldFormElement.isEditable` is false as it indicates the presence of an arcade expression backing the value of this field.

### Summary of changes:

- `BaseFieldState` declares a new `hasValueExpression` property.
- If `BaseFieldState.hasValueExpression` is true, a special `<>` icon is displayed on the field.
- Since such fields are also read-only, these fields now also receive any validation errors with an error color.
- Updated messaging for the validation errors if hasValueExpression is true based on the [common-toolkit design](https://devtopia.esri.com/runtime/common-toolkit/blob/c3eac57cfff0d586cb2c2a76bd50e219e3b4e232/designs/Forms/InputValidationDesign.md#user-facing-messages-for-validation-errors)
- `ReadOnlyFieldColors` provides a new `errorSupportingTextColor` to support error color customization.
- Updated `featureforms.api` to include the above change.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  