### PR TITLE
fix insertion index

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -162,13 +162,14 @@ internal class AttachmentElementState(
             scope = scope,
             formAttachment = formAttachment
         )
-        attachments.add(state)
+        // add the new state to the beginning of the list
+        attachments.add(0, state)
         // load the new attachment
         state.loadWithParentScope()
         // scroll to the new attachment after a delay to allow the recomposition to complete
         scope.launch {
             delay(100)
-            lazyListState.scrollToItem(attachments.count())
+            lazyListState.scrollToItem(0)
             evaluateExpressions()
         }
     }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/653](https://devtopia.esri.com/runtime/apollo/issues/653)

<!-- link to design, if applicable -->

### Description:

When a new attachment is added, the state object is added to the front of the state list. 

This is because, before the attachment changes are synced to the service, the newly added attachment is at the end of the `AttachmentsFormElement.attachmets` list. But after saving it to the service and fetching the attachments, the attachment is at the beginning of the list.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  