### PR TITLE
fixes failing tests

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/GroupElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/GroupElementTests.kt
@@ -20,11 +20,12 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onParent
 import androidx.compose.ui.test.performClick
@@ -105,7 +106,7 @@ class GroupElementTests {
         val groupElementToTest =
             getGroupElementWithLabel("Group with children that are visible dependent")
         // find the scrollable container
-        val lazyColumn = composeTestRule.onNode(hasScrollAction())
+        val lazyColumn = composeTestRule.onNodeWithContentDescription("lazy column")
         // scroll until the group is visible
         lazyColumn.performScrollToNode(hasText(groupElementToTest.label))
         // find the group and check if displayed
@@ -115,8 +116,15 @@ class GroupElementTests {
         groupElement.assertTextContains(groupElementToTest.description)
         // assert only the header is visible and other field elements are not
         assert(groupElement.onParent().onChildren().fetchSemanticsNodes().count() == 1)
-        // find and click on the radio button option
-        composeTestRule.onNodeWithText("show invisible form element").performClick()
+        // find the radio button option that enables the group element's children visibility
+        val radioButtonLabel = "show invisible form element"
+        val radioButton = composeTestRule.onNodeWithText(radioButtonLabel)
+        // scroll to the radio button and click it
+        lazyColumn.performScrollToNode(hasText(radioButtonLabel))
+        radioButton.performClick()
+        radioButton.assertIsSelected()
+        // scroll back to the group element
+        lazyColumn.performScrollToNode(hasText(groupElementToTest.label))
         // assert the and other field elements are visible
         assert(groupElement.onParent().onChildren().fetchSemanticsNodes().count() > 1)
     }

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/ThemingTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/ThemingTests.kt
@@ -135,8 +135,11 @@ class ThemingTests {
         field.performTextInput("test")
         val text = composeTestRule.onNodeWithText("test", useUnmergedTree = true)
         text.assertIsDisplayed()
+        // bring focus to the field
+        field.performClick()
         // test focused text color
         text.assertTextColor(Color.Blue)
+        // clear focus from the field
         field.performImeAction()
         // test unfocused text color
         text.assertTextColor(Color.Black)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/731](https://devtopia.esri.com/runtime/apollo/issues/731)

<!-- link to design, if applicable -->

### Description: Fixes failing test cases.



### Summary of changes:

- Fixed test test case 6.2, where the ui element being clicked isn't on screen and hence causes the test to fail.
- Fixed test `testPlaceHolderTransformation` under ThemingTests, where the focus color of the text field being tested wasn't in focus causing the test to fail.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/17/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  