### PR TITLE
`Forms` : consume latest api

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,4 +54,4 @@ ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.5.0
-sdkBuildNumber=4265
+sdkBuildNumber=4273

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -45,9 +45,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import com.arcgismaps.LoadStatus
 import com.arcgismaps.Loadable
-import com.arcgismaps.mapping.featureforms.AnyAttachmentsFormInput
 import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
-import com.arcgismaps.mapping.featureforms.AttachmentsFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FormAttachment
 import com.arcgismaps.mapping.featureforms.FormAttachmentType
@@ -101,11 +99,6 @@ internal class AttachmentElementState(
      * The state of the lazy list that displays the [attachments].
      */
     val lazyListState = LazyListState()
-
-    /**
-     * The input type of the attachment form element.
-     */
-    val input = formElement.input
 
     init {
         scope.launch {
@@ -485,17 +478,6 @@ internal sealed class CaptureOptions {
             Signature -> listOf("image/*")
             Video -> listOf("video/*")
             Unknown -> emptyList()
-        }
-    }
-
-    companion object {
-
-        /**
-         * Creates a [CaptureOptions] from the given [AttachmentsFormInput].
-         */
-        fun create(value: AttachmentsFormInput): CaptureOptions = when (value) {
-            is AnyAttachmentsFormInput -> Any
-            else -> Unknown
         }
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -86,7 +86,7 @@ internal fun AttachmentFormElement(
         label = state.label,
         description = state.description,
         editable = editable,
-        captureOptions = CaptureOptions.create(state.input),
+        captureOptions = CaptureOptions.Any,
         stateId = state.id,
         attachments = state.attachments,
         lazyListState = state.lazyListState,


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Consumes latest api changes for feature forms

### Summary of changes:

- AttachmentsFormInput class has been removed

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  