### PR TITLE
`Forms` : Attachments horizontal scrollbar

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -102,7 +102,8 @@ import java.io.File
 
 @Composable
 internal fun AttachmentTile(
-    state: FormAttachmentState
+    state: FormAttachmentState,
+    modifier: Modifier = Modifier
 ) {
     val loadStatus by state.loadStatus.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }
@@ -114,7 +115,7 @@ internal fun AttachmentTile(
     val context = LocalContext.current
     Surface(
         onClick = {},
-        modifier = Modifier
+        modifier = modifier
             .width(92.dp)
             .height(75.dp)
             .clip(shape = RoundedCornerShape(8.dp))


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/670](https://devtopia.esri.com/runtime/apollo/issues/670)

<!-- link to design, if applicable -->

### Description: 

Adds a horizontal scrollbar to the list of attachments.

### Summary of changes:

- Created a customizable `horizontalScrollbar` modifier which works with a `LazyRow` to show a horizontal scroll bar.
- If there are more attachments and the list is scrollable, the scroll bar becomes visible under the list. If the list is not scrollable, the scroll bar disappears.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  