### PR TITLE
`Forms` : Add attachment tests

### DIFF
--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -115,6 +115,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.material.icons)
     testImplementation(libs.bundles.unitTest)
+    androidTestImplementation(libs.truth)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.bundles.composeTest)
     debugImplementation(libs.bundles.debug)

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentTests.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertContentDescriptionContains
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class AttachmentTests : FeatureFormTestRunner(
+    uri = "https://www.arcgis.com/home/item.html?id=3e551c383fc949c7982ec73ba67d409b",
+    objectId = 1
+) {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testImageAttachments() = runTest {
+        composeTestRule.setContent {
+            FeatureForm(featureForm = featureForm)
+        }
+        val attachmentsFormElement = featureForm.defaultAttachmentsElement
+        assertThat(attachmentsFormElement).isNotNull()
+        val formAttachment = attachmentsFormElement!!.attachments.first()
+        // get the attachments form element node
+        val attachmentsField = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsField.assertIsDisplayed()
+        // get the form attachment node
+        val attachmentNode = attachmentsField.onChildWithText(formAttachment.name)
+        attachmentNode.assertIsDisplayed()
+        // check the attachment size is visible
+        attachmentNode.assertTextContains("154 kB")
+        // check the download icon is visible
+        attachmentNode.assertContentDescriptionContains("Download")
+        // download the attachment
+        attachmentNode.performClick()
+        // wait for the attachment to download
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            val contentDescription =
+                attachmentNode.fetchSemanticsNode().config.getOrNull(SemanticsProperties.ContentDescription)
+            // check the download icon is no longer visible which indicates the attachment
+            // has been downloaded
+            contentDescription?.none { item ->
+                item.equals("Download", true)
+            } ?: false
+        }
+        // check the thumbnail icon is visible
+        attachmentNode.assertContentDescriptionContains("Thumbnail")
+    }
+}

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentTests.kt
@@ -36,6 +36,14 @@ class AttachmentTests : FeatureFormTestRunner(
     @get:Rule
     val composeTestRule = createComposeRule()
 
+    /**
+     * Test case 8.1:
+     * Given a `FeatureForm` with a `defaultAttachmentsElement` that has an image attachment
+     * When the `FeatureForm` is displayed
+     * Then the image attachment is displayed with the correct size and download icon
+     * And the attachment is downloaded correctly
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-81-test-image-attachment-data
+     */
     @Test
     fun testImageAttachments() = runTest {
         composeTestRule.setContent {

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FeatureFormTestRunner.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FeatureFormTestRunner.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms
+
+import com.arcgismaps.ArcGISEnvironment
+import com.arcgismaps.LoadStatus
+import com.arcgismaps.Loadable
+import com.arcgismaps.data.ArcGISFeature
+import com.arcgismaps.data.QueryParameters
+import com.arcgismaps.mapping.ArcGISMap
+import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.layers.FeatureLayer
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+
+/**
+ * A test runner for feature form tests. This class is responsible for loading the map with the
+ * given [uri] and the feature with the given [objectId] and initializing the [FeatureForm] for
+ * the feature.
+ *
+ * If the [FeatureForm] is already initialized, the setup method will not run again.
+ *
+ * If the map fails to load or the feature is not found, the test will fail.
+ *
+ * @param uri The URI of the web map.
+ * @param objectId The ID of the feature.
+ */
+open class FeatureFormTestRunner(
+    private val uri: String,
+    private val objectId: Long
+) {
+    @Before
+    fun setup(): Unit = runTest {
+        // If the feature form is already initialized, return
+        if (isInitialized) return@runTest
+        ArcGISEnvironment.authenticationManager.arcGISAuthenticationChallengeHandler =
+            FeatureFormsTestChallengeHandler(
+                BuildConfig.webMapUser, BuildConfig.webMapPassword
+            )
+        // Load the map
+        val map = ArcGISMap(uri = uri)
+        map.assertIsLoaded()
+        // Load the feature layer
+        val featureLayer = map.operationalLayers.first() as? FeatureLayer
+        assertThat(featureLayer).isNotNull()
+        featureLayer!!.assertIsLoaded()
+        // Get the feature form definition
+        val featureFormDefinition = featureLayer.featureFormDefinition
+        assertThat(featureFormDefinition).isNotNull()
+        // Query the feature
+        val parameters = QueryParameters().also {
+            it.objectIds.add(objectId)
+            it.maxFeatures = 1
+        }
+        val featureQueryResult = featureLayer.featureTable?.queryFeatures(parameters)?.getOrNull()
+        assertThat(featureQueryResult).isNotNull()
+        val feature = featureQueryResult!!.find {
+            it is ArcGISFeature
+        } as? ArcGISFeature
+        assertThat(feature).isNotNull()
+        feature!!.assertIsLoaded()
+        // Initialize the feature form
+        featureForm = FeatureForm(feature, featureFormDefinition!!)
+        featureForm.evaluateExpressions()
+    }
+
+    // The featureForm must be a singleton because the test runner creates a new instance of this
+    // class for each test method. This avoids reinitializing the feature form for each test method.
+    companion object {
+        /**
+         * The feature form for the feature with the given [objectId].
+         */
+        lateinit var featureForm: FeatureForm
+            private set
+
+        private val isInitialized : Boolean
+            get() = ::featureForm.isInitialized
+    }
+}
+
+suspend fun Loadable.assertIsLoaded() {
+    val result = load()
+    assertThat(loadStatus.value).isEqualTo(LoadStatus.Loaded)
+    assertThat(result.isSuccess).isTrue()
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -117,7 +118,7 @@ internal fun AttachmentFormElement(
     colors: AttachmentElementColors = AttachmentElementDefaults.colors()
 ) {
     Card(
-        modifier = modifier,
+        modifier = modifier.semantics(mergeDescendants = true) {},
         shape = AttachmentElementDefaults.containerShape,
         border = BorderStroke(AttachmentElementDefaults.borderThickness, colors.borderColor)
     ) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -262,14 +262,14 @@ private fun LoadedView(
         if (thumbnailUri.isNotEmpty()) {
             AsyncImage(
                 model = thumbnailUri,
-                contentDescription = null,
+                contentDescription = "Thumbnail",
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize()
             )
         } else {
             Icon(
                 imageVector = type.getIcon(),
-                contentDescription = null,
+                contentDescription = "Thumbnail",
                 modifier = Modifier
                     .padding(top = 10.dp, bottom = 25.dp)
                     .fillMaxSize(0.8f)
@@ -322,7 +322,7 @@ private fun DefaultView(
             Size(size = size)
             Icon(
                 imageVector = Icons.Outlined.ArrowDownward,
-                contentDescription = null,
+                contentDescription = "Download",
                 modifier = Modifier.size(11.dp)
             )
         }
@@ -334,14 +334,14 @@ private fun DefaultView(
         } else if (isError) {
             Image(
                 imageVector = Icons.Outlined.ErrorOutline,
-                contentDescription = null,
+                contentDescription = "Error",
                 modifier = Modifier.size(20.dp),
                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.error)
             )
         } else {
             Icon(
                 imageVector = type.getIcon(),
-                contentDescription = null,
+                contentDescription = "Placeholder",
                 modifier = Modifier.size(20.dp)
             )
         }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/407](https://devtopia.esri.com/runtime/apollo/issues/407)

<!-- link to design, if applicable -->

### Description:

Adds instrumented tests for AttachmentsFormElement.

### Summary of changes:

- Added a test that checks the defaultAttachmentElement is displayed correctly.
- Added a class `FeatureFormsTestRunner` which provides common logic to load a map, find a feature and get its `FeatureForm`. This boilerplate code is common for all tests and this runner can be used to provide that functionality. Existing tests can be refactored to use this new runner in a separate PR.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/21/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  