### PR TITLE
fix for CalloutRecomposition

### DIFF
--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -111,7 +111,13 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         rotateOffsetWithGeoView: Boolean = false,
         content: @Composable BoxScope.() -> Unit
     ) {
-        if (this.isCalloutBeingDisplayed.compareAndSet(false, true)) {
+        // Facilitates the recomposition of the first Callout
+        var allowCalloutRecomposition by remember { mutableStateOf(false) }
+
+        if (this.isCalloutBeingDisplayed.compareAndSet(false, true)
+            || allowCalloutRecomposition
+        ) {
+            allowCalloutRecomposition = true
             this.CalloutInternal(location, modifier, offset, rotateOffsetWithGeoView, content)
         }
     }
@@ -138,7 +144,13 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         tapLocation: Point? = null,
         content: @Composable BoxScope.() -> Unit
     ) {
-        if (this.isCalloutBeingDisplayed.compareAndSet(false, true)) {
+        // Facilitates the recomposition of the first Callout
+        var allowCalloutRecomposition by remember { mutableStateOf(false) }
+
+        if (this.isCalloutBeingDisplayed.compareAndSet(false, true)
+            || allowCalloutRecomposition
+        ) {
+            allowCalloutRecomposition = true
             val leaderLocation = this.computeLeaderLocationForGeoelement(geoElement, tapLocation) ?: return
             this.CalloutInternal(
                 leaderLocation.location,
@@ -187,7 +199,7 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
             )
         }
 
-        LaunchedEffect(location) {
+        LaunchedEffect(location, offset, rotateOffsetWithGeoView) {
             // Used to update screen coordinate when new location point is used
             leaderScreenCoordinate =
                 getLeaderScreenCoordinate(geoView, location, offset, rotateOffsetWithGeoView)

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -111,7 +111,8 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         rotateOffsetWithGeoView: Boolean = false,
         content: @Composable BoxScope.() -> Unit
     ) {
-        // Facilitates the recomposition of the first Callout
+        // Enables the recomposition of the first Callout in the content lambda that is displayed
+        // on the MapView/SceneView
         var allowCalloutRecomposition by remember { mutableStateOf(false) }
 
         if (this.isCalloutBeingDisplayed.compareAndSet(false, true)
@@ -144,7 +145,8 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         tapLocation: Point? = null,
         content: @Composable BoxScope.() -> Unit
     ) {
-        // Facilitates the recomposition of the first Callout
+        // Enables the recomposition of the first Callout in the content lambda that is displayed
+        // on the MapView/SceneView
         var allowCalloutRecomposition by remember { mutableStateOf(false) }
 
         if (this.isCalloutBeingDisplayed.compareAndSet(false, true)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4178

<!-- link to design, if applicable -->

### Description:

Fixes the issue where Callout recompositions will not work independent of MapView/SceneView recomposition

### Summary of changes:

- Add a flag in a rememeber mutable state which will allow calling CalloutInternal when the recomposition of the Callout displaying on the screen is triggered by the parameters being passed to it.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/22/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  