### PR TITLE
Callout leader animation

### DIFF
--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/MainActivity.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/MainActivity.kt
@@ -33,16 +33,15 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.API_KEY)
-        val viewModel: MapViewModel by viewModels()
         setContent {
             MicroAppTheme {
-                MapViewCalloutApp(viewModel)
+                MapViewCalloutApp()
             }
         }
     }
 }
 
 @Composable
-fun MapViewCalloutApp(viewModel: MapViewModel) {
-    MainScreen(viewModel)
+fun MapViewCalloutApp() {
+    MainScreen()
 }

--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/MainActivity.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/MainActivity.kt
@@ -21,12 +21,10 @@ package com.arcgismaps.toolkit.mapviewcalloutapp
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.toolkit.mapviewcalloutapp.screens.MainScreen
-import com.arcgismaps.toolkit.mapviewcalloutapp.screens.MapViewModel
 import com.esri.microappslib.theme.MicroAppTheme
 
 class MainActivity : ComponentActivity() {

--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/GraphicScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/GraphicScreen.kt
@@ -33,7 +33,7 @@ import com.arcgismaps.toolkit.geoviewcompose.MapView
 //- add switch to enable/disable animation
 
 @Composable
-fun GraphicScreen(){
+fun GraphicScreen(mapViewModel: MapViewModel) {
     Box{
         MapView(
             modifier = Modifier.fillMaxSize(),

--- a/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/MainScreen.kt
+++ b/microapps/MapViewCalloutApp/app/src/main/java/com/arcgismaps/toolkit/mapviewcalloutapp/screens/MainScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -63,7 +64,7 @@ private val calloutAppScreens = mutableListOf(
  * a [Callout] on a [MapView].
  */
 @Composable
-fun MainScreen(viewModel: MapViewModel) {
+fun MainScreen() {
     var currentScreen by remember { mutableStateOf("") }
     val navController = rememberNavController()
 
@@ -77,13 +78,16 @@ fun MainScreen(viewModel: MapViewModel) {
         currentScreen = currentScreen
     ) {
         composable(route = calloutAppScreens[0]) {
-            TapLocationScreen(viewModel)
+            val tapLocationViewModel: MapViewModel = viewModel()
+            TapLocationScreen(tapLocationViewModel)
         }
         composable(route = calloutAppScreens[1]) {
-            FeatureScreen(viewModel)
+            val featureViewModel: MapViewModel = viewModel()
+            FeatureScreen(featureViewModel)
         }
         composable(route = calloutAppScreens[2]) {
-            GraphicScreen()
+            val graphicsViewModel : MapViewModel = viewModel()
+            GraphicScreen(graphicsViewModel)
         }
     }
 }

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -184,6 +184,15 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
     }
 
     /**
+     * Convert [ScreenCoordinate] to an animatable 2D vector type.
+     */
+    private val screenCoordinateToVector: TwoWayConverter<ScreenCoordinate, AnimationVector2D> =
+        TwoWayConverter(
+            { AnimationVector2D(v1 = it.x.toFloat(), v2 = it.y.toFloat()) },
+            { ScreenCoordinate(x = it.v1.toDouble(), y = it.v2.toDouble()) }
+        )
+
+    /**
      * Creates a Callout at the specified [geoElement] on the GeoView.
      *
      * @since 200.5.0
@@ -312,14 +321,9 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
             is MapView -> geoView.locationToScreen(location).takeIf {
                 !it.x.isNaN() && !it.y.isNaN()
             }
-            is SceneView -> {
-                val locationToScreenResult = geoView.locationToScreen(location)
-                if (locationToScreenResult?.visibility == SceneLocationVisibility.Visible) {
-                    locationToScreenResult.screenPoint
-                } else {
-                    null
-                }
-            }
+            is SceneView -> geoView.locationToScreen(location)?.takeIf {
+                it.visibility == SceneLocationVisibility.Visible
+            }?.screenPoint
         }
         return locationToScreen?.let { screenCoordinate ->
             if (rotateOffsetWithGeoView && geoViewRotation != 0.0) {
@@ -851,15 +855,6 @@ private fun calloutPath(
         close()
     }
 }
-
-/**
- * Convert [ScreenCoordinate] to an animatable 2D vector type.
- */
-private val screenCoordinateToVector: TwoWayConverter<ScreenCoordinate, AnimationVector2D> =
-    TwoWayConverter(
-        { AnimationVector2D(v1 = it.x.toFloat(), v2 = it.y.toFloat()) },
-        { ScreenCoordinate(x = it.v1.toDouble(), y = it.v2.toDouble()) }
-    )
 
 /**
  * This function is used to wait for the GeoView to be ready to return positive values

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -228,7 +228,7 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
             typeConverter = screenCoordinateToVector,
             targetValue = leaderScreenCoordinate!!,
             label = "AnimateScreenCoordinate",
-            animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing)
+            animationSpec = tween(easing = FastOutSlowInEasing)
         )
 
 

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -255,6 +255,10 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         }
 
         leaderScreenCoordinate?.let {
+            // While rotating, the screen coordinate may have NaN values
+            if (it.x.isNaN() || it.y.isNaN())
+                return@let
+
             val animateToPoint by animateValueAsState(
                 typeConverter = screenCoordinateToVector,
                 targetValue = it,

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -255,10 +255,6 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         }
 
         leaderScreenCoordinate?.let {
-            // While rotating, the screen coordinate may have NaN values
-            if (it.x.isNaN() || it.y.isNaN())
-                return@let
-
             val animateToPoint by animateValueAsState(
                 typeConverter = screenCoordinateToVector,
                 targetValue = it,
@@ -313,7 +309,16 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
     ): ScreenCoordinate? {
         val geoViewRotation = geoView.rotation()
         val locationToScreen = when (geoView) {
-            is MapView -> geoView.locationToScreen(location)
+            is MapView -> {
+                val locationToScreenCoordinate = geoView.locationToScreen(location)
+                // While rotating, the screen coordinate may have NaN values
+                if (!locationToScreenCoordinate.x.isNaN() && !locationToScreenCoordinate.y.isNaN()) {
+                    locationToScreenCoordinate
+                } else {
+                    null
+                }
+            }
+
             is SceneView -> {
                 val locationToScreenResult = geoView.locationToScreen(location)
                 if (locationToScreenResult?.visibility == SceneLocationVisibility.Visible) {

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -244,7 +244,7 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         LaunchedEffect(location, offset, rotateOffsetWithGeoView) {
             // Used to update screen coordinate when new location point is used
             leaderScreenCoordinate = getLeaderScreenCoordinate(geoView, location, offset, rotateOffsetWithGeoView)
-            // animate to the new screen coord when Callout params are changed
+            // animate to the new screen coordinate when Callout params are changed
             animationEnabled = true
             // update screen coordinate when viewpoint is changed
             geoView.viewpointChanged.collect {
@@ -309,16 +309,9 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
     ): ScreenCoordinate? {
         val geoViewRotation = geoView.rotation()
         val locationToScreen = when (geoView) {
-            is MapView -> {
-                val locationToScreenCoordinate = geoView.locationToScreen(location)
-                // While rotating, the screen coordinate may have NaN values
-                if (!locationToScreenCoordinate.x.isNaN() && !locationToScreenCoordinate.y.isNaN()) {
-                    locationToScreenCoordinate
-                } else {
-                    null
-                }
+            is MapView -> geoView.locationToScreen(location).takeIf {
+                !it.x.isNaN() && !it.y.isNaN()
             }
-
             is SceneView -> {
                 val locationToScreenResult = geoView.locationToScreen(location)
                 if (locationToScreenResult?.visibility == SceneLocationVisibility.Visible) {

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -246,9 +246,6 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
             leaderScreenCoordinate = getLeaderScreenCoordinate(geoView, location, offset, rotateOffsetWithGeoView)
             // animate to the new screen coord when Callout params are changed
             animationEnabled = true
-        }
-
-        LaunchedEffect(leaderScreenCoordinate) {
             // update screen coordinate when viewpoint is changed
             geoView.viewpointChanged.collect {
                 leaderScreenCoordinate = getLeaderScreenCoordinate(geoView, location, offset, rotateOffsetWithGeoView)

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -224,17 +224,16 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
             }
         }
 
-        val animateToPoint by animateValueAsState(
-            typeConverter = screenCoordinateToVector,
-            targetValue = leaderScreenCoordinate!!,
-            label = "AnimateScreenCoordinate",
-            animationSpec = tween(easing = FastOutSlowInEasing)
-        )
+        leaderScreenCoordinate?.let {
+            val animateToPoint by animateValueAsState(
+                typeConverter = screenCoordinateToVector,
+                targetValue = it,
+                label = "AnimateScreenCoordinate",
+                animationSpec = tween(easing = FastOutSlowInEasing)
+            )
 
-
-        (if (animationEnabled) animateToPoint else leaderScreenCoordinate)?.let {
             CalloutSubComposeLayout(
-                leaderScreenCoordinate = it,
+                leaderScreenCoordinate = (if (animationEnabled) animateToPoint else it),
                 maxSize = calloutContentMaxSize(
                     geoView = geoView,
                     density = LocalDensity.current,


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: `kotlin/issues/4207 `

<!-- link to design, if applicable -->

### Description:
Update Callout to animate the anchor leader point when Callout params are changed (point, offset, rotation offset)


### Summary of changes
- Added a [TwoWayConverter](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/TwoWayConverter) private property to animateValueAsState on a ScreenCoordinate.
- Added a `animationEnabled` flag to avoid leader animation when map is panning, but enabled when Callout params change. 
- Added `animateContentSize` Modifier to Callout container for size animation
- Updated microapps to not use a shared ViewModel object, since the `_mapPoint` stateflow could contain NaN values which can crash the app while switching screens. 

### How to test
- Use TapLocationScreen to change the offset, or by tapping new location point to view the animation. 
- Try the SceneView Callout app and tap different points. 
 

