### PR TITLE
`Forms`: Fix validation error max value is null

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/CorePrototypes.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/CorePrototypes.kt
@@ -67,7 +67,7 @@ internal val RangeDomain.asDoubleTuple: MinMax<Double>
     get() {
         return when (fieldType) {
             FieldType.Int16 -> {
-                MinMax((minValue as? Int)?.toDouble(), (maxValue as? Int)?.toDouble())
+                MinMax((minValue as? Short)?.toDouble(), (maxValue as? Short)?.toDouble())
             }
 
             FieldType.Int32 -> {
@@ -98,7 +98,7 @@ internal val RangeDomain.asLongTuple: MinMax<Long>
     get() {
         return when (fieldType) {
             FieldType.Int16 -> {
-                MinMax((minValue as? Int)?.toLong(), (maxValue as? Int)?.toLong())
+                MinMax((minValue as? Short)?.toLong(), (maxValue as? Short)?.toLong())
             }
 
             FieldType.Int32 -> {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/756](https://devtopia.esri.com/runtime/apollo/issues/756)

<!-- link to design, if applicable -->

### Description

Casts the minValue and maxValue properties of a `RangeDomain` into the appropriate type. This was causing an issue where the coerced values were null and the eventual validation error message would say - "Exceeds maximum value null"

### Summary of changes:

-  Cast a Int16 field type into a `Short` instead of an `Int.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/30/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  