### PR TITLE
`Forms` : handle empty attachments

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -219,8 +219,13 @@ internal fun AttachmentTile(
                         haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                         // handle single tap
                         if (loadStatus is LoadStatus.NotLoaded || loadStatus is LoadStatus.FailedToLoad) {
-                            // load attachment
-                            state.loadWithParentScope()
+                            if (state.size > 0) {
+                                // load attachment
+                                state.loadWithParentScope()
+                            } else {
+                                // show an error toast if the attachment is empty
+                                Toast.makeText(context, context.getString(R.string.download_empty_file), Toast.LENGTH_SHORT).show()
+                            }
                         } else if (loadStatus is LoadStatus.Loaded) {
                             // open attachment
                             val intent = Intent()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -219,11 +219,11 @@ internal fun AttachmentTile(
                         haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                         // handle single tap
                         if (loadStatus is LoadStatus.NotLoaded || loadStatus is LoadStatus.FailedToLoad) {
-                            if (state.size > 0) {
-                                // load attachment
-                                state.loadWithParentScope()
-                            } else {
-                                // show an error toast if the attachment is empty
+                            // load attachment
+                            state.loadWithParentScope()
+                            if (state.size == 0L) {
+                                // show an error toast if the attachment is empty since the load
+                                // will likely fail
                                 Toast.makeText(context, context.getString(R.string.download_empty_file), Toast.LENGTH_SHORT).show()
                             }
                         } else if (loadStatus is LoadStatus.Loaded) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -361,7 +361,7 @@ internal fun computeWindowSizeClasses(context: Context): WindowSizeClass {
 }
 
 internal fun showError(context: Context, message: String) {
-    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    Toast.makeText(context, message, Toast.LENGTH_LONG).show()
 }
 
 /**
@@ -408,7 +408,9 @@ private suspend fun AttachmentElementState.addAttachmentFromUri(
         }
     }
     // check if the size is within the limit of 50 MB
-    return@withContext if (size > 50_000_000) {
+    return@withContext if (size == 0L) {
+        Result.failure(Exception(context.getString(R.string.attachment_is_empty)))
+    } else if (size > 50_000_000) {
         Result.failure(Exception(context.getString(R.string.attachment_too_large)))
     } else {
         var result = Result.success(Unit)

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -109,4 +109,6 @@
     <string name="attachment_error">Error Adding Attachment</string>
     <string name="no_app_found">No application found to open this file type.</string>
     <string name="attachment_too_large">The File is too large. Please add a file less than 50 MB.</string>
+    <string name="attachment_is_empty">Empty files are not supported</string>
+    <string name="download_empty_file">Empty files cannot be downloaded</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/771](https://devtopia.esri.com/runtime/apollo/issues/771)

<!-- link to design, if applicable -->

### Description: 

Since empty attachments cannot be downloaded or added due to service restrictions, they are blocked from being added and downloaded in the toolkit.

### Summary of changes:

- Shows a Toast with an error message if the user tries to add an empty attachment.
- Shows a Toast with an error message if the user tries to download or view an empty attachment.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  