### PR TITLE
`Forms` : Ignore any unsupported attachments 

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -352,14 +352,12 @@ internal fun rememberStates(
                 states.add(element, groupState)
             }
 
-            is AttachmentsFormElement -> {
-                val state = rememberAttachmentElementState(form, element)
-                states.add(element, state)
-            }
-
             else -> {}
         }
     }
+    // The Toolkit currently only supports AttachmentsFormElements via the
+    // default attachments element. Once AttachmentsFormElements can be authored
+    // the switch case above should have a case added for AttachmentsFormElement.
     if (form.defaultAttachmentsElement != null) {
         val state = rememberAttachmentElementState(form, form.defaultAttachmentsElement!!)
         states.add(form.defaultAttachmentsElement!!, state)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/761](https://devtopia.esri.com/runtime/apollo/issues/761)

<!-- link to design, if applicable -->

### Summary of changes:

- Ignores any `AttachmentsFormElement` present in the `FeatureForm.elements` list since authoring workflow does not currently exist.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  