### PR TITLE
`Forms` : Fix strings

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
@@ -74,7 +74,8 @@ internal sealed class ValidationErrorState(
             }
 
             is MaxCharConstraint -> {
-                stringResource(id = R.string.maximum_n_chars, *formatArgs)
+                val count = formatArgs.first() as Int
+                pluralStringResource(id = R.plurals.maximum_n_chars, count, count)
             }
 
             is MinNumericConstraint -> {

--- a/toolkit/featureforms/src/main/res/values-ar/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ar/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">تحديد صباحًا أو مساءً</string>
     <string name="ff_time_picker_pm">مساءً</string>
     <string name="take_photo">التقاط صورة</string>
-    <string name="add_photo">إضافة صورة</string>
     <string name="rename">إعادة تسمية</string>
     <string name="delete">حذف</string>
     <string name="rename_attachment">إعادة تسمية المرفق</string>

--- a/toolkit/featureforms/src/main/res/values-bg/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-bg/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Изберете AM (преди обяд) или PM (следобед)</string>
     <string name="ff_time_picker_pm">След обяд</string>
     <string name="take_photo">Направете снимка</string>
-    <string name="add_photo">Добавяне на снимка</string>
     <string name="rename">Преименуване</string>
     <string name="delete">Изтриване</string>
     <string name="rename_attachment">Преименуване на прикачен файл</string>

--- a/toolkit/featureforms/src/main/res/values-bs/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-bs/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Odaberi AM ili PM</string>
     <string name="ff_time_picker_pm">Popodne</string>
     <string name="take_photo">Snimi fotografiju</string>
-    <string name="add_photo">Dodaj fotografiju</string>
     <string name="rename">Preimenuj</string>
     <string name="delete">Izbriši</string>
     <string name="rename_attachment">Preimenuj privitak</string>

--- a/toolkit/featureforms/src/main/res/values-ca/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ca/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Seleccioneu am o pm</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Feu una foto</string>
-    <string name="add_photo">Afegeix una foto</string>
     <string name="rename">Canvia el nom</string>
     <string name="delete">Suprimeix</string>
     <string name="rename_attachment">Canvia el nom del fitxer adjunt</string>

--- a/toolkit/featureforms/src/main/res/values-cs/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-cs/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Zvolte dopoledne/odpoledne</string>
     <string name="ff_time_picker_pm">odpoledne</string>
     <string name="take_photo">Vyfotografovat</string>
-    <string name="add_photo">Přidat fotografii</string>
     <string name="rename">Přejmenovat</string>
     <string name="delete">Odstranit</string>
     <string name="rename_attachment">Přejmenovat přílohu</string>

--- a/toolkit/featureforms/src/main/res/values-da/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-da/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Vælg AM eller PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Tag foto</string>
-    <string name="add_photo">Tilføj foto</string>
     <string name="rename">Omdøb</string>
     <string name="delete">Slet</string>
     <string name="rename_attachment">Omdøb vedhæftning</string>

--- a/toolkit/featureforms/src/main/res/values-de/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-de/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">AM oder PM auswählen</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Foto aufnehmen</string>
-    <string name="add_photo">Foto hinzufügen</string>
     <string name="rename">Umbenennen</string>
     <string name="delete">Löschen</string>
     <string name="rename_attachment">Anlage umbenennen</string>

--- a/toolkit/featureforms/src/main/res/values-el/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-el/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Επιλογή π.μ. ή μ.μ.</string>
     <string name="ff_time_picker_pm">μ.μ.</string>
     <string name="take_photo">Λήψη φωτογραφίας</string>
-    <string name="add_photo">Προσθήκη φωτογραφίας</string>
     <string name="rename">Μετονομασία</string>
     <string name="delete">Διαγραφή</string>
     <string name="rename_attachment">Μετονομασία συνημμένου</string>

--- a/toolkit/featureforms/src/main/res/values-es/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-es/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Seleccionar a.m. o p.m.</string>
     <string name="ff_time_picker_pm">p.m.</string>
     <string name="take_photo">Tomar foto</string>
-    <string name="add_photo">Agregar foto</string>
     <string name="rename">Cambiar el nombre</string>
     <string name="delete">Eliminar</string>
     <string name="rename_attachment">Cambiar nombre de adjunto</string>

--- a/toolkit/featureforms/src/main/res/values-et/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-et/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Valige AM või PM</string>
     <string name="ff_time_picker_pm">p.l.</string>
     <string name="take_photo">Pildista</string>
-    <string name="add_photo">Lisa foto</string>
     <string name="rename">Nimeta ümber</string>
     <string name="delete">Kustuta</string>
     <string name="rename_attachment">Nimeta manus ümber</string>

--- a/toolkit/featureforms/src/main/res/values-fi/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-fi/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Valitse AP tai IP</string>
     <string name="ff_time_picker_pm">IP</string>
     <string name="take_photo">Ota valokuva</string>
-    <string name="add_photo">Lisää valokuva</string>
     <string name="rename">Nimeä uudelleen</string>
     <string name="delete">Poista</string>
     <string name="rename_attachment">Nimeä liite uudelleen</string>

--- a/toolkit/featureforms/src/main/res/values-fr/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-fr/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Sélectionner AM ou PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Prendre une photo</string>
-    <string name="add_photo">Ajouter une photo</string>
     <string name="rename">Renommer</string>
     <string name="delete">Supprimer</string>
     <string name="rename_attachment">Renommer la pièce jointe</string>

--- a/toolkit/featureforms/src/main/res/values-he/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-he/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">בחר AM או PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">צלם תמונה</string>
-    <string name="add_photo">הוסף תמונה</string>
     <string name="rename">שנה שם</string>
     <string name="delete">מחק</string>
     <string name="rename_attachment">שנה שם קובץ מצורף</string>

--- a/toolkit/featureforms/src/main/res/values-hr/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-hr/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Odaberi AM ili PM</string>
     <string name="ff_time_picker_pm">Popodne</string>
     <string name="take_photo">Snimi fotografiju</string>
-    <string name="add_photo">Dodaj fotografiju</string>
     <string name="rename">Preimenuj</string>
     <string name="delete">Izbriši</string>
     <string name="rename_attachment">Preimenuj privitak</string>

--- a/toolkit/featureforms/src/main/res/values-hu/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-hu/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">DE/DU kiválasztása</string>
     <string name="ff_time_picker_pm">DU</string>
     <string name="take_photo">Fénykép készítése</string>
-    <string name="add_photo">Fénykép hozzáadása</string>
     <string name="rename">Átnevezés</string>
     <string name="delete">Törlés</string>
     <string name="rename_attachment">Csatolmány átnevezése</string>

--- a/toolkit/featureforms/src/main/res/values-id/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-id/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Pilih AM atau PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Ambil Foto</string>
-    <string name="add_photo">Tambahkan Foto</string>
     <string name="rename">Ubah Nama</string>
     <string name="delete">Hapus</string>
     <string name="rename_attachment">Ganti Nama Lampiran</string>

--- a/toolkit/featureforms/src/main/res/values-in/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-in/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Pilih AM atau PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Ambil Foto</string>
-    <string name="add_photo">Tambahkan Foto</string>
     <string name="rename">Ubah Nama</string>
     <string name="delete">Hapus</string>
     <string name="rename_attachment">Ganti Nama Lampiran</string>

--- a/toolkit/featureforms/src/main/res/values-it/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-it/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Selezionare AM o PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Scatta una foto</string>
-    <string name="add_photo">Aggiungi foto</string>
     <string name="rename">Rinomina</string>
     <string name="delete">Elimina</string>
     <string name="rename_attachment">Rinomina allegato</string>

--- a/toolkit/featureforms/src/main/res/values-iw/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-iw/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">בחר AM או PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">צלם תמונה</string>
-    <string name="add_photo">הוסף תמונה</string>
     <string name="rename">שנה שם</string>
     <string name="delete">מחק</string>
     <string name="rename_attachment">שנה שם קובץ מצורף</string>

--- a/toolkit/featureforms/src/main/res/values-ja/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ja/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">AM/PM の選択</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">写真の撮影</string>
-    <string name="add_photo">写真の追加</string>
     <string name="rename">名前の変更</string>
     <string name="delete">削除</string>
     <string name="rename_attachment">添付ファイル名の変更</string>

--- a/toolkit/featureforms/src/main/res/values-ko/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ko/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">오전 또는 오후 선택</string>
     <string name="ff_time_picker_pm">오후</string>
     <string name="take_photo">사진 촬영</string>
-    <string name="add_photo">사진 추가</string>
     <string name="rename">이름 바꾸기</string>
     <string name="delete">삭제</string>
     <string name="rename_attachment">첨부 파일 이름 바꾸기</string>

--- a/toolkit/featureforms/src/main/res/values-lt/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-lt/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Pasirinkti priešpiet ar popiet</string>
     <string name="ff_time_picker_pm">popiet</string>
     <string name="take_photo">Fotografuoti</string>
-    <string name="add_photo">Pridėti nuotrauką</string>
     <string name="rename">Pervardinti</string>
     <string name="delete">Ištrinti</string>
     <string name="rename_attachment">Pervardinti priedą</string>

--- a/toolkit/featureforms/src/main/res/values-lv/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-lv/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Atlasīt AM vai PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Uzņemt fotoattēlu</string>
-    <string name="add_photo">Pievienot fotoattēlu</string>
     <string name="rename">Pārdēvēt</string>
     <string name="delete">Dzēst</string>
     <string name="rename_attachment">Pārdēvēt pielikumu</string>

--- a/toolkit/featureforms/src/main/res/values-nl/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-nl/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Selecteer AM of PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Foto maken</string>
-    <string name="add_photo">Foto toevoegen</string>
     <string name="rename">Naam wijzigen</string>
     <string name="delete">Verwijderen</string>
     <string name="rename_attachment">Naam bijlage wijzigen</string>

--- a/toolkit/featureforms/src/main/res/values-no/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-no/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Velg AM eller PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Ta bilde</string>
-    <string name="add_photo">Legg til bilde</string>
     <string name="rename">Gi nytt navn</string>
     <string name="delete">Slett</string>
     <string name="rename_attachment">Endre navn på vedlegg</string>

--- a/toolkit/featureforms/src/main/res/values-pl/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-pl/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Wybierz Rano lub Po południu</string>
     <string name="ff_time_picker_pm">po południu</string>
     <string name="take_photo">Zrób zdjęcie</string>
-    <string name="add_photo">Dodaj zdjęcie</string>
     <string name="rename">Zmień nazwę</string>
     <string name="delete">Usuń</string>
     <string name="rename_attachment">Zmień nazwę załącznika</string>

--- a/toolkit/featureforms/src/main/res/values-pt-rBR/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-pt-rBR/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Selecionar AM ou PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Tirar Foto</string>
-    <string name="add_photo">Adicionar foto</string>
     <string name="rename">Renomear</string>
     <string name="delete">Excluir</string>
     <string name="rename_attachment">Renomear Anexo</string>

--- a/toolkit/featureforms/src/main/res/values-pt-rPT/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-pt-rPT/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Selecionar AM ou PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Tirar fotografia</string>
-    <string name="add_photo">Adicionar fotografia</string>
     <string name="rename">Mudar o nome</string>
     <string name="delete">Eliminar</string>
     <string name="rename_attachment">Mudar o nome do anexo</string>

--- a/toolkit/featureforms/src/main/res/values-ro/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ro/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Selectați AM șu PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Realizare fotografie</string>
-    <string name="add_photo">Adăugare fotografie</string>
     <string name="rename">Redenumire</string>
     <string name="delete">Ștergere</string>
     <string name="rename_attachment">Redenumire atașament</string>

--- a/toolkit/featureforms/src/main/res/values-ru/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ru/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Выбрать AM или PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Сделать фотографию</string>
-    <string name="add_photo">Добавить фотографию</string>
     <string name="rename">Переименовать</string>
     <string name="delete">Удалить</string>
     <string name="rename_attachment">Переименовать вложение</string>

--- a/toolkit/featureforms/src/main/res/values-sk/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-sk/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Vybrať dopoludnie alebo popoludnie</string>
     <string name="ff_time_picker_pm">Popoludní</string>
     <string name="take_photo">Odfotiť</string>
-    <string name="add_photo">Pridať fotografiu</string>
     <string name="rename">Premenovať</string>
     <string name="delete">Zmazať</string>
     <string name="rename_attachment">Premenovať prílohu</string>

--- a/toolkit/featureforms/src/main/res/values-sl/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-sl/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Izberi AM ali PM</string>
     <string name="ff_time_picker_pm">popoldne</string>
     <string name="take_photo">Fotografirajte</string>
-    <string name="add_photo">Dodaj fotografijo</string>
     <string name="rename">Preimenuj</string>
     <string name="delete">Izbriši</string>
     <string name="rename_attachment">Preimenuj prilogo</string>

--- a/toolkit/featureforms/src/main/res/values-sr/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-sr/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Izaberite prepodne ili popodne</string>
     <string name="ff_time_picker_pm">Popodne</string>
     <string name="take_photo">Fotografišite</string>
-    <string name="add_photo">Dodaj fotografiju</string>
     <string name="rename">Preimenuj</string>
     <string name="delete">Izbriši</string>
     <string name="rename_attachment">Preimenuj prilog</string>

--- a/toolkit/featureforms/src/main/res/values-sv/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-sv/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Välj FM eller EM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Ta ett foto</string>
-    <string name="add_photo">Lägg till foto</string>
     <string name="rename">Byt namn</string>
     <string name="delete">Ta bort</string>
     <string name="rename_attachment">Byt namn på bilaga</string>

--- a/toolkit/featureforms/src/main/res/values-th/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-th/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">เลือก AM หรือ PM</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">ถ่ายภาพ</string>
-    <string name="add_photo">เพิ่มรูปถ่าย</string>
     <string name="rename">เปลี่ยนชื่อ</string>
     <string name="delete">ลบ</string>
     <string name="rename_attachment">เปลี่ยนชื่อไฟล์แนบ</string>

--- a/toolkit/featureforms/src/main/res/values-tr/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-tr/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">AM veya PM olarak seç</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Fotoğraf Çek</string>
-    <string name="add_photo">Fotoğraf Ekle</string>
     <string name="rename">Yeniden Adlandır</string>
     <string name="delete">Sil</string>
     <string name="rename_attachment">Eki Yeniden Adlandır</string>

--- a/toolkit/featureforms/src/main/res/values-uk/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-uk/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Виберіть ранок або вечір</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">Зробити фото</string>
-    <string name="add_photo">Додати фото</string>
     <string name="rename">Змінити назву</string>
     <string name="delete">Видалити</string>
     <string name="rename_attachment">Перейменувати прикріплення</string>

--- a/toolkit/featureforms/src/main/res/values-vi/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-vi/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">Chọn SA hoặc CH</string>
     <string name="ff_time_picker_pm">CH</string>
     <string name="take_photo">Chụp Ảnh</string>
-    <string name="add_photo">Thêm Ảnh</string>
     <string name="rename">Đổi tên</string>
     <string name="delete">Xóa</string>
     <string name="rename_attachment">Đổi tên Tệp đính kèm</string>

--- a/toolkit/featureforms/src/main/res/values-zh-rHK/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-zh-rHK/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">選擇 AM 或 PM</string>
     <string name="ff_time_picker_pm">下午</string>
     <string name="take_photo">拍照</string>
-    <string name="add_photo">新增相片</string>
     <string name="rename">重新命名</string>
     <string name="delete">刪除</string>
     <string name="rename_attachment">重新命名附件</string>

--- a/toolkit/featureforms/src/main/res/values-zh-rTW/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-zh-rTW/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">選擇 AM 或 PM</string>
     <string name="ff_time_picker_pm">下午</string>
     <string name="take_photo">拍照</string>
-    <string name="add_photo">新增相片</string>
     <string name="rename">重新命名</string>
     <string name="delete">刪除</string>
     <string name="rename_attachment">重新命名附件</string>

--- a/toolkit/featureforms/src/main/res/values-zh/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-zh/strings.xml
@@ -88,7 +88,6 @@
     <string name="ff_time_picker_period_toggle_description">选择上午或下午</string>
     <string name="ff_time_picker_pm">PM</string>
     <string name="take_photo">拍照</string>
-    <string name="add_photo">添加照片</string>
     <string name="rename">重命名</string>
     <string name="delete">删除</string>
     <string name="rename_attachment">重命名附件</string>

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -27,6 +27,10 @@
     </plurals>
     <string name="enter_min_to_max_chars">Enter %1$d to %2$d characters</string>
     <string name="value_must_be_from_to_characters">Value must be %1$d to %2$d characters</string>
+    <plurals name="maximum_n_chars">
+        <item quantity="one">Maximum %1$d character</item>
+        <item quantity="other">Maximum %1$d characters</item>
+    </plurals>
     <string name="maximum_n_chars">Maximum %1$d characters</string>
     <string name="no_value">No value</string>
     <string name="enter_value">Enter Value</string>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/631](https://devtopia.esri.com/runtime/apollo/issues/631)

<!-- link to design, if applicable -->

### Description:

Ensures and verifies all the strings that need localization are present in the toolkit.

### Summary of changes:

- updated `maximum_n_chars` to use plurals.
- removed the usage of "Add photo" which has been replaced by "Take Photo".

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/34/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  