### PR TITLE
`Forms` : Refactor new attachment name generation

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -272,7 +272,7 @@ internal class FormAttachmentState(
      * The name of the attachment. Setting the name will update the [FormAttachment.name] property.
      * This is backed by a [MutableState] and can be observed by the composition.
      */
-    var name : String
+    var name: String
         get() = _name.value
         set(value) {
             formAttachment?.name = value
@@ -523,15 +523,18 @@ internal fun FormAttachmentType.getIcon(): ImageVector = when (this) {
 /**
  * Returns a new attachment name based on the content type.
  */
-internal fun List<FormAttachmentState>.getNewAttachmentNameForContentType(contentType: String): String {
-    val prefix = when {
-        contentType.startsWith("image/") -> "Image"
-        contentType.startsWith("video/") -> "Video"
-        else -> "Attachment"
-    }
-    val count = this.count { entry ->
-        entry.contentType.split("/").firstOrNull()
-            .equals(contentType.split("/").firstOrNull(), ignoreCase = true)
+internal fun AttachmentElementState.getNewAttachmentNameForContentType(contentType: String): String {
+    // use the content type prefix to generate a new attachment name
+    val prefix = contentType.split("/").firstOrNull()?.replaceFirstChar(Char::titlecase)
+        ?: "Attachment"
+    var count = attachments.count { entry ->
+        // count the number of attachments with the same content type
+        entry.contentType == contentType
     } + 1
-    return "$prefix $count"
+    // create a set of attachment names to check for duplicates
+    val names = attachments.mapTo(hashSetOf()) { it.name }
+    while (names.contains("${prefix}$count")) {
+        count++
+    }
+    return "${prefix}$count"
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -387,7 +387,7 @@ private suspend fun AttachmentElementState.addAttachmentFromUri(
         return@withContext Result.failure(Exception(context.getString(R.string.attachment_error)))
     }
     // generate a name for the attachment
-    var name = "${attachments.getNewAttachmentNameForContentType(contentType)}.$extension"
+    var name = "${getNewAttachmentNameForContentType(contentType)}.$extension"
     // size of the attachment
     var size = 0L
     // get the name and size of the attachment


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/682](https://devtopia.esri.com/runtime/apollo/issues/682)

<!-- link to design, if applicable -->

### Description:

Refactors how the new attachment names are generated so it is equivalent with swift.

### Summary of changes:

- New attachment name is prefixed by its contentType followed by the number of such types in the list of attachments.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  