### PR TITLE
some small fixes

### DIFF
--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
@@ -77,7 +77,7 @@ internal class MediaElementState(
                         ""
                     },
                     MediaImageProvider(
-                        fileName = "media-${Objects.hash(mediaPopupElement.title, media.title, media.caption)}",
+                        fileName = "media-${Objects.hash(mediaPopupElement.title, media.title, media.caption)}.png",
                         folderName = mediaFolder
                     ) {
                         media.generateChart(chartParams).getOrThrow().image.bitmap
@@ -173,7 +173,7 @@ internal fun rememberMediaElementState(
     val mediaFolder = "${LocalContext.current.cacheDir.canonicalPath}/popup_media"
     val context = LocalContext.current
     return rememberSaveable(
-        inputs = arrayOf(popup, element),
+        inputs = arrayOf(popup, element.toJson()),
         saver = MediaElementState.Saver(element, scope, mediaFolder, chartParams, context)
     ) {
         MediaElementState(

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/util/MediaImageProvider.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/util/MediaImageProvider.kt
@@ -40,11 +40,9 @@ internal class MediaImageProvider(
         val directory = File(folderName)
         directory.mkdirs()
         val file = File(directory, fileName)
-        if (!file.exists()) {
-            file.createNewFile()
-            BufferedOutputStream(FileOutputStream(file)).use { bos ->
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, bos)
-            }
+        file.createNewFile()
+        BufferedOutputStream(FileOutputStream(file)).use { bos ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, bos)
         }
         file.canonicalPath
     }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #4251

<!-- link to design, if applicable -->

### Description:

* fix keying of MediaElementState saver to work when the PopupMediaElement instance from the SDK has changed. this can happen when evaluateExpressions is called.
* always save the image in MediaImageProvider. Just call it intelligently.
* add png suffix to chart images saved to disk

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/38/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  