### PR TITLE
`Forms` : fix thumbnails mismatch

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -18,6 +18,7 @@ package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.graphics.Bitmap
 import android.text.format.Formatter
 import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
@@ -109,7 +110,7 @@ internal fun AttachmentTile(
 ) {
     val loadStatus by state.loadStatus.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }
-    val thumbnailUri by state.thumbnailUri
+    val thumbnail by state.thumbnail
     val configuration = LocalViewConfiguration.current
     val haptic = LocalHapticFeedback.current
     var showContextMenu by remember { mutableStateOf(false) }
@@ -133,7 +134,7 @@ internal fun AttachmentTile(
                 LoadStatus.Loaded -> LoadedView(
                     title = state.name,
                     type = state.type,
-                    thumbnailUri = thumbnailUri
+                    thumbnail = thumbnail
                 )
 
                 LoadStatus.Loading -> DefaultView(
@@ -262,16 +263,16 @@ internal fun AttachmentTile(
 private fun LoadedView(
     title: String,
     type: FormAttachmentType,
-    thumbnailUri: String,
+    thumbnail: Bitmap?,
     modifier: Modifier = Modifier
 ) {
     Box(
         modifier = modifier
             .fillMaxSize()
     ) {
-        if (thumbnailUri.isNotEmpty()) {
+        if (thumbnail != null) {
             AsyncImage(
-                model = thumbnailUri,
+                model = thumbnail,
                 contentDescription = "Thumbnail",
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize()


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/781](https://devtopia.esri.com/runtime/apollo/issues/781)

<!-- link to design, if applicable -->

### Description:

Fixes an issue where thumbnails for a `FormAttachment` are re-used. This PR refactors the thumbnail creation logic to fix the issue.

### Summary of changes:

- Thumbnails are no longer saved to a file. Instead they are loaded directly into the state object `FormAttachmentState`. 
- This is because the `Attachment.id` property is not unique when the attachment has just been added and is not yet synced with the service. Hence there is no unique property available to name the thumbnail file.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  