### PR TITLE
`Forms` : Attachment size based functionality restrictions

### DIFF
--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -116,4 +116,5 @@
     <string name="attachment_is_empty">Empty files are not supported</string>
     <string name="download_empty_file">Empty files cannot be downloaded</string>
     <string name="attachment_deleted">%1s was deleted successfully</string>
+    <string name="attachment_size_limit_exceeded">Attachments larger than %1$s cannot be downloaded</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/775](https://devtopia.esri.com/runtime/apollo/issues/755), #[apollo/768](https://devtopia.esri.com/runtime/apollo/issues/768)


<!-- link to design, if applicable -->

### Description:

Restricts rename/delete for empty attachment.  This is because rename/delete on an 0 sized attachment will result in error when `applyEdits()` is called.
Blocks download and rename of large attachments of > 50 MB. This is because renaming an attachment will load the attachment into memory which we are trying to avoid


### Summary of changes:

- The context menu is hidden for any attachments whose size is 0.
- `FormAttachmentState.maxAttachmentSize` specifies the max allowed attachment size that can be loaded. This is 50 MB currently.
- Added two exception types that can be used to send error information to the UI from the `FormAttachmentState`.
    -  `AttachmentSizeLimitExceededException` - indicates attachment size exceeds the maximum limit.
    - `EmptyAttachmentException` - indicates attachment size is 0.
- `AttachmentTile` can now collect on the `FormAttachmentState.loadStatus` to listen to failures and display a toast accordingly.
- Rename is disabled in the context menu for attachments greater than the specified limit in `FormAttachmentState.maxAttachmentSize`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  