### PR TITLE
Add SideEffect to Callout

### DIFF
--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -169,6 +169,7 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
     ) {
         if (this.isCalloutBeingDisplayed.compareAndSet(false, true)) {
             this.CalloutInternal(geoElement, modifier, tapLocation, colorScheme, shapes, content)
+
             SideEffect {
                 // The SideEffect is executed after every successful (re)composition. This means that it runs at the
                 // end of the GeoView's content lambda from which this Callout function was called. Resetting at this point

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -134,6 +135,12 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
             allowCalloutRecomposition = true
             this.CalloutInternal(location, modifier, offset, rotateOffsetWithGeoView, colorScheme, shapes, content)
         }
+
+        DisposableEffect(Unit) {
+            onDispose {
+                reset()
+            }
+        }
     }
 
     /**
@@ -174,6 +181,12 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         ) {
             allowCalloutRecomposition = true
             this.CalloutInternal(geoElement, modifier, tapLocation, colorScheme, shapes, content)
+        }
+
+        DisposableEffect(Unit) {
+            onDispose {
+                reset()
+            }
         }
     }
 

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -125,19 +125,16 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         shapes: CalloutShapes = CalloutDefaults.shapes(),
         content: @Composable BoxScope.() -> Unit
     ) {
-        // Enables the recomposition of the first Callout in the content lambda that is displayed
-        // on the MapView/SceneView
-        var allowCalloutRecomposition by remember { mutableStateOf(false) }
-
-        if (this.isCalloutBeingDisplayed.compareAndSet(false, true)
-            || allowCalloutRecomposition
-        ) {
-            allowCalloutRecomposition = true
+        if (this.isCalloutBeingDisplayed.compareAndSet(false, true)) {
             this.CalloutInternal(location, modifier, offset, rotateOffsetWithGeoView, colorScheme, shapes, content)
-        }
 
-        SideEffect {
-            reset()
+            SideEffect {
+                // The SideEffect is executed after every successful (re)composition. This means that it runs at the
+                // end of the GeoView's content lambda from which this Callout function was called. Resetting at this point
+                // allows us to run the callout code at subsequent recomposition but also to prevent multiple callouts from
+                // being rendered within a single (re)composition pass.
+                reset()
+            }
         }
     }
 
@@ -170,19 +167,15 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         shapes: CalloutShapes = CalloutDefaults.shapes(),
         content: @Composable BoxScope.() -> Unit
     ) {
-        // Enables the recomposition of the first Callout in the content lambda that is displayed
-        // on the MapView/SceneView
-        var allowCalloutRecomposition by remember { mutableStateOf(false) }
-
-        if (this.isCalloutBeingDisplayed.compareAndSet(false, true)
-            || allowCalloutRecomposition
-        ) {
-            allowCalloutRecomposition = true
+        if (this.isCalloutBeingDisplayed.compareAndSet(false, true)) {
             this.CalloutInternal(geoElement, modifier, tapLocation, colorScheme, shapes, content)
-        }
-
-        SideEffect {
-            reset()
+            SideEffect {
+                // The SideEffect is executed after every successful (re)composition. This means that it runs at the
+                // end of the GeoView's content lambda from which this Callout function was called. Resetting at this point
+                // allows us to run the callout code at subsequent recomposition but also to prevent multiple callouts from
+                // being rendered within a single (re)composition pass.
+                reset()
+            }
         }
     }
 

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -30,8 +30,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -136,10 +136,8 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
             this.CalloutInternal(location, modifier, offset, rotateOffsetWithGeoView, colorScheme, shapes, content)
         }
 
-        DisposableEffect(Unit) {
-            onDispose {
-                reset()
-            }
+        SideEffect {
+            reset()
         }
     }
 
@@ -183,10 +181,8 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
             this.CalloutInternal(geoElement, modifier, tapLocation, colorScheme, shapes, content)
         }
 
-        DisposableEffect(Unit) {
-            onDispose {
-                reset()
-            }
+        SideEffect {
+            reset()
         }
     }
 
@@ -202,7 +198,7 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
      *
      * @since 200.5.0
      */
-    internal fun reset() {
+    private fun reset() {
         isCalloutBeingDisplayed.set(false)
     }
 

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
@@ -206,7 +206,6 @@ public fun MapView(
 
         if (isMapViewReady.value) {
             content?.let {
-                mapViewScope.reset()
                 mapViewScope.it()
             }
         }

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/SceneView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/SceneView.kt
@@ -211,7 +211,6 @@ public fun SceneView(
 
         if (isSceneViewReady.value) {
             content?.let {
-                sceneViewScope.reset()
                 sceneViewScope.it()
             }
         }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#4289](https://devtopia.esri.com/runtime/kotlin/issues/4289)

<!-- link to design, if applicable -->

### Description:
PR to trigger a Callout `reset()` when Callout is disposed. 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/49/