### PR TITLE
Disable UsernamePassword Login button when fields are empty

### DIFF
--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
@@ -5,12 +5,16 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasImeAction
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.text.input.ImeAction
 import androidx.test.platform.app.InstrumentationRegistry
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeResponse
@@ -18,13 +22,18 @@ import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallenge
 import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallengeResponse
 import com.arcgismaps.httpcore.authentication.NetworkAuthenticationType
 import com.arcgismaps.httpcore.authentication.TokenCredential
+import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -42,7 +51,7 @@ import org.junit.rules.TestRule
  */
 class UsernamePasswordTests {
 
-    val authenticatorState = AuthenticatorState()
+    private val authenticatorState = AuthenticatorState()
 
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
@@ -87,7 +96,7 @@ class UsernamePasswordTests {
     }
 
     /**
-     * Given a Dialog Authenticator
+     * Given an UsernamePasswordAuthenticator
      * When the username or password fields are empty
      * Then the login button should be disabled
      * And when the username and password fields are both filled
@@ -95,19 +104,69 @@ class UsernamePasswordTests {
      *
      * @since 200.5.0
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun loginButtonEnabledState() = runTest {
-        val response = testUsernamePasswordChallengeWithStateRestoration {
-            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsNotEnabled()
-            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_label))
-                .performTextInput("testuser")
-            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsNotEnabled()
-            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.password_label))
-                .performTextInput("testPassword")
-            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsEnabled()
-            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).performClick()
-        }.await()
-        assert(response is NetworkAuthenticationChallengeResponse.ContinueWithCredential)
+        composeTestRule.setContent {
+            UsernamePasswordAuthenticator(
+                UsernamePasswordChallenge(
+                    url = "https://arcgis.com",
+                    onUsernamePasswordReceived = { _, _ -> },
+                    onCancel = {}
+                )
+            )
+        }
+        advanceUntilIdle()
+        // verify the login button is disabled when the fields are empty
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsNotEnabled()
+        // verify the login button is disabled when only the username field is filled
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_label))
+            .performTextInput("testuser")
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsNotEnabled()
+        // verify the login button is disabled when only the password field is filled
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_label)).performTextClearance()
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.password_label))
+            .performTextInput("testPassword")
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsNotEnabled()
+        // verify it is enabled when both are filled
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_label))
+            .performTextInput("testuser")
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsEnabled()
+    }
+
+    /**
+     * Given an UsernamePasswordAuthenticator
+     * When the username field is clicked
+     * Then the keyboard should be displayed with ImeAction.Next
+     * And when the password field is clicked
+     * Then the keyboard should be displayed with ImeAction.Send
+     *
+     * When the the ImeAction.Send is clicked
+     * Then the form should not be submitted when the fields are empty
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun keyboardActions() = runTest {
+        val usernamePasswordChallengeMock = mockk<UsernamePasswordChallenge>()
+        every { usernamePasswordChallengeMock.url } returns "https://arcgis.com"
+        every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
+        every { usernamePasswordChallengeMock.continueWithCredentials(any(),any())} just Runs
+
+        composeTestRule.setContent {
+            UsernamePasswordAuthenticator(usernamePasswordChallengeMock)
+        }
+
+        // ensure the dialog prompt is displayed as expected
+        advanceUntilIdle()
+        // verify that clicking on the username field displays the keyboard with ImeAction.Next
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_label)).performClick()
+        composeTestRule.onNode(hasImeAction(ImeAction.Next)).assertExists()
+        // verify that clicking on the password field displays the keyboard with ImeAction.Send
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.password_label)).performClick()
+        composeTestRule.onNode(hasImeAction(ImeAction.Send)).assertExists()
+        // verify that clicking on ImeAction.Send will not submit the form when the fields are empty
+        composeTestRule.onNode(hasImeAction(ImeAction.Send)).performImeAction()
+        verify (exactly = 0) { usernamePasswordChallengeMock.continueWithCredentials(any(),any()) }
     }
 
 

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
@@ -3,6 +3,8 @@ package com.arcgismaps.toolkit.authentication
 import android.view.KeyEvent
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -83,6 +85,31 @@ class UsernamePasswordTests {
         }.await()
         assert(response is NetworkAuthenticationChallengeResponse.ContinueWithCredential)
     }
+
+    /**
+     * Given a Dialog Authenticator
+     * When the username or password fields are empty
+     * Then the login button should be disabled
+     * And when the username and password fields are both filled
+     * Then the login button should be enabled
+     *
+     * @since 200.5.0
+     */
+    @Test
+    fun loginButtonEnabledState() = runTest {
+        val response = testUsernamePasswordChallengeWithStateRestoration {
+            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsNotEnabled()
+            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_label))
+                .performTextInput("testuser")
+            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsNotEnabled()
+            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.password_label))
+                .performTextInput("testPassword")
+            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsEnabled()
+            composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).performClick()
+        }.await()
+        assert(response is NetworkAuthenticationChallengeResponse.ContinueWithCredential)
+    }
+
 
     /**
      * Given a Dialog Authenticator

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
@@ -124,7 +124,8 @@ class UsernamePasswordTests {
             .performTextInput("testuser")
         composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsNotEnabled()
         // verify the login button is disabled when only the password field is filled
-        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_label)).performTextClearance()
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_label))
+            .performTextClearance()
         composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.password_label))
             .performTextInput("testPassword")
         composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.login)).assertIsNotEnabled()
@@ -142,7 +143,10 @@ class UsernamePasswordTests {
      * Then the keyboard should be displayed with ImeAction.Send
      *
      * When the the ImeAction.Send is clicked
-     * Then the form should not be submitted when the fields are empty
+     * And both text fields are empty
+     * Then the credentials should not be submitted
+     *
+     * @since 200.5.0
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
@@ -150,7 +154,7 @@ class UsernamePasswordTests {
         val usernamePasswordChallengeMock = mockk<UsernamePasswordChallenge>()
         every { usernamePasswordChallengeMock.url } returns "https://arcgis.com"
         every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
-        every { usernamePasswordChallengeMock.continueWithCredentials(any(),any())} just Runs
+        every { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) } just Runs
 
         composeTestRule.setContent {
             UsernamePasswordAuthenticator(usernamePasswordChallengeMock)
@@ -166,7 +170,7 @@ class UsernamePasswordTests {
         composeTestRule.onNode(hasImeAction(ImeAction.Send)).assertExists()
         // verify that clicking on ImeAction.Send will not submit the form when the fields are empty
         composeTestRule.onNode(hasImeAction(ImeAction.Send)).performImeAction()
-        verify (exactly = 0) { usernamePasswordChallengeMock.continueWithCredentials(any(),any()) }
+        verify(exactly = 0) { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) }
     }
 
 

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
@@ -160,6 +160,7 @@ public fun UsernamePasswordAuthenticator(
             ) {
                 Button(
                     modifier = Modifier.padding(4.dp).fillMaxWidth(),
+                    enabled = usernameFieldText.isNotEmpty() && passwordFieldText.isNotEmpty(),
                     onClick = { submitUsernamePassword() }
                 ) {
                     Text(stringResource(id = R.string.login))

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
@@ -113,11 +113,13 @@ public fun UsernamePasswordAuthenticator(
             var passwordFieldText by rememberSaveable { mutableStateOf("") }
 
             fun submitUsernamePassword() {
-                usernamePasswordChallenge.continueWithCredentials(
-                    usernameFieldText,
-                    passwordFieldText
-                )
-                passwordFieldText = ""
+                if (usernameFieldText.isNotEmpty() && passwordFieldText.isNotEmpty()) {
+                    usernamePasswordChallenge.continueWithCredentials(
+                        usernameFieldText,
+                        passwordFieldText
+                    )
+                    passwordFieldText = ""
+                }
             }
 
             val keyboardActions = remember {
@@ -136,7 +138,6 @@ public fun UsernamePasswordAuthenticator(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Next
                 ),
-                keyboardActions = keyboardActions,
                 label = { Text(text = stringResource(id = R.string.username_label)) },
                 singleLine = true
             )


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:
- Improvements to the Username/Login prompt 

### Summary of changes:
- Disables the "Login" button when the text is empty
- Disallows submitting empty username/password with keyboard action button 
- Adds test to verify behavior 
 
### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/53
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  