### PR TITLE
prepare toolkit for 200.5.0 release build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,8 +50,8 @@ versionNumber=200.5.0
 buildNumber=0000-snapshot
 #set this flag to `true` to ignore the build number when publishing. This
 # will publish an artifact with a build number like "..:200.2.0" as opposed to "...:200.2.0-3963
-ignoreBuildNumber=false
+ignoreBuildNumber=true
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.5.0
-sdkBuildNumber=4297
+sdkBuildNumber=


### PR DESCRIPTION
remove sdk build number
set ignoreBuildNumbers to true so the toolkit is published with a version that does not contain build numbers