### PR TITLE
prepare toolkit for 200.6.0 daily builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,12 +46,12 @@ artifactoryUsername=""
 artifactoryPassword=""
 # these numbers will define the artifact version on artifactory
 # and are overridden by the jenkins command line in the daily build
-versionNumber=200.5.0
+versionNumber=200.6.0
 buildNumber=0000-snapshot
 #set this flag to `true` to ignore the build number when publishing. This
 # will publish an artifact with a build number like "..:200.2.0" as opposed to "...:200.2.0-3963
-ignoreBuildNumber=true
+ignoreBuildNumber=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
-sdkVersionNumber=200.5.0
-sdkBuildNumber=
+sdkVersionNumber=200.6.0
+sdkBuildNumber=4315


### PR DESCRIPTION
undo the `no build number` sdk build dependency and the `no build number` publication.

set values for 200.6.0

to be merged after v.next is merged to main.