### PR TITLE
drive publication of final toolkit build from FINAL_BUILD 

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -31,8 +31,9 @@ val artifactoryUsername: String by project
 val artifactoryPassword: String by project
 val versionNumber: String by project
 val buildNumber: String by project
-val finalBuild: String by project
-val artifactVersion: String = if (finalBuild == "true") {
+val finalBuild: Boolean = (project.properties["finalBuild"] ?: "false")
+    .run { this == "true" }
+val artifactVersion: String = if (finalBuild) {
     versionNumber
 } else {
     "$versionNumber-$buildNumber"

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -31,8 +31,8 @@ val artifactoryUsername: String by project
 val artifactoryPassword: String by project
 val versionNumber: String by project
 val buildNumber: String by project
-val ignoreBuildNumber: String by project
-val artifactVersion: String = if (ignoreBuildNumber == "true") {
+val finalBuild: String by project
+val artifactVersion: String = if (finalBuild == "true") {
     versionNumber
 } else {
     "$versionNumber-$buildNumber"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,14 +38,13 @@ buildscript {
         // before any dependent subproject uses its symbols to configure a dokka task.
         classpath(libs.dokka.versioning)
     }
+    val finalBuild: Boolean = (project.properties["finalBuild"] ?: "false")
+        .run { this == "true" }
 
-    if (!project.hasProperty("finalBuild") || project.properties["finalBuild"] != "true") {
-        project.extra.set("finalBuild", "false")
-    } else {
-        project.logger.warn("release candidate build requested")
-    }
-
-    if (!project.hasProperty("versionNumber") || !project.hasProperty("buildNumber")) {
+    if (finalBuild) {
+        check(project.hasProperty("versionNumber"))
+        project.logger.info("release candidate build requested version ${project.properties["versionNumber"]}")
+    } else if (!project.hasProperty("versionNumber") && !project.hasProperty("buildNum")) {
         // both version number and build number must be set
         java.util.Properties().run {
             try {
@@ -70,8 +69,6 @@ buildscript {
                 project.extra.set("buildNumber", "SNAPSHOT")
             }
         }
-    } else {
-        project.logger.info("version and build number set from properties to ${project.properties["versionNumber"]}-${project.properties["buildNumber"]}")
     }
 }
 

--- a/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
+++ b/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
@@ -21,10 +21,12 @@ package deploy
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
-import org.gradle.kotlin.dsl.*
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.configurationcache.extensions.capitalized
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.provideDelegate
 import java.net.URI
 
 /**
@@ -45,9 +47,9 @@ class ArtifactPublisher : Plugin<Project> {
         val artifactoryUsername: String by project
         val artifactoryPassword: String by project
         val versionNumber: String by project
-        val ignoreBuildNumber: String by project
+        val finalBuild: String by project
         val buildNumber: String by project
-        val artifactVersion: String = if (ignoreBuildNumber == "true") {
+        val artifactVersion: String = if (finalBuild == "true") {
             versionNumber
         } else {
             "$versionNumber-$buildNumber"

--- a/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
+++ b/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
@@ -47,9 +47,10 @@ class ArtifactPublisher : Plugin<Project> {
         val artifactoryUsername: String by project
         val artifactoryPassword: String by project
         val versionNumber: String by project
-        val finalBuild: String by project
+        val finalBuild: Boolean = (project.properties["finalBuild"] ?: "false")
+            .run { this == "true" }
         val buildNumber: String by project
-        val artifactVersion: String = if (finalBuild == "true") {
+        val artifactVersion: String = if (finalBuild) {
             versionNumber
         } else {
             "$versionNumber-$buildNumber"

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -67,9 +67,20 @@ function _check_options_and_set_variables() {
   fi
 }
 
+function _publishReleaseCandidate() {
+  _log "Publish the release candidate build to artifactory"
+  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PsdkVersionNumber=${BUILDVER} -PsdkBuildNumber=${BUILDNUM} -PfinalBuild=true" ; then
+    echo "error: Running the publish gradle task failed for the release candidate"
+    exit 1
+  fi
+}
+
 function _publish() {
   _log "Publish the release build to artifactory"
-  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -v -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM}" ; then
+
+  if [ ! -z "${FINAL_BUILD}" ]; then
+    _publishReleaseCandidate
+  elif ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM}" ; then
     echo "error: Running the publish gradle task failed"
     exit 1
   fi

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -69,7 +69,7 @@ function _check_options_and_set_variables() {
 
 function _publishReleaseCandidate() {
   _log "Publish the release candidate build to artifactory"
-  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PsdkVersionNumber=${BUILDVER} -PsdkBuildNumber=${BUILDNUM} -PfinalBuild=true" ; then
+  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publishToMavenLocal -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PsdkVersionNumber=${BUILDVER} -PsdkBuildNumber=${BUILDNUM} -PfinalBuild=true" ; then
     echo "error: Running the publish gradle task failed for the release candidate"
     exit 1
   fi
@@ -80,7 +80,7 @@ function _publish() {
 
   if [ ! -z "${FINAL_BUILD}" ]; then
     _publishReleaseCandidate
-  elif ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM}" ; then
+  elif ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publishToMavenLocal -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM}" ; then
     echo "error: Running the publish gradle task failed"
     exit 1
   fi

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -67,20 +67,10 @@ function _check_options_and_set_variables() {
   fi
 }
 
-function _publishReleaseCandidate() {
-  _log "Publish the release candidate build to artifactory"
-  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PsdkVersionNumber=${BUILDVER} -PsdkBuildNumber=${BUILDNUM} -PfinalBuild=true" ; then
-    echo "error: Running the publish gradle task failed for the release candidate"
-    exit 1
-  fi
-}
-
 function _publish() {
   _log "Publish the release build to artifactory"
 
-  if [ ! -z "${FINAL_BUILD}" ]; then
-    _publishReleaseCandidate
-  elif ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM}" ; then
+  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publishToMavenLocal -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PfinalBuild=${FINAL_BUILD}" ; then
     echo "error: Running the publish gradle task failed"
     exit 1
   fi

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -69,7 +69,7 @@ function _check_options_and_set_variables() {
 
 function _publishReleaseCandidate() {
   _log "Publish the release candidate build to artifactory"
-  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publishToMavenLocal -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PsdkVersionNumber=${BUILDVER} -PsdkBuildNumber=${BUILDNUM} -PfinalBuild=true" ; then
+  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PsdkVersionNumber=${BUILDVER} -PsdkBuildNumber=${BUILDNUM} -PfinalBuild=true" ; then
     echo "error: Running the publish gradle task failed for the release candidate"
     exit 1
   fi
@@ -80,7 +80,7 @@ function _publish() {
 
   if [ ! -z "${FINAL_BUILD}" ]; then
     _publishReleaseCandidate
-  elif ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publishToMavenLocal -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM}" ; then
+  elif ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM}" ; then
     echo "error: Running the publish gradle task failed"
     exit 1
   fi

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -70,7 +70,7 @@ function _check_options_and_set_variables() {
 function _publish() {
   _log "Publish the release build to artifactory"
 
-  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publishToMavenLocal -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PfinalBuild=${FINAL_BUILD}" ; then
+  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PfinalBuild=${FINAL_BUILD}" ; then
     echo "error: Running the publish gradle task failed"
     exit 1
   fi

--- a/ci/run_gradle_task.sh
+++ b/ci/run_gradle_task.sh
@@ -77,7 +77,7 @@ function _run_gradle_task() {
   if [ "${verbose}" == "true" ]; then
     gradle_flags+="--info "
   fi
-
+ 
   if ! ./gradlew ${gradle_flags} ${task} ${extra_gradle_flags}; then
     echo
     echo "error: Something went wrong when running gradle"

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,6 +47,6 @@ artifactoryPassword=""
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 # A final build before release is such a special build, in which case these SDK version numbers
-# are overridden via command line, see _publishReleaseCandidate() in ci/publish.sh.
+# are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
 sdkBuildNumber=4315

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,5 +46,7 @@ artifactoryUsername=""
 artifactoryPassword=""
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
+# A final build before release is such a special build, in which case these SDK version numbers
+# are overridden via command line, see _publishReleaseCandidate() in ci/publish.sh.
 sdkVersionNumber=200.6.0
 sdkBuildNumber=4315

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,13 +44,6 @@ artifactoryGroupId=com.esri
 artifactoryArtifactBaseId=arcgis-maps-kotlin-toolkit
 artifactoryUsername=""
 artifactoryPassword=""
-# these numbers will define the artifact version on artifactory
-# and are overridden by the jenkins command line in the daily build
-versionNumber=200.6.0
-buildNumber=0000-snapshot
-#set this flag to `true` to ignore the build number when publishing. This
-# will publish an artifact with a build number like "..:200.2.0" as opposed to "...:200.2.0-3963
-finalBuild=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ versionNumber=200.6.0
 buildNumber=0000-snapshot
 #set this flag to `true` to ignore the build number when publishing. This
 # will publish an artifact with a build number like "..:200.2.0" as opposed to "...:200.2.0-3963
-ignoreBuildNumber=false
+finalBuild=false
 # these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # and are generally not overridden at the command line unless a special build is requested.
 sdkVersionNumber=200.6.0

--- a/kdoc/build.gradle.kts
+++ b/kdoc/build.gradle.kts
@@ -24,8 +24,8 @@ plugins {
 
 val versionNumber: String by project
 val buildNumber: String by project
-val ignoreBuildNumber: String by project
-val artifactVersion: String = if (ignoreBuildNumber == "true") {
+val finalBuild: String by project
+val artifactVersion: String = if (finalBuild == "true") {
     versionNumber
 } else {
     "$versionNumber-$buildNumber"

--- a/kdoc/build.gradle.kts
+++ b/kdoc/build.gradle.kts
@@ -23,13 +23,6 @@ plugins {
 }
 
 val versionNumber: String by project
-val buildNumber: String by project
-val finalBuild: String by project
-val artifactVersion: String = if (finalBuild == "true") {
-    versionNumber
-} else {
-    "$versionNumber-$buildNumber"
-}
 
 // make this project get evaluated after all the other projects
 // so that we can be sure the logic to determine released components

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,9 @@ pluginManagement {
 val sdkVersionNumber: String by settings
 // The build number of the ArcGIS Maps SDK for Kotlin dependency
 val sdkBuildNumber: String by settings
+// Ignore the build number and pick up the released version of the SDK dependency
+val finalBuild: String = (providers.gradleProperty("finalBuild").orNull ?: "false")
+    .run { if (this != "false") "true" else "false" }
 
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
@@ -50,11 +53,13 @@ dependencyResolutionManagement {
     
     versionCatalogs {
         create("arcgis") {
-            val versionAndBuild = if (sdkBuildNumber.isNotEmpty()) {
-                "$sdkVersionNumber-$sdkBuildNumber"
-            } else {
+            val versionAndBuild = if (finalBuild == "true" || sdkBuildNumber.isEmpty()) {
+                logger.log(LogLevel.WARN,"requested RC build of the SDK $sdkVersionNumber")
                 sdkVersionNumber
+            } else {
+                "$sdkVersionNumber-$sdkBuildNumber"
             }
+
             version("mapsSdk", versionAndBuild)
             library("mapsSdk", "com.esri", "arcgis-maps-kotlin").versionRef("mapsSdk")
         }


### PR DESCRIPTION
environment variable

<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/4399

<!-- link to design, if applicable -->

### Description:

when FINAL_BUILD environment variable is set (to any value)
* publish the toolkit artifacts and the BOM with the no build number (e.g. 200.6.0)
* pick up the daily build of the SDK as a dependency (e.g. 200.6.0-4133, not 200.6.0) 

The build number from `buildnum.txt` is already used. It is passed in to the gradle command line from the jenkins environment in `ci/publish.sh`. The variables in gradle.properties just provide gradle properties to be passed at the command line.

### Summary of changes:

- check for `FINAL_BUILD` in the environment in the ci script `ci/publish.sh`. If present, pass in appropriate gradle properties to ignore build numbers and use the daily build for the sdk dependency.
- change the name of the `ignoreBuildNumber` gradle property to `finalBuild`.

### Pre-merge Checklist

testing: tested using `publishToMavenLocal` for both FINAL_BUILD and non FINAL_BUILD scenarios

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/57/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  