### PR TITLE
Barebones implementation

### DIFF
--- a/microapps/UtilityNetworkTraceApp/app/src/main/java/com/arcgismaps/toolkit/utilitynetworktraceapp/screens/MainScreen.kt
+++ b/microapps/UtilityNetworkTraceApp/app/src/main/java/com/arcgismaps/toolkit/utilitynetworktraceapp/screens/MainScreen.kt
@@ -19,6 +19,10 @@ package com.arcgismaps.toolkit.utilitynetworktraceapp.screens
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -33,6 +37,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.LoadStatus
@@ -79,7 +86,9 @@ fun MainScreen() {
                 label = "popup",
                 modifier = Modifier.heightIn(min = 0.dp, max = 400.dp)
             ) {
-                Trace(utilityNetwork = arcGISMap.utilityNetworks.first())
+                Trace(
+                    arcGISMap = arcGISMap
+                )
             }
         },
         modifier = Modifier.fillMaxSize(),

--- a/microapps/UtilityNetworkTraceApp/app/src/main/java/com/arcgismaps/toolkit/utilitynetworktraceapp/screens/MainScreen.kt
+++ b/microapps/UtilityNetworkTraceApp/app/src/main/java/com/arcgismaps/toolkit/utilitynetworktraceapp/screens/MainScreen.kt
@@ -19,10 +19,6 @@ package com.arcgismaps.toolkit.utilitynetworktraceapp.screens
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -37,9 +33,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Alignment.Companion.CenterHorizontally
-import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.LoadStatus

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -32,6 +32,7 @@ import com.arcgismaps.utilitynetworks.UtilityElementTraceResult
 import com.arcgismaps.utilitynetworks.UtilityNetwork
 import com.arcgismaps.utilitynetworks.UtilityTraceParameters
 import com.arcgismaps.utilitynetworks.UtilityTraceType
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
@@ -74,37 +75,41 @@ public fun Trace(
         horizontalArrangement = Arrangement.Center
     ) {
         Button(onClick = {
-            coroutineScope.launch {
-                // Run a trace
-                val utilityNetworkDefinition = utilityNetwork.definition
-                val utilityNetworkSource =
-                    utilityNetworkDefinition!!.getNetworkSource("Electric Distribution Line")
-                val utilityAssetGroup = utilityNetworkSource!!.getAssetGroup("Medium Voltage")
-                val utilityAssetType =
-                    utilityAssetGroup!!.getAssetType("Underground Three Phase")
-                val startingLocation = utilityNetwork.createElementOrNull(
-                    utilityAssetType!!,
-                    Guid("0B1F4188-79FD-4DED-87C9-9E3C3F13BA77")
-                )
-
-                val utilityTraceParameters = UtilityTraceParameters(
-                    UtilityTraceType.Connected,
-                    listOf(startingLocation!!)
-                )
-
-                val traceResults = utilityNetwork.trace(
-                    utilityTraceParameters
-                ).onSuccess {
-                    // Handle trace results
-                    val traceResult = it[0]
-                    Log.i("UtilityNetworkTraceApp", "Trace results: $it")
-                    Log.i("UtilityNetworkTraceApp", "Trace result element size: ${(traceResult as UtilityElementTraceResult).elements.size}")
-                }.onFailure {
-                    // Handle error
-                }
-            }
+            trace(coroutineScope, utilityNetwork)
         }) {
             Text(text = "Trace")
+        }
+    }
+}
+
+private fun trace(coroutineScope: CoroutineScope, utilityNetwork: UtilityNetwork) {
+    coroutineScope.launch {
+        // Run a trace
+        val utilityNetworkDefinition = utilityNetwork.definition
+        val utilityNetworkSource =
+            utilityNetworkDefinition!!.getNetworkSource("Electric Distribution Line")
+        val utilityAssetGroup = utilityNetworkSource!!.getAssetGroup("Medium Voltage")
+        val utilityAssetType =
+            utilityAssetGroup!!.getAssetType("Underground Three Phase")
+        val startingLocation = utilityNetwork.createElementOrNull(
+            utilityAssetType!!,
+            Guid("0B1F4188-79FD-4DED-87C9-9E3C3F13BA77")
+        )
+
+        val utilityTraceParameters = UtilityTraceParameters(
+            UtilityTraceType.Connected,
+            listOf(startingLocation!!)
+        )
+
+        val traceResults = utilityNetwork.trace(
+            utilityTraceParameters
+        ).onSuccess {
+            // Handle trace results
+            val traceResult = it[0]
+            Log.i("UtilityNetworkTraceApp", "Trace results: $it")
+            Log.i("UtilityNetworkTraceApp", "Trace result element size: ${(traceResult as UtilityElementTraceResult).elements.size}")
+        }.onFailure {
+            // Handle error
         }
     }
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4482

<!-- link to design, if applicable -->

### Description:

Adds changes to perform a successful Trace with predefined Trace Configuration and Starting point


### Summary of changes:

- Add Button to perform trace on the utility network
- use hard coded values as input
- put the result as a Log statement
`Log.i("UtilityNetworkTraceApp", "Trace results: $it")`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/65/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  