### PR TITLE
replace return@Surface with else block

### DIFF
--- a/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilter.kt
+++ b/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilter.kt
@@ -159,94 +159,94 @@ public fun FloorFilter(
                         isFacilitiesSelectorVisible = isVisible
                     }
                 )
-                return@Surface
-            }
-
-            // display close button if set to top, if not display facilities button
-            if (uiProperties.closeButtonPosition == ButtonPosition.Top) {
-                // check if close button is set to visible and not collapsed
-                if (uiProperties.closeButtonVisibility == View.VISIBLE &&
-                    !isFloorsCollapsed &&
-                    selectedFacility.levels.isNotEmpty()
-                ) {
-                    FloorListCloseButton(
-                        modifier,
-                        uiProperties.buttonSize,
-                        onClick = { isFloorsCollapsed = true })
-                }
             } else {
-                if (uiProperties.siteFacilityButtonVisibility == View.VISIBLE) {
-                    SiteFacilityButton(
-                        modifier,
-                        floorFilterState,
-                        isSiteAndFacilitySelectorVisible,
-                        isFacilitiesSelectorVisible,
-                        uiProperties,
-                        onSiteFacilitySelectorVisibilityChanged = { isVisible ->
-                            isSiteAndFacilitySelectorVisible = isVisible
-                        },
-                        onFacilitiesSelectorVisible = { isVisible ->
-                            isFacilitiesSelectorVisible = isVisible
-                        }
-                    )
-                }
-            }
-
-            if (selectedLevelID != null) {
-                if (!isFloorsCollapsed) {
-                    // display a list of floor levels in the selected facility
-                    FloorListColumn(
-                        modifier = modifier.weight(1f,false),
-                        currentFacility = selectedFacility,
-                        selectedLevelID = selectedLevelID,
-                        uiProperties = uiProperties,
-                        onFloorLevelSelected = { index: Int ->
-                            // update the selected level ID on click
-                            floorFilterState.selectedLevelId = selectedFacility.levels[index].id
-                        }
-                    )
-
-                } else {
-                    val selectedLevelName = selectedFacility.levels.find { it.id == selectedLevelID }?.let {
-                        it.shortName.ifBlank { it.levelNumber }
+                // display close button if set to top, if not display facilities button
+                if (uiProperties.closeButtonPosition == ButtonPosition.Top) {
+                    // check if close button is set to visible and not collapsed
+                    if (uiProperties.closeButtonVisibility == View.VISIBLE &&
+                        !isFloorsCollapsed &&
+                        selectedFacility.levels.isNotEmpty()
+                    ) {
+                        FloorListCloseButton(
+                            modifier,
+                            uiProperties.buttonSize,
+                            onClick = { isFloorsCollapsed = true })
                     }
-                    // display only the selected floor level
-                    FloorLevelSelectButton(
-                        index = 0,
-                        selected = true,
-                        floorText = selectedLevelName.toString(),
-                        uiProperties = uiProperties,
-                        onFloorLevelSelected = {
-                            // display all floor levels when clicked
-                            isFloorsCollapsed = false
-                        }
-                    )
+                } else {
+                    if (uiProperties.siteFacilityButtonVisibility == View.VISIBLE) {
+                        SiteFacilityButton(
+                            modifier,
+                            floorFilterState,
+                            isSiteAndFacilitySelectorVisible,
+                            isFacilitiesSelectorVisible,
+                            uiProperties,
+                            onSiteFacilitySelectorVisibilityChanged = { isVisible ->
+                                isSiteAndFacilitySelectorVisible = isVisible
+                            },
+                            onFacilitiesSelectorVisible = { isVisible ->
+                                isFacilitiesSelectorVisible = isVisible
+                            }
+                        )
+                    }
                 }
-            }
 
-            // display close button if set to bottom, if not display facilities button
-            if (uiProperties.closeButtonPosition == ButtonPosition.Bottom) {
-                // check if close button is set to visible and not collapsed
-                if (uiProperties.closeButtonVisibility == View.VISIBLE && !isFloorsCollapsed) {
-                    FloorListCloseButton(modifier, uiProperties.buttonSize, onClick = {
-                        isFloorsCollapsed = true
-                    })
+                if (selectedLevelID != null) {
+                    if (!isFloorsCollapsed) {
+                        // display a list of floor levels in the selected facility
+                        FloorListColumn(
+                            modifier = modifier.weight(1f, false),
+                            currentFacility = selectedFacility,
+                            selectedLevelID = selectedLevelID,
+                            uiProperties = uiProperties,
+                            onFloorLevelSelected = { index: Int ->
+                                // update the selected level ID on click
+                                floorFilterState.selectedLevelId = selectedFacility.levels[index].id
+                            }
+                        )
+
+                    } else {
+                        val selectedLevelName =
+                            selectedFacility.levels.find { it.id == selectedLevelID }?.let {
+                                it.shortName.ifBlank { it.levelNumber }
+                            }
+                        // display only the selected floor level
+                        FloorLevelSelectButton(
+                            index = 0,
+                            selected = true,
+                            floorText = selectedLevelName.toString(),
+                            uiProperties = uiProperties,
+                            onFloorLevelSelected = {
+                                // display all floor levels when clicked
+                                isFloorsCollapsed = false
+                            }
+                        )
+                    }
                 }
-            } else {
-                if (uiProperties.siteFacilityButtonVisibility == View.VISIBLE) {
-                    SiteFacilityButton(
-                        modifier,
-                        floorFilterState,
-                        isSiteAndFacilitySelectorVisible,
-                        isFacilitiesSelectorVisible,
-                        uiProperties,
-                        onSiteFacilitySelectorVisibilityChanged = { isVisible ->
-                            isSiteAndFacilitySelectorVisible = isVisible
-                        },
-                        onFacilitiesSelectorVisible = { isVisible ->
-                            isFacilitiesSelectorVisible = isVisible
-                        }
-                    )
+
+                // display close button if set to bottom, if not display facilities button
+                if (uiProperties.closeButtonPosition == ButtonPosition.Bottom) {
+                    // check if close button is set to visible and not collapsed
+                    if (uiProperties.closeButtonVisibility == View.VISIBLE && !isFloorsCollapsed) {
+                        FloorListCloseButton(modifier, uiProperties.buttonSize, onClick = {
+                            isFloorsCollapsed = true
+                        })
+                    }
+                } else {
+                    if (uiProperties.siteFacilityButtonVisibility == View.VISIBLE) {
+                        SiteFacilityButton(
+                            modifier,
+                            floorFilterState,
+                            isSiteAndFacilitySelectorVisible,
+                            isFacilitiesSelectorVisible,
+                            uiProperties,
+                            onSiteFacilitySelectorVisibilityChanged = { isVisible ->
+                                isSiteAndFacilitySelectorVisible = isVisible
+                            },
+                            onFacilitiesSelectorVisible = { isVisible ->
+                                isFacilitiesSelectorVisible = isVisible
+                            }
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4551

<!-- link to design, if applicable -->

### Description:

- With the upgrade to the compose compiler the FloorFilter has started crashing. 

### Summary of changes:

- Remove the return @Surface call which is causing the crash and replace it with else block.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/75/
  https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/75/Test_20Report_20-_20Integration/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  