### PR TITLE
`Forms`: Add `TextFormElement` tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4336
+sdkBuildNumber=4344

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,7 +47,6 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenLocal()
         google()
         mavenCentral()
         maven {

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/TextFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/TextFormElementTests.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import com.arcgismaps.mapping.featureforms.TextFormElement
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class TextFormElementTests : FeatureFormTestRunner(
+    uri = "https://www.arcgis.com/home/item.html?id=e10c0061182c4102a109dc6b030aa9ef",
+    objectId = 1
+) {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /**
+     * Test case 10.1:
+     * Given a `FeatureForm` with a `TextFormElement` that references a different field
+     * When the `FeatureForm` is displayed
+     * And the field is updated
+     * Then the `TextFormElement` displays the correct updated text
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-101-test-substitution
+     */
+    @Test
+    fun testTextFormElementSubstitution() = runTest {
+        composeTestRule.setContent {
+            MaterialTheme {
+                FeatureForm(featureForm = featureForm)
+            }
+        }
+        // verify initial state
+        val fieldFormElement = featureForm.getFieldFormElementWithLabel("Title")
+        assertThat(fieldFormElement).isNotNull()
+        val titleNode = composeTestRule.onNodeWithText(fieldFormElement!!.label)
+        titleNode.assertIsDisplayed()
+        titleNode.assertEditableTextEquals(fieldFormElement.formattedValue)
+        // verify the text form element displays the correct initial text
+        val textFormElement = featureForm.elements[1] as TextFormElement
+        val initialSubstitutedText = "Title of the map is ${fieldFormElement.formattedValue}."
+        assertThat(textFormElement.text.value).isEqualTo(initialSubstitutedText)
+        composeTestRule.onNodeWithText(initialSubstitutedText).assertIsDisplayed()
+        // enter new text into the field form element which drives the substitution in the text form element
+        titleNode.performTextClearance()
+        titleNode.performTextInput("Los Angeles")
+        titleNode.performImeAction()
+        assertThat(fieldFormElement.formattedValue).isEqualTo("Los Angeles")
+        // verify the text form element displays the correct updated text
+        val updatedSubstitutedText = "Title of the map is Los Angeles."
+        assertThat(textFormElement.text.value).isEqualTo(updatedSubstitutedText)
+        composeTestRule.onNodeWithText(updatedSubstitutedText).assertIsDisplayed()
+    }
+
+    /**
+     * Test case 10.2:
+     *  Given a `FeatureForm` with a `TextFormElement` with a plain-text format
+     *  When the `FeatureForm` is displayed
+     *  Then the `TextFormElement` displays the text as plain text without any formatting
+     *
+     *  https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-102-test-plain-text
+     */
+    @Test
+    fun testTextFormElementDisplaysPlainText() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                FeatureForm(featureForm = featureForm)
+            }
+        }
+        val textFormElement = featureForm.elements[2] as TextFormElement
+        composeTestRule.onNodeWithText(textFormElement.text.value).assertIsDisplayed()
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -54,6 +54,7 @@ import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.featureforms.FormInput
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.FormElement
 import com.arcgismaps.mapping.featureforms.GroupFormElement
@@ -108,6 +109,22 @@ public sealed class ValidationErrorVisibility {
  * A composable Form toolkit component that enables users to edit field values of features in a
  * layer using forms that have been configured externally. Forms may be configured in the [Web Map Viewer](https://www.arcgis.com/home/webmap/viewer.html)
  * or [Fields Maps Designer](https://www.arcgis.com/apps/fieldmaps/)).
+ *
+ * The [FeatureForm] component supports the following [FormElement] types as part of its configuration.
+ * - [AttachmentsFormElement]
+ * - [FieldFormElement] with the following [FormInput] types -
+ *     * [ComboBoxFormInput]
+ *     * [DateTimePickerFormInput]
+ *     * [RadioButtonsFormInput]
+ *     * [SwitchFormInput]
+ *     * [TextAreaFormInput]
+ *     * [TextBoxFormInput]
+ * - [GroupFormElement]
+ * - [TextFormElement]
+ *
+ * Note : Any [AttachmentsFormElement] present in the [FeatureForm.elements] collection are not
+ * currently supported. A default attachments editing support is provided using the
+ * [FeatureForm.defaultAttachmentsElement] property.
  *
  * The colors and typography for the Form can use customized using [FeatureFormColorScheme] and
  * [FeatureFormTypography]. This customization is built on top of [MaterialTheme].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElement.kt
@@ -16,19 +16,20 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.text
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.featureforms.FormTextFormat
+import com.arcgismaps.mapping.featureforms.TextFormElement
 import com.arcgismaps.toolkit.featureforms.theme.FeatureFormTheme
 import kotlinx.coroutines.flow.MutableStateFlow
-import com.arcgismaps.mapping.featureforms.TextFormElement
 
 /**
  * A composable that displays a [TextFormElement].
@@ -41,7 +42,11 @@ internal fun TextFormElement(state: TextFormElementState, modifier: Modifier = M
     val text by state.text.collectAsState()
     val visible by state.isVisible.collectAsState()
     if (visible) {
-        Column(modifier = modifier) {
+        // do not merge semantics for this composable so that each markdown/plain-text element
+        // is treated as a separate node in the semantic tree
+        Surface(
+            modifier = modifier.semantics(mergeDescendants = false) {}
+        ) {
             if (state.format == FormTextFormat.Markdown) {
                 Markdown(text = text)
             } else {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElementState.kt
@@ -63,7 +63,7 @@ internal class TextFormElementState(
                     description = formElement.description,
                     isVisible = formElement.isVisible,
                     text = formElement.text,
-                    format = formElement.textFormat
+                    format = formElement.format
                 )
             }
         )
@@ -84,6 +84,6 @@ internal fun rememberTextFormElementState(
         description = element.description,
         isVisible = element.isVisible,
         text = element.text,
-        format = element.textFormat
+        format = element.format
     )
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/809](https://devtopia.esri.com/runtime/apollo/issues/809)

<!-- link to design, if applicable -->

### Description:

Introduces `TextFormElement` tests using the [common test design](https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-10-textformelement). Note that the test 10.3 will be implemented as an image comparison test when such a framework is available.

### Summary of changes:

- Added test case 10.1 and 10.2 of the common toolkit tests.
- Updated sdk version to the latest since the `TextFormElement` API is now approved and generated.
- Updated `FeatureForm` doc.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/72/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  