### PR TITLE
`Forms` : Add SubTypeFeatureLayer support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4344
+sdkBuildNumber=4350

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4350
+sdkBuildNumber=4352

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -19,12 +19,15 @@
 package com.arcgismaps.toolkit.featureformsapp.screens.map
 
 import android.content.Context
+import android.content.res.Resources
+import android.graphics.Bitmap
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,8 +39,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -50,14 +56,18 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -65,6 +75,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -72,10 +84,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.window.core.layout.WindowSizeClass
 import androidx.window.layout.WindowMetricsCalculator
+import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.exceptions.FeatureFormValidationException
+import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.layers.ArcGISSublayer
+import com.arcgismaps.mapping.layers.FeatureLayer
+import com.arcgismaps.mapping.layers.SubtypeFeatureLayer
 import com.arcgismaps.toolkit.featureforms.FeatureForm
 import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureformsapp.R
@@ -85,17 +103,16 @@ import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetLayout
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetValue
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.StandardBottomSheet
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberStandardBottomSheetState
+import com.arcgismaps.toolkit.featureformsapp.screens.login.verticalScrollbar
 import com.arcgismaps.toolkit.geoviewcompose.MapView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () -> Unit = {}) {
     val uiState by mapViewModel.uiState
     val context = LocalContext.current
-    val windowSize = getWindowSize(context)
     val (featureForm, errorVisibility) = remember(uiState) {
         when (uiState) {
             is UIState.Editing -> {
@@ -154,9 +171,11 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                     onBackPressed()
                 }
                 if (uiState is UIState.Loading) {
-                    LinearProgressIndicator(modifier = Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter))
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.BottomCenter)
+                    )
                 }
             }
         }
@@ -170,6 +189,14 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                 .fillMaxSize(),
             onSingleTapConfirmed = { mapViewModel.onSingleTapConfirmed(it) }
         )
+        // show pick a feature dialog if the layer is a sublayer
+        if (uiState is UIState.SelectFeature) {
+            SelectFeatureDialog(
+                state = uiState as UIState.SelectFeature,
+                onSelectFeature = mapViewModel::selectFeature,
+                onDismissRequest = mapViewModel::setDefaultState
+            )
+        }
         AnimatedVisibility(
             visible = featureForm != null,
             enter = slideInVertically { h -> h },
@@ -181,34 +208,11 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             val rememberedForm = remember(this, isSwitching) {
                 featureForm!!
             }
-            val bottomSheetState = rememberStandardBottomSheetState(
-                initialValue = SheetValue.PartiallyExpanded,
-                confirmValueChange = { it != SheetValue.Hidden },
-                skipHiddenState = false
+            FeatureFormSheet(
+                featureForm = rememberedForm,
+                errorVisibility = errorVisibility,
+                modifier = Modifier.padding(padding)
             )
-            SheetLayout(
-                windowSizeClass = windowSize,
-                sheetOffsetY = { bottomSheetState.requireOffset() },
-                modifier = Modifier.padding(padding),
-                maxWidth = BottomSheetMaxWidth,
-            ) { layoutWidth, layoutHeight ->
-                StandardBottomSheet(
-                    state = bottomSheetState,
-                    peekHeight = 40.dp,
-                    expansionHeight = SheetExpansionHeight(0.5f),
-                    sheetSwipeEnabled = true,
-                    shape = RoundedCornerShape(5.dp),
-                    layoutHeight = layoutHeight.toFloat(),
-                    sheetWidth = with(LocalDensity.current) { layoutWidth.toDp() }
-                ) {
-                    // set bottom sheet content to the FeatureForm
-                    FeatureForm(
-                        featureForm = rememberedForm,
-                        modifier = Modifier.fillMaxSize(),
-                        validationErrorVisibility = errorVisibility
-                    )
-                }
-            }
         }
     }
     when (uiState) {
@@ -251,7 +255,144 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             }
         )
     }
+}
 
+@Composable
+fun SelectFeatureDialog(
+    state: UIState.SelectFeature,
+    onSelectFeature: (ArcGISFeature) -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    val features = state.features
+    val lazyListState = rememberLazyListState()
+    Dialog(onDismissRequest = onDismissRequest) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 50.dp)
+                .wrapContentHeight(),
+            shape = RoundedCornerShape(15.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(20.dp),
+                verticalArrangement = Arrangement.Top,
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    text = stringResource(R.string.multiple_features, state.featureCount),
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                )
+                Text(
+                    text = stringResource(R.string.select_a_feature_to_edit),
+                    style = MaterialTheme.typography.titleSmall
+                )
+                Spacer(modifier = Modifier.height(5.dp))
+                HorizontalDivider(thickness = 2.dp)
+                Spacer(modifier = Modifier.height(5.dp))
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScrollbar(lazyListState),
+                    state = lazyListState
+                ) {
+                    features.keys.forEachIndexed { index, layer ->
+                        item {
+                            Text(
+                                text = layer,
+                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                                modifier = Modifier.padding(vertical = 5.dp)
+                            )
+                        }
+                        items(features[layer]!!) { feature ->
+                            FeatureItem(
+                                feature = feature,
+                                onClick = {
+                                    onSelectFeature(feature)
+                                }
+                            )
+                        }
+                        if (index < features.keys.size - 1) {
+                            item {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = 10.dp),
+                                    thickness = 2.dp
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun FeatureItem(
+    feature: ArcGISFeature,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val context = LocalContext.current
+    var bitmap by remember { mutableStateOf<Bitmap?>(null) }
+    ListItem(
+        headlineContent = {
+            Text(text = feature.label)
+        },
+        leadingContent = {
+            bitmap?.let {
+                Image(bitmap = bitmap!!.asImageBitmap(), contentDescription = null)
+            }
+        },
+        colors = ListItemDefaults.colors(
+            containerColor = Color.Transparent
+        ),
+        modifier = modifier.clickable {
+            onClick()
+        }
+    )
+    LaunchedEffect(feature) {
+        bitmap = feature.getSymbol(context.resources)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeatureFormSheet(
+    featureForm: FeatureForm,
+    errorVisibility: ValidationErrorVisibility,
+    modifier: Modifier = Modifier,
+) {
+    val windowSize = getWindowSize(LocalContext.current)
+    val bottomSheetState = rememberStandardBottomSheetState(
+        initialValue = SheetValue.PartiallyExpanded,
+        confirmValueChange = { it != SheetValue.Hidden },
+        skipHiddenState = false
+    )
+    SheetLayout(
+        windowSizeClass = windowSize,
+        sheetOffsetY = { bottomSheetState.requireOffset() },
+        modifier = modifier,
+        maxWidth = BottomSheetMaxWidth,
+    ) { layoutWidth, layoutHeight ->
+        StandardBottomSheet(
+            state = bottomSheetState,
+            peekHeight = 40.dp,
+            expansionHeight = SheetExpansionHeight(0.5f),
+            sheetSwipeEnabled = true,
+            shape = RoundedCornerShape(5.dp),
+            layoutHeight = layoutHeight.toFloat(),
+            sheetWidth = with(LocalDensity.current) { layoutWidth.toDp() }
+        ) {
+            // set bottom sheet content to the FeatureForm
+            FeatureForm(
+                featureForm = featureForm,
+                modifier = Modifier.fillMaxSize(),
+                validationErrorVisibility = errorVisibility
+            )
+        }
+    }
 }
 
 @Composable
@@ -288,7 +429,10 @@ fun NoFormDefinitionDialog(
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(text = stringResource(R.string.no_featureform_found), modifier = Modifier.weight(1f))
+                Text(
+                    text = stringResource(R.string.no_featureform_found),
+                    modifier = Modifier.weight(1f)
+                )
                 Image(imageVector = Icons.Rounded.Warning, contentDescription = null)
             }
         },
@@ -336,7 +480,10 @@ fun TopFormBar(
                 }
             } else {
                 IconButton(onClick = onBackPressed) {
-                    Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
                 }
             }
         },
@@ -472,16 +619,64 @@ fun FeatureFormValidationException.getString(): String {
     }
 }
 
-@Preview
-@Composable
-fun TopFormBarPreview() {
-    TopFormBar("Map", false)
-}
-
 fun getWindowSize(context: Context): WindowSizeClass {
     val metrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context)
     val width = metrics.bounds.width()
     val height = metrics.bounds.height()
     val density = context.resources.displayMetrics.density
     return WindowSizeClass.compute(width / density, height / density)
+}
+
+/**
+ * Returns the label of the feature. If the feature has a name attribute, it will return that.
+ * If the feature has an objectid attribute, it will return "Object ID : <objectid>". If neither
+ * of these attributes are present, it will return "Unnamed Feature".
+ */
+val ArcGISFeature.label: String
+    get() {
+        return if (attributes["name"] != null) {
+            attributes["name"] as String
+        } else if (attributes["objectid"] != null) {
+            "Object ID : ${attributes["objectid"]}"
+        } else {
+            "Unnamed Feature"
+        }
+    }
+
+/**
+ * Returns the symbol of the feature as a bitmap. If the feature's layer is a subtype feature layer,
+ * it will return the symbol of the sublayer that the feature belongs to. If the feature's layer is
+ * a feature layer, it will return the symbol of the feature layer.
+ *
+ * If the symbol cannot be created, it will return null.
+ */
+suspend fun ArcGISFeature.getSymbol(resources: Resources): Bitmap? {
+    val renderer = when (featureTable?.layer) {
+        is SubtypeFeatureLayer -> sublayer?.renderer
+        is FeatureLayer -> (featureTable?.layer as? FeatureLayer)?.renderer
+        else -> null
+    }
+    val symbol = renderer?.getSymbol(this) ?: return null
+    symbol.createSwatch(resources.displayMetrics.density)
+        .onSuccess { bitmap ->
+            return bitmap.bitmap
+        }
+    return null
+}
+
+/**
+ * Returns the sublayer that the feature belongs to. If the feature's layer is not a subtype feature
+ * layer, it will return null.
+ */
+val ArcGISFeature.sublayer: ArcGISSublayer?
+    get() {
+        val subtypeFeatureLayer = featureTable?.layer as? SubtypeFeatureLayer ?: return null
+        val code = getFeatureSubtype()?.code ?: return null
+        return subtypeFeatureLayer.getSublayerWithSubtypeCode(code)
+    }
+
+@Preview
+@Composable
+private fun TopFormBarPreview() {
+    TopFormBar("Map", false)
 }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -64,6 +65,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -341,8 +343,16 @@ fun FeatureItem(
             Text(text = feature.label)
         },
         leadingContent = {
-            bitmap?.let {
-                Image(bitmap = bitmap!!.asImageBitmap(), contentDescription = null)
+            Surface(
+                modifier = Modifier.size(40.dp),
+                shape = CircleShape,
+                // set the color of the surface to white since the bitmap does not support
+                // dark mode
+                color = Color.White
+            ) {
+                bitmap?.let {
+                    Image(bitmap = bitmap!!.asImageBitmap(), contentDescription = null, modifier = Modifier.padding(10.dp))
+                }
             }
         },
         colors = ListItemDefaults.colors(
@@ -657,11 +667,7 @@ suspend fun ArcGISFeature.getSymbol(resources: Resources): Bitmap? {
         else -> null
     }
     val symbol = renderer?.getSymbol(this) ?: return null
-    symbol.createSwatch(resources.displayMetrics.density)
-        .onSuccess { bitmap ->
-            return bitmap.bitmap
-        }
-    return null
+    return symbol.createSwatch(resources.displayMetrics.density).getOrNull()?.bitmap
 }
 
 /**

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -344,6 +344,12 @@ class MapViewModel @Inject constructor(
                 layer.selectFeature(feature)
                 // set the UI to an editing state with the FeatureForm
                 _uiState.value = UIState.Editing(featureForm)
+                scope.launch {
+                    // set the viewpoint to the feature extent
+                    feature.geometry?.let {
+                        proxy.setViewpointGeometry(it.extent, 50.0)
+                    }
+                }
             }
             is UIState.Editing -> {
                 // if the current state is editing then switch to the switching state

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -283,6 +283,8 @@ class MapViewModel @Inject constructor(
      * and sets the UI state to select a feature if multiple features are identified.
      */
     fun onSingleTapConfirmed(singleTapEvent: SingleTapConfirmedEvent) {
+        // do not identify layers if the state is editing
+        if (_uiState.value is UIState.Editing) return
         scope.launch {
             proxy.identifyLayers(
                 screenCoordinate = singleTapEvent.screenCoordinate,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -32,12 +32,15 @@ import com.arcgismaps.exceptions.FeatureFormValidationException
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.featureforms.FeatureFormDefinition
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.FormElement
 import com.arcgismaps.mapping.featureforms.GroupFormElement
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.layers.GroupLayer
 import com.arcgismaps.mapping.layers.Layer
+import com.arcgismaps.mapping.layers.SubtypeFeatureLayer
+import com.arcgismaps.mapping.view.IdentifyLayerResult
 import com.arcgismaps.mapping.view.SingleTapConfirmedEvent
 import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureformsapp.data.PortalItemRepository
@@ -93,6 +96,16 @@ sealed class UIState {
         val featureForm: FeatureForm,
         val errors: List<ErrorInfo>
     ) : UIState()
+
+    /**
+     * State to select a feature from the [features] map. The [featureCount] is the total number of
+     * features identified. This state is used when multiple features are identified at a single
+     * point.
+     */
+    data class SelectFeature(
+        val features: Map<String, List<ArcGISFeature>>,
+        val featureCount: Int
+    ) : UIState()
 }
 
 /**
@@ -138,6 +151,9 @@ class MapViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Check if the map has a FeatureFormDefinition on any of its layers.
+     */
     private suspend fun checkFeatureFormDefinition() {
         map.load()
         val layer = map.operationalLayers.firstOrNull {
@@ -162,22 +178,9 @@ class MapViewModel @Inject constructor(
         val state = (_uiState.value as? UIState.Editing)
             ?: return Result.failure(IllegalStateException("Not in editing state"))
         // build the list of errors
-        val errors = mutableListOf<ErrorInfo>()
         val featureForm = state.featureForm
-        featureForm.validationErrors.value.forEach { entry ->
-            entry.value.forEach { error ->
-                featureForm.elements.getFormElement(entry.key)?.let { formElement ->
-                    if (formElement.isEditable.value || formElement.hasValueExpression) {
-                        errors.add(
-                            ErrorInfo(
-                                formElement.label,
-                                error as FeatureFormValidationException
-                            )
-                        )
-                    }
-                }
-            }
-        }
+        // filter the errors to show only the appropriate ones
+        val errors = filterErrors(featureForm)
         // set the state to committing with the errors if any
         _uiState.value = UIState.Committing(
             featureForm = featureForm,
@@ -235,26 +238,36 @@ class MapViewModel @Inject constructor(
         return Result.success(Unit)
     }
 
-    fun selectNewFeature() =
+    /**
+     * Selects the new feature from the [UIState.Switching] state and sets the UI state to
+     * [UIState.Editing].
+     */
+    fun selectNewFeature() {
         (_uiState.value as? UIState.Switching)?.let { prevState ->
             prevState.oldState.featureForm.discardEdits()
             val layer = prevState.oldState.featureForm.feature.featureTable?.layer as FeatureLayer
             layer.clearSelection()
             layer.selectFeature(prevState.newFeature)
-            _uiState.value =
-                UIState.Editing(
-                    featureForm = FeatureForm(
-                        prevState.newFeature,
-                        layer.featureFormDefinition!!
-                    )
+            _uiState.value = UIState.Editing(
+                featureForm = FeatureForm(
+                    prevState.newFeature,
+                    layer.featureFormDefinition!!
                 )
+            )
         }
+    }
 
+    /**
+     * Continues editing the previous feature from the [UIState.Switching] state.
+     */
     fun continueEditing() =
         (_uiState.value as? UIState.Switching)?.let { prevState ->
             _uiState.value = prevState.oldState
         }
 
+    /**
+     * Rolls back the edits on the current feature and sets the UI state to not editing.
+     */
     fun rollbackEdits(): Result<Unit> {
         (_uiState.value as? UIState.Editing)?.let {
             it.featureForm.discardEdits()
@@ -265,34 +278,41 @@ class MapViewModel @Inject constructor(
         } ?: return Result.failure(IllegalStateException("Not in editing state"))
     }
 
+    /**
+     * Handles the single tap event on the map. Identifies the layers at the given screen coordinate
+     * and sets the UI state to select a feature if multiple features are identified.
+     */
     fun onSingleTapConfirmed(singleTapEvent: SingleTapConfirmedEvent) {
         scope.launch {
             proxy.identifyLayers(
                 screenCoordinate = singleTapEvent.screenCoordinate,
-                tolerance = 22.dp,
-                returnPopupsOnly = false
+                tolerance = 10.dp,
+                returnPopupsOnly = false,
+                maximumResults = null
             ).onSuccess { results ->
+                val context = getApplication<Application>().applicationContext
                 try {
-                    results.forEach { result ->
-                        result.geoElements.firstOrNull {
-                            it is ArcGISFeature && (it.featureTable?.layer as? FeatureLayer)?.featureFormDefinition != null
-                        }?.let {
-                            if (_uiState.value is UIState.Editing) {
-                                val currentState = _uiState.value as UIState.Editing
-                                val newFeature = it as ArcGISFeature
-                                _uiState.value = UIState.Switching(
-                                    oldState = currentState,
-                                    newFeature = newFeature
-                                )
-                            } else if (_uiState.value is UIState.NotEditing) {
-                                val feature = it as ArcGISFeature
-                                val layer = feature.featureTable!!.layer as FeatureLayer
-                                val featureForm =
-                                    FeatureForm(feature, layer.featureFormDefinition!!)
-                                // select the feature
-                                layer.selectFeature(feature)
-                                // set the UI to an editing state with the FeatureForm
-                                _uiState.value = UIState.Editing(featureForm)
+                    if (results.isNotEmpty()) {
+                        val layerFeatures = results.getAllFeatures()
+                        when (val featureCount = layerFeatures.getFeatureCount()) {
+                            0 -> {
+                                withContext(Dispatchers.Main) {
+                                    Toast.makeText(
+                                        context,
+                                        "No Features found with a FeatureFormDefinition",
+                                        Toast.LENGTH_LONG
+                                    ).show()
+                                }
+                            }
+
+                            1 -> {
+                                // select the feature if there is only one
+                                selectFeature(layerFeatures.values.first().first())
+                            }
+
+                            else -> {
+                                // set the UI to select a feature from the list
+                                _uiState.value = UIState.SelectFeature(layerFeatures, featureCount)
                             }
                         }
                     }
@@ -300,8 +320,8 @@ class MapViewModel @Inject constructor(
                     e.printStackTrace()
                     withContext(Dispatchers.Main) {
                         Toast.makeText(
-                            getApplication<Application>().applicationContext,
-                            "failed to create a FeatureForm for the feature",
+                            context,
+                            "Failed to create a FeatureForm for the feature",
                             Toast.LENGTH_LONG
                         ).show()
                     }
@@ -310,8 +330,54 @@ class MapViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Selects the feature and sets the UI state to editing. If the current state is [UIState.Editing]
+     * then the state is switched to [UIState.Switching] to allow switching between features.
+     */
+    fun selectFeature(feature: ArcGISFeature) {
+        when(_uiState.value) {
+            is UIState.SelectFeature, UIState.NotEditing -> {
+                // if the current state is selecting a feature or not editing then select the feature
+                val layer = feature.featureTable!!.layer as FeatureLayer
+                val featureForm = FeatureForm(feature, feature.getFeatureFormDefinition()!!)
+                // select the feature
+                layer.selectFeature(feature)
+                // set the UI to an editing state with the FeatureForm
+                _uiState.value = UIState.Editing(featureForm)
+            }
+            is UIState.Editing -> {
+                // if the current state is editing then switch to the switching state
+                val currentState = _uiState.value as UIState.Editing
+                _uiState.value = UIState.Switching(
+                    oldState = currentState,
+                    newFeature = feature
+                )
+            }
+            else -> return
+        }
+    }
+
+    /**
+     * Sets the UI state to not editing.
+     */
     fun setDefaultState() {
         _uiState.value = UIState.NotEditing
+    }
+
+    /**
+     * Filters the validation errors in the [featureForm] to show only the errors for the editable
+     * fields and fields with value expressions.
+     */
+    private fun filterErrors(featureForm: FeatureForm): List<ErrorInfo> = buildList {
+        featureForm.validationErrors.value.forEach { entry ->
+            entry.value.forEach { error ->
+                featureForm.elements.getFieldFormElement(entry.key)?.let { formElement ->
+                    if (formElement.isEditable.value || formElement.hasValueExpression) {
+                        add(ErrorInfo(formElement.label, error as FeatureFormValidationException))
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -319,33 +385,57 @@ class MapViewModel @Inject constructor(
  * Returns the [FieldFormElement] with the given [fieldName] in the [FeatureForm]. If none exists
  * null is returned.
  */
-fun List<FormElement>.getFormElement(fieldName: String): FieldFormElement? {
-    val fieldElements = filterIsInstance<FieldFormElement>()
-    val element = if (fieldElements.isNotEmpty()) {
-        fieldElements.firstNotNullOfOrNull {
-            if (it.fieldName == fieldName) it else null
+fun List<FormElement>.getFieldFormElement(fieldName: String): FieldFormElement? {
+    for (element in this) {
+        when(element) {
+            is FieldFormElement -> if (element.fieldName == fieldName) return element
+            is GroupFormElement -> element.elements.getFieldFormElement(fieldName)?.let { return it }
+            else -> continue
         }
-    } else {
-        null
     }
+    return null
+}
 
-    return element ?: run {
-        val groupElements = filterIsInstance<GroupFormElement>()
-        if (groupElements.isNotEmpty()) {
-            groupElements.firstNotNullOfOrNull {
-                it.elements.getFormElement(fieldName)
+/**
+ * Returns all the [ArcGISFeature]s from the [IdentifyLayerResult] list that have a [FeatureFormDefinition]
+ * including the sublayer results. The result is a map of layer name to a list of features.
+ */
+fun List<IdentifyLayerResult>.getAllFeatures(): Map<String, List<ArcGISFeature>> {
+    val map = mutableMapOf<String, List<ArcGISFeature>>()
+    forEach { result ->
+        // check if the result has sublayer results and recursively get all features
+        if (result.sublayerResults.isNotEmpty()) {
+            map += result.sublayerResults.getAllFeatures()
+        }
+        // find the features with a FeatureFormDefinition
+        result.geoElements.forEach { geoElement ->
+            if (geoElement is ArcGISFeature && geoElement.getFeatureFormDefinition() != null) {
+                val layerName = result.layerContent.name
+                map[layerName] = map[layerName]?.plus(geoElement) ?: listOf(geoElement)
             }
-        } else {
-            null
         }
     }
+    return map
+}
+
+/**
+ * Returns the total number of features in the map.
+ */
+fun Map<String, List<ArcGISFeature>>.getFeatureCount(): Int {
+    return values.sumOf { it.size }
 }
 
 /**
  * Returns true if the layer has a feature form definition. If the layer is a [GroupLayer] then
  * this function will return true if any of the layers in the group have a feature form definition.
+ * If the layer is a [SubtypeFeatureLayer] then this function will return true if any of the sublayers
+ * have a feature form definition.
  */
 private suspend fun Layer.hasFeatureFormDefinition(): Boolean = when(this) {
+    is SubtypeFeatureLayer -> {
+        load()
+        subtypeSublayers.any { it.featureFormDefinition != null }
+    }
     is FeatureLayer -> {
         load()
         featureFormDefinition != null

--- a/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
+++ b/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
@@ -48,4 +48,6 @@
     <string name="exit">Exit</string>
     <string name="no_featureform_description">FeatureLayers in this map do not contain a FeatureFormDefinition. Feature editing will be disabled.</string>
     <string name="camera_permission_required">Camera permission is required for Attachments. This will result in limited functionality.</string>
+    <string name="multiple_features">Multiple Features (%1$s)</string>
+    <string name="select_a_feature_to_edit">Select a Feature to edit</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/835](https://devtopia.esri.com/runtime/apollo/issues/835)

<!-- link to design, if applicable -->

### Description: 

Added support for fetching the `FeatureFormDefinition` from any sub layers in a map.

### Summary of changes:

- `FeatureFormDefinition` can now be fetched from any `SubTypeSubLayer`.
- A dialog is displayed in the micro-app with all the features identified when a user taps on the map. This includes features from any sub layer results. If a single feature is identified, a FeatureForm is displayed. In case of multiple features identified tapping a feature in the list opens up the FeatureForm.
- checking for a feature form definition now also includes looking at the `SubTypeSubLayer`s.
- Switching to a new feature is disabled, since a lot of refactoring is needed now that selecting from multiple features and sublayers is available. This can be re-added later.

### Test data

- The map "SubtypeSublayers with Forms" can be used to test.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  