### PR TITLE
`Forms`: Fix stale `LaunchedEffect`s

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
@@ -95,7 +95,7 @@ internal fun ComboBoxField(
     val value by state.value
     val isEditable by state.isEditable.collectAsState()
     val isRequired by state.isRequired.collectAsState()
-    val interactionSource = remember { MutableInteractionSource() }
+    val interactionSource = remember(state) { MutableInteractionSource() }
     val placeholder = if (isRequired) {
         stringResource(R.string.enter_value)
     } else if (state.showNoValueOption == FormInputNoValueOption.Show) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -91,36 +92,37 @@ internal fun ComboBoxField(
     state: CodedValueFieldState,
     modifier: Modifier = Modifier
 ) {
+    val currentState by rememberUpdatedState(newValue = state)
     val dialogRequester = LocalDialogRequester.current
-    val value by state.value
-    val isEditable by state.isEditable.collectAsState()
-    val isRequired by state.isRequired.collectAsState()
-    val interactionSource = remember(state) { MutableInteractionSource() }
+    val value by currentState.value
+    val isEditable by currentState.isEditable.collectAsState()
+    val isRequired by currentState.isRequired.collectAsState()
+    val interactionSource = remember { MutableInteractionSource() }
     val placeholder = if (isRequired) {
         stringResource(R.string.enter_value)
-    } else if (state.showNoValueOption == FormInputNoValueOption.Show) {
-        state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
+    } else if (currentState.showNoValueOption == FormInputNoValueOption.Show) {
+        currentState.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
     } else ""
     val isError = value.error !is ValidationErrorState.NoError
     // if any errors are present, show the error as the supporting text
     val supportingText = if (!isError) {
-        state.description
+        currentState.description
     } else {
         value.error.getString()
     }
 
     BaseTextField(
-        text = state.getNameForCodedValue(value.data),
+        text = currentState.getNameForCodedValue(value.data),
         onValueChange = {
             // usually only triggered on a "clear" action
             // this value will be an empty string and the type conversion must be handled
             // by the state object
-            state.onValueChanged(it)
+            currentState.onValueChanged(it)
         },
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
-        label = state.label,
+        label = currentState.label,
         placeholder = placeholder,
         supportingText = supportingText,
         isError = isError,
@@ -128,21 +130,21 @@ internal fun ComboBoxField(
         singleLine = true,
         trailingIcon = Icons.AutoMirrored.Outlined.List,
         interactionSource = interactionSource,
-        onFocusChange = state::onFocusChanged,
+        onFocusChange = currentState::onFocusChanged,
         trailingContent = if (isRequired) {
             // if required then do not show a clear icon
             {
                 Icon(imageVector = Icons.AutoMirrored.Outlined.List, contentDescription = "field icon")
             }
         } else null,
-        hasValueExpression = state.hasValueExpression
+        hasValueExpression = currentState.hasValueExpression
     )
 
     LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect {
             if (it is PressInteraction.Release) {
                 if (isEditable) {
-                    dialogRequester.requestDialog(DialogType.ComboBoxDialog(state.id))
+                    dialogRequester.requestDialog(DialogType.ComboBoxDialog(currentState.id))
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchField.kt
@@ -37,7 +37,7 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
     val checkedState = codeValue.data == state.onValue.code
     val value = if (checkedState) state.onValue.name else state.offValue.name
     val isEditable by state.isEditable.collectAsState()
-    val interactionSource = remember { MutableInteractionSource() }
+    val interactionSource = remember(state) { MutableInteractionSource() }
     BaseTextField(
         text = value,
         onValueChange = {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchField.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -33,11 +34,12 @@ import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseTextFiel
 
 @Composable
 internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier) {
-    val codeValue by state.value
-    val checkedState = codeValue.data == state.onValue.code
-    val value = if (checkedState) state.onValue.name else state.offValue.name
-    val isEditable by state.isEditable.collectAsState()
-    val interactionSource = remember(state) { MutableInteractionSource() }
+    val currentState by rememberUpdatedState(newValue = state)
+    val codeValue by currentState.value
+    val checkedState by rememberUpdatedState (codeValue.data == currentState.onValue.code)
+    val value = if (checkedState) currentState.onValue.name else currentState.offValue.name
+    val isEditable by currentState.isEditable.collectAsState()
+    val interactionSource = remember { MutableInteractionSource() }
     BaseTextField(
         text = value,
         onValueChange = {
@@ -46,24 +48,24 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
-        label = state.label,
-        placeholder = state.placeholder,
-        supportingText = state.description,
+        label = currentState.label,
+        placeholder = currentState.placeholder,
+        supportingText = currentState.description,
         isError = false,
         isRequired = false,
         singleLine = true,
         interactionSource = interactionSource,
-        hasValueExpression = state.hasValueExpression
+        hasValueExpression = currentState.hasValueExpression
     ) {
         Switch(
             checked = checkedState,
             onCheckedChange = { newState ->
                 val code = if (newState) {
-                    state.onValue.code
+                    currentState.onValue.code
                 } else {
-                    state.offValue.code
+                    currentState.offValue.code
                 }
-                state.onValueChanged(code)
+                currentState.onValueChanged(code)
             },
             modifier = Modifier
                 .semantics { contentDescription = "switch" }
@@ -72,16 +74,16 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
         )
     }
 
-    LaunchedEffect(codeValue) {
+    LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect {
             if (isEditable) {
                 if (it is PressInteraction.Release) {
                     val code = if (checkedState) {
-                        state.offValue.code
+                        currentState.offValue.code
                     } else {
-                        state.onValue.code
+                        currentState.onValue.code
                     }
-                    state.onValueChanged(code)
+                    currentState.onValueChanged(code)
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
@@ -49,7 +49,7 @@ internal fun DateTimeField(
     val isEditable by state.isEditable.collectAsState()
     val isRequired by state.isRequired.collectAsState()
     val value by state.value
-    val interactionSource = remember { MutableInteractionSource() }
+    val interactionSource = remember(state) { MutableInteractionSource() }
     val isError = value.error !is ValidationErrorState.NoError
     // if any errors are present, show the error as the supporting text
     val supportingText = if (!isError) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -45,39 +46,40 @@ internal fun DateTimeField(
     state: DateTimeFieldState,
     modifier: Modifier = Modifier
 ) {
+    val currentState by rememberUpdatedState(newValue = state)
     val dialogRequester = LocalDialogRequester.current
-    val isEditable by state.isEditable.collectAsState()
-    val isRequired by state.isRequired.collectAsState()
-    val value by state.value
-    val interactionSource = remember(state) { MutableInteractionSource() }
+    val isEditable by currentState.isEditable.collectAsState()
+    val isRequired by currentState.isRequired.collectAsState()
+    val value by currentState.value
+    val interactionSource = remember { MutableInteractionSource() }
     val isError = value.error !is ValidationErrorState.NoError
     // if any errors are present, show the error as the supporting text
     val supportingText = if (!isError) {
-        state.description
+        currentState.description
     } else {
         value.error.getString()
     }
 
     BaseTextField(
-        text = value.data?.formattedDateTime(state.shouldShowTime) ?: "",
+        text = value.data?.formattedDateTime(currentState.shouldShowTime) ?: "",
         onValueChange = {
             // the only allowable change is to clear the text
             if (it.isEmpty()) {
-                state.onValueChanged(null)
+                currentState.onValueChanged(null)
             }
         },
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
-        label = state.label,
-        placeholder = state.placeholder.ifEmpty { stringResource(id = R.string.no_value) },
+        label = currentState.label,
+        placeholder = currentState.placeholder.ifEmpty { stringResource(id = R.string.no_value) },
         supportingText = supportingText,
         isError = isError,
         isRequired = isRequired,
         singleLine = true,
         interactionSource = interactionSource,
         trailingIcon = Icons.Rounded.EditCalendar,
-        onFocusChange = state::onFocusChanged,
+        onFocusChange = currentState::onFocusChanged,
         trailingContent =
         if (isRequired) {
             {
@@ -89,7 +91,7 @@ internal fun DateTimeField(
         } else {
             null
         },
-        hasValueExpression = state.hasValueExpression
+        hasValueExpression = currentState.hasValueExpression
     )
 
     LaunchedEffect(interactionSource) {
@@ -98,7 +100,7 @@ internal fun DateTimeField(
                 // request to show the date picker dialog only when the touch is released
                 // the dialog is responsible for updating the value on the state
                 if (isEditable) {
-                    dialogRequester.requestDialog(DialogType.DateTimeDialog(state.id))
+                    dialogRequester.requestDialog(DialogType.DateTimeDialog(currentState.id))
                 }
             }
         }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Fixes the following bug :

#### The Bug

When a new `FeatureForm` instance is provided to the `FeatureForm` composable while it is in the composition, the collection of internal states are re-created with the new form data. However, long living operations like collecting on interactions within a `LaunchedEffect` are still referencing the old state data which is now stale.

This results in a condition where tapping on a field like the `ComboBox` and `DateTime`, which request a dialog does not work, since the `state.id` used to request the dialog is no longer in memory.

#### The Fix

An easy fix would be to restart the `LaunchedEffect` when the state changes, but this could be an expensive operation as indicated [here](https://developer.android.com/develop/ui/compose/side-effects#rememberupdatedstate).

Instead, the more optimal fix is to wrap the state object with `rememberUpdatedState(state)` like below.

```kotlin
val currentState by rememberUpdatedState(newValue = state)
```

Using the `currentState` variable ensures that the any long lived operation always has the reference to the latest state object.

Similarly, this also fixes the `LaunchedEffect(codeValue)` in `SwitchField` which would restart the `LaunchedEffect` every time the value changes which is not ideal. Wrapping any values used in the `LaunchedEffect` with `rememberUpdatedState` allows the composable to run the side effects only once.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/90/Test_20Report_20-_20Integration/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  