### PR TITLE
merge `Feature branches/forms` into v.next

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4344
+sdkBuildNumber=4352

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4336
+sdkBuildNumber=4344

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4315
+sdkBuildNumber=4336

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ androidxWindow = "1.2.0"
 binaryCompatibilityValidator = "0.14.0"
 compileSdk = "34"
 compose-navigation = "2.7.7"
+commonMark = "0.22.0"
 dokka = "1.9.20"
 hilt = "2.49"
 hiltExt = "1.2.0"
@@ -63,6 +64,8 @@ coil-bom = { group = "io.coil-kt", name = "coil-bom", version.ref = "coilBOM" }
 coil = { group = "io.coil-kt", name = "coil" }
 coil-base = { group = "io.coil-kt", name = "coil-base" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose" }
+commonmark = { group = "org.commonmark", name = "commonmark", version.ref="commonMark" }
+commonmark-strikethrough = { group = "org.commonmark", name = "commonmark-ext-gfm-strikethrough", version.ref="commonMark" }
 hilt-android-core = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-ext-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltExt" }
@@ -94,6 +97,11 @@ gmazzo-test-aggregation = { id = "io.github.gmazzo.test.aggregation.results", ve
 [bundles]
 core = [
     "androidx-core-ktx"
+]
+
+commonmark = [
+    "commonmark",
+    "commonmark-strikethrough"
 ]
 
 composeCore = [

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -19,12 +19,15 @@
 package com.arcgismaps.toolkit.featureformsapp.screens.map
 
 import android.content.Context
+import android.content.res.Resources
+import android.graphics.Bitmap
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,8 +39,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -50,14 +57,19 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -65,6 +77,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -72,10 +86,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.window.core.layout.WindowSizeClass
 import androidx.window.layout.WindowMetricsCalculator
+import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.exceptions.FeatureFormValidationException
+import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.layers.ArcGISSublayer
+import com.arcgismaps.mapping.layers.FeatureLayer
+import com.arcgismaps.mapping.layers.SubtypeFeatureLayer
 import com.arcgismaps.toolkit.featureforms.FeatureForm
 import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureformsapp.R
@@ -85,17 +105,16 @@ import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetLayout
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.SheetValue
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.StandardBottomSheet
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberStandardBottomSheetState
+import com.arcgismaps.toolkit.featureformsapp.screens.login.verticalScrollbar
 import com.arcgismaps.toolkit.geoviewcompose.MapView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () -> Unit = {}) {
     val uiState by mapViewModel.uiState
     val context = LocalContext.current
-    val windowSize = getWindowSize(context)
     val (featureForm, errorVisibility) = remember(uiState) {
         when (uiState) {
             is UIState.Editing -> {
@@ -154,9 +173,11 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                     onBackPressed()
                 }
                 if (uiState is UIState.Loading) {
-                    LinearProgressIndicator(modifier = Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter))
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.BottomCenter)
+                    )
                 }
             }
         }
@@ -170,6 +191,14 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                 .fillMaxSize(),
             onSingleTapConfirmed = { mapViewModel.onSingleTapConfirmed(it) }
         )
+        // show pick a feature dialog if the layer is a sublayer
+        if (uiState is UIState.SelectFeature) {
+            SelectFeatureDialog(
+                state = uiState as UIState.SelectFeature,
+                onSelectFeature = mapViewModel::selectFeature,
+                onDismissRequest = mapViewModel::setDefaultState
+            )
+        }
         AnimatedVisibility(
             visible = featureForm != null,
             enter = slideInVertically { h -> h },
@@ -181,34 +210,11 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             val rememberedForm = remember(this, isSwitching) {
                 featureForm!!
             }
-            val bottomSheetState = rememberStandardBottomSheetState(
-                initialValue = SheetValue.PartiallyExpanded,
-                confirmValueChange = { it != SheetValue.Hidden },
-                skipHiddenState = false
+            FeatureFormSheet(
+                featureForm = rememberedForm,
+                errorVisibility = errorVisibility,
+                modifier = Modifier.padding(padding)
             )
-            SheetLayout(
-                windowSizeClass = windowSize,
-                sheetOffsetY = { bottomSheetState.requireOffset() },
-                modifier = Modifier.padding(padding),
-                maxWidth = BottomSheetMaxWidth,
-            ) { layoutWidth, layoutHeight ->
-                StandardBottomSheet(
-                    state = bottomSheetState,
-                    peekHeight = 40.dp,
-                    expansionHeight = SheetExpansionHeight(0.5f),
-                    sheetSwipeEnabled = true,
-                    shape = RoundedCornerShape(5.dp),
-                    layoutHeight = layoutHeight.toFloat(),
-                    sheetWidth = with(LocalDensity.current) { layoutWidth.toDp() }
-                ) {
-                    // set bottom sheet content to the FeatureForm
-                    FeatureForm(
-                        featureForm = rememberedForm,
-                        modifier = Modifier.fillMaxSize(),
-                        validationErrorVisibility = errorVisibility
-                    )
-                }
-            }
         }
     }
     when (uiState) {
@@ -251,7 +257,152 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             }
         )
     }
+}
 
+@Composable
+fun SelectFeatureDialog(
+    state: UIState.SelectFeature,
+    onSelectFeature: (ArcGISFeature) -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    val features = state.features
+    val lazyListState = rememberLazyListState()
+    Dialog(onDismissRequest = onDismissRequest) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 50.dp)
+                .wrapContentHeight(),
+            shape = RoundedCornerShape(15.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(20.dp),
+                verticalArrangement = Arrangement.Top,
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    text = stringResource(R.string.multiple_features, state.featureCount),
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                )
+                Text(
+                    text = stringResource(R.string.select_a_feature_to_edit),
+                    style = MaterialTheme.typography.titleSmall
+                )
+                Spacer(modifier = Modifier.height(5.dp))
+                HorizontalDivider(thickness = 2.dp)
+                Spacer(modifier = Modifier.height(5.dp))
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScrollbar(lazyListState),
+                    state = lazyListState
+                ) {
+                    features.keys.forEachIndexed { index, layer ->
+                        item {
+                            Text(
+                                text = layer,
+                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                                modifier = Modifier.padding(vertical = 5.dp)
+                            )
+                        }
+                        items(features[layer]!!) { feature ->
+                            FeatureItem(
+                                feature = feature,
+                                onClick = {
+                                    onSelectFeature(feature)
+                                }
+                            )
+                        }
+                        if (index < features.keys.size - 1) {
+                            item {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = 10.dp),
+                                    thickness = 2.dp
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun FeatureItem(
+    feature: ArcGISFeature,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val context = LocalContext.current
+    var bitmap by remember { mutableStateOf<Bitmap?>(null) }
+    ListItem(
+        headlineContent = {
+            Text(text = feature.label)
+        },
+        leadingContent = {
+            Surface(
+                modifier = Modifier.size(40.dp),
+                shape = CircleShape,
+                // set the color of the surface to white since the bitmap does not support
+                // dark mode
+                color = Color.White
+            ) {
+                bitmap?.let {
+                    Image(bitmap = bitmap!!.asImageBitmap(), contentDescription = null, modifier = Modifier.padding(10.dp))
+                }
+            }
+        },
+        colors = ListItemDefaults.colors(
+            containerColor = Color.Transparent
+        ),
+        modifier = modifier.clickable {
+            onClick()
+        }
+    )
+    LaunchedEffect(feature) {
+        bitmap = feature.getSymbol(context.resources)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeatureFormSheet(
+    featureForm: FeatureForm,
+    errorVisibility: ValidationErrorVisibility,
+    modifier: Modifier = Modifier,
+) {
+    val windowSize = getWindowSize(LocalContext.current)
+    val bottomSheetState = rememberStandardBottomSheetState(
+        initialValue = SheetValue.PartiallyExpanded,
+        confirmValueChange = { it != SheetValue.Hidden },
+        skipHiddenState = false
+    )
+    SheetLayout(
+        windowSizeClass = windowSize,
+        sheetOffsetY = { bottomSheetState.requireOffset() },
+        modifier = modifier,
+        maxWidth = BottomSheetMaxWidth,
+    ) { layoutWidth, layoutHeight ->
+        StandardBottomSheet(
+            state = bottomSheetState,
+            peekHeight = 40.dp,
+            expansionHeight = SheetExpansionHeight(0.5f),
+            sheetSwipeEnabled = true,
+            shape = RoundedCornerShape(5.dp),
+            layoutHeight = layoutHeight.toFloat(),
+            sheetWidth = with(LocalDensity.current) { layoutWidth.toDp() }
+        ) {
+            // set bottom sheet content to the FeatureForm
+            FeatureForm(
+                featureForm = featureForm,
+                modifier = Modifier.fillMaxSize(),
+                validationErrorVisibility = errorVisibility
+            )
+        }
+    }
 }
 
 @Composable
@@ -288,7 +439,10 @@ fun NoFormDefinitionDialog(
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(text = stringResource(R.string.no_featureform_found), modifier = Modifier.weight(1f))
+                Text(
+                    text = stringResource(R.string.no_featureform_found),
+                    modifier = Modifier.weight(1f)
+                )
                 Image(imageVector = Icons.Rounded.Warning, contentDescription = null)
             }
         },
@@ -336,7 +490,10 @@ fun TopFormBar(
                 }
             } else {
                 IconButton(onClick = onBackPressed) {
-                    Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
                 }
             }
         },
@@ -472,16 +629,60 @@ fun FeatureFormValidationException.getString(): String {
     }
 }
 
-@Preview
-@Composable
-fun TopFormBarPreview() {
-    TopFormBar("Map", false)
-}
-
 fun getWindowSize(context: Context): WindowSizeClass {
     val metrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context)
     val width = metrics.bounds.width()
     val height = metrics.bounds.height()
     val density = context.resources.displayMetrics.density
     return WindowSizeClass.compute(width / density, height / density)
+}
+
+/**
+ * Returns the label of the feature. If the feature has a name attribute, it will return that.
+ * If the feature has an objectid attribute, it will return "Object ID : <objectid>". If neither
+ * of these attributes are present, it will return "Unnamed Feature".
+ */
+val ArcGISFeature.label: String
+    get() {
+        return if (attributes["name"] != null) {
+            attributes["name"] as String
+        } else if (attributes["objectid"] != null) {
+            "Object ID : ${attributes["objectid"]}"
+        } else {
+            "Unnamed Feature"
+        }
+    }
+
+/**
+ * Returns the symbol of the feature as a bitmap. If the feature's layer is a subtype feature layer,
+ * it will return the symbol of the sublayer that the feature belongs to. If the feature's layer is
+ * a feature layer, it will return the symbol of the feature layer.
+ *
+ * If the symbol cannot be created, it will return null.
+ */
+suspend fun ArcGISFeature.getSymbol(resources: Resources): Bitmap? {
+    val renderer = when (featureTable?.layer) {
+        is SubtypeFeatureLayer -> sublayer?.renderer
+        is FeatureLayer -> (featureTable?.layer as? FeatureLayer)?.renderer
+        else -> null
+    }
+    val symbol = renderer?.getSymbol(this) ?: return null
+    return symbol.createSwatch(resources.displayMetrics.density).getOrNull()?.bitmap
+}
+
+/**
+ * Returns the sublayer that the feature belongs to. If the feature's layer is not a subtype feature
+ * layer, it will return null.
+ */
+val ArcGISFeature.sublayer: ArcGISSublayer?
+    get() {
+        val subtypeFeatureLayer = featureTable?.layer as? SubtypeFeatureLayer ?: return null
+        val code = getFeatureSubtype()?.code ?: return null
+        return subtypeFeatureLayer.getSublayerWithSubtypeCode(code)
+    }
+
+@Preview
+@Composable
+private fun TopFormBarPreview() {
+    TopFormBar("Map", false)
 }

--- a/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
+++ b/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
@@ -48,4 +48,6 @@
     <string name="exit">Exit</string>
     <string name="no_featureform_description">FeatureLayers in this map do not contain a FeatureFormDefinition. Feature editing will be disabled.</string>
     <string name="camera_permission_required">Camera permission is required for Attachments. This will result in limited functionality.</string>
+    <string name="multiple_features">Multiple Features (%1$s)</string>
+    <string name="select_a_feature_to_edit">Select a Feature to edit</string>
 </resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,7 +47,6 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenLocal()
         google()
         mavenCentral()
         maven {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,6 +47,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     @Suppress("UnstableApiUsage")
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
         maven {

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -97,7 +97,8 @@ apiValidation {
         "com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.time.ComposableSingletons\$TimePickerKt",
         "com.arcgismaps.toolkit.featureforms.internal.components.attachment.ComposableSingletons\$AttachmentFormElementKt",
         "com.arcgismaps.toolkit.featureforms.internal.components.attachment.ComposableSingletons\$AttachmentTileKt",
-        "com.arcgismaps.toolkit.featureforms.internal.components.formelement.ComposableSingletons\$GroupElementKt"
+        "com.arcgismaps.toolkit.featureforms.internal.components.formelement.ComposableSingletons\$GroupElementKt",
+        "com.arcgismaps.toolkit.featureforms.internal.components.text.ComposableSingletons\$TextFormElementKt",
     )
     
     ignoredClasses.addAll(composableSingletons)
@@ -106,6 +107,7 @@ apiValidation {
 
 dependencies {
     api(arcgis.mapsSdk)
+    implementation(libs.bundles.commonmark)
     implementation(platform(libs.coil.bom))
     implementation(libs.coil.compose)
     implementation(platform(libs.androidx.compose.bom))

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/TextFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/TextFormElementTests.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import com.arcgismaps.mapping.featureforms.TextFormElement
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class TextFormElementTests : FeatureFormTestRunner(
+    uri = "https://www.arcgis.com/home/item.html?id=e10c0061182c4102a109dc6b030aa9ef",
+    objectId = 1
+) {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /**
+     * Test case 10.1:
+     * Given a `FeatureForm` with a `TextFormElement` that references a different field
+     * When the `FeatureForm` is displayed
+     * And the field is updated
+     * Then the `TextFormElement` displays the correct updated text
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-101-test-substitution
+     */
+    @Test
+    fun testTextFormElementSubstitution() = runTest {
+        composeTestRule.setContent {
+            MaterialTheme {
+                FeatureForm(featureForm = featureForm)
+            }
+        }
+        // verify initial state
+        val fieldFormElement = featureForm.getFieldFormElementWithLabel("Title")
+        assertThat(fieldFormElement).isNotNull()
+        val titleNode = composeTestRule.onNodeWithText(fieldFormElement!!.label)
+        titleNode.assertIsDisplayed()
+        titleNode.assertEditableTextEquals(fieldFormElement.formattedValue)
+        // verify the text form element displays the correct initial text
+        val textFormElement = featureForm.elements[1] as TextFormElement
+        val initialSubstitutedText = "Title of the map is ${fieldFormElement.formattedValue}."
+        assertThat(textFormElement.text.value).isEqualTo(initialSubstitutedText)
+        composeTestRule.onNodeWithText(initialSubstitutedText).assertIsDisplayed()
+        // enter new text into the field form element which drives the substitution in the text form element
+        titleNode.performTextClearance()
+        titleNode.performTextInput("Los Angeles")
+        titleNode.performImeAction()
+        assertThat(fieldFormElement.formattedValue).isEqualTo("Los Angeles")
+        // verify the text form element displays the correct updated text
+        val updatedSubstitutedText = "Title of the map is Los Angeles."
+        assertThat(textFormElement.text.value).isEqualTo(updatedSubstitutedText)
+        composeTestRule.onNodeWithText(updatedSubstitutedText).assertIsDisplayed()
+    }
+
+    /**
+     * Test case 10.2:
+     *  Given a `FeatureForm` with a `TextFormElement` with a plain-text format
+     *  When the `FeatureForm` is displayed
+     *  Then the `TextFormElement` displays the text as plain text without any formatting
+     *
+     *  https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-102-test-plain-text
+     */
+    @Test
+    fun testTextFormElementDisplaysPlainText() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                FeatureForm(featureForm = featureForm)
+            }
+        }
+        val textFormElement = featureForm.elements[2] as TextFormElement
+        composeTestRule.onNodeWithText(textFormElement.text.value).assertIsDisplayed()
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -108,7 +108,8 @@ public sealed class ValidationErrorVisibility {
 /**
  * A composable Form toolkit component that enables users to edit field values of features in a
  * layer using forms that have been configured externally. Forms may be configured in the [Web Map Viewer](https://www.arcgis.com/home/webmap/viewer.html)
- * or [Fields Maps Designer](https://www.arcgis.com/apps/fieldmaps/)).
+ * or [Fields Maps Designer](https://www.arcgis.com/apps/fieldmaps/)) and can be obtained from either
+ * an `ArcGISFeature`, `ArcGISFeatureTable`, `FeatureLayer` or `SubtypeSublayer`.
  *
  * The [FeatureForm] component supports the following [FormElement] types as part of its configuration.
  * - [AttachmentsFormElement]

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -54,6 +54,7 @@ import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.featureforms.FormInput
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.FormElement
 import com.arcgismaps.mapping.featureforms.GroupFormElement
@@ -108,6 +109,22 @@ public sealed class ValidationErrorVisibility {
  * A composable Form toolkit component that enables users to edit field values of features in a
  * layer using forms that have been configured externally. Forms may be configured in the [Web Map Viewer](https://www.arcgis.com/home/webmap/viewer.html)
  * or [Fields Maps Designer](https://www.arcgis.com/apps/fieldmaps/)).
+ *
+ * The [FeatureForm] component supports the following [FormElement] types as part of its configuration.
+ * - [AttachmentsFormElement]
+ * - [FieldFormElement] with the following [FormInput] types -
+ *     * [ComboBoxFormInput]
+ *     * [DateTimePickerFormInput]
+ *     * [RadioButtonsFormInput]
+ *     * [SwitchFormInput]
+ *     * [TextAreaFormInput]
+ *     * [TextBoxFormInput]
+ * - [GroupFormElement]
+ * - [TextFormElement]
+ *
+ * Note : Any [AttachmentsFormElement] present in the [FeatureForm.elements] collection are not
+ * currently supported. A default attachments editing support is provided using the
+ * [FeatureForm.defaultAttachmentsElement] property.
  *
  * The colors and typography for the Form can use customized using [FeatureFormColorScheme] and
  * [FeatureFormTypography]. This customization is built on top of [MaterialTheme].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -61,6 +61,7 @@ import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.mapping.featureforms.SwitchFormInput
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
+import com.arcgismaps.mapping.featureforms.TextFormElement
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentFormElement
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.rememberAttachmentElementState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseFieldState
@@ -75,7 +76,9 @@ import com.arcgismaps.toolkit.featureforms.internal.components.codedvalue.rememb
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.rememberDateTimeFieldState
 import com.arcgismaps.toolkit.featureforms.internal.components.formelement.FieldElement
 import com.arcgismaps.toolkit.featureforms.internal.components.formelement.GroupElement
+import com.arcgismaps.toolkit.featureforms.internal.components.text.TextFormElement
 import com.arcgismaps.toolkit.featureforms.internal.components.text.rememberFormTextFieldState
+import com.arcgismaps.toolkit.featureforms.internal.components.text.rememberTextFormElementState
 import com.arcgismaps.toolkit.featureforms.internal.utils.FeatureFormDialog
 import com.arcgismaps.toolkit.featureforms.theme.FeatureFormColorScheme
 import com.arcgismaps.toolkit.featureforms.theme.FeatureFormDefaults
@@ -270,6 +273,15 @@ private fun FeatureFormBody(
                             )
                         }
 
+                        is TextFormElement -> {
+                            TextFormElement(
+                                state = entry.getState(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 15.dp, vertical = 10.dp)
+                            )
+                        }
+
                         else -> {
                             // other form elements are not created
                         }
@@ -350,6 +362,11 @@ internal fun rememberStates(
                     fieldStates = fieldStateCollection
                 )
                 states.add(element, groupState)
+            }
+
+            is TextFormElement -> {
+                val state = rememberTextFormElementState(element, form)
+                states.add(element, state)
             }
 
             else -> {}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -91,36 +92,37 @@ internal fun ComboBoxField(
     state: CodedValueFieldState,
     modifier: Modifier = Modifier
 ) {
+    val currentState by rememberUpdatedState(newValue = state)
     val dialogRequester = LocalDialogRequester.current
-    val value by state.value
-    val isEditable by state.isEditable.collectAsState()
-    val isRequired by state.isRequired.collectAsState()
+    val value by currentState.value
+    val isEditable by currentState.isEditable.collectAsState()
+    val isRequired by currentState.isRequired.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }
     val placeholder = if (isRequired) {
         stringResource(R.string.enter_value)
-    } else if (state.showNoValueOption == FormInputNoValueOption.Show) {
-        state.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
+    } else if (currentState.showNoValueOption == FormInputNoValueOption.Show) {
+        currentState.noValueLabel.ifEmpty { stringResource(R.string.no_value) }
     } else ""
     val isError = value.error !is ValidationErrorState.NoError
     // if any errors are present, show the error as the supporting text
     val supportingText = if (!isError) {
-        state.description
+        currentState.description
     } else {
         value.error.getString()
     }
 
     BaseTextField(
-        text = state.getNameForCodedValue(value.data),
+        text = currentState.getNameForCodedValue(value.data),
         onValueChange = {
             // usually only triggered on a "clear" action
             // this value will be an empty string and the type conversion must be handled
             // by the state object
-            state.onValueChanged(it)
+            currentState.onValueChanged(it)
         },
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
-        label = state.label,
+        label = currentState.label,
         placeholder = placeholder,
         supportingText = supportingText,
         isError = isError,
@@ -128,21 +130,21 @@ internal fun ComboBoxField(
         singleLine = true,
         trailingIcon = Icons.AutoMirrored.Outlined.List,
         interactionSource = interactionSource,
-        onFocusChange = state::onFocusChanged,
+        onFocusChange = currentState::onFocusChanged,
         trailingContent = if (isRequired) {
             // if required then do not show a clear icon
             {
                 Icon(imageVector = Icons.AutoMirrored.Outlined.List, contentDescription = "field icon")
             }
         } else null,
-        hasValueExpression = state.hasValueExpression
+        hasValueExpression = currentState.hasValueExpression
     )
 
     LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect {
             if (it is PressInteraction.Release) {
                 if (isEditable) {
-                    dialogRequester.requestDialog(DialogType.ComboBoxDialog(state.id))
+                    dialogRequester.requestDialog(DialogType.ComboBoxDialog(currentState.id))
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchField.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -33,10 +34,11 @@ import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseTextFiel
 
 @Composable
 internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier) {
-    val codeValue by state.value
-    val checkedState = codeValue.data == state.onValue.code
-    val value = if (checkedState) state.onValue.name else state.offValue.name
-    val isEditable by state.isEditable.collectAsState()
+    val currentState by rememberUpdatedState(newValue = state)
+    val codeValue by currentState.value
+    val checkedState by rememberUpdatedState (codeValue.data == currentState.onValue.code)
+    val value = if (checkedState) currentState.onValue.name else currentState.offValue.name
+    val isEditable by currentState.isEditable.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }
     BaseTextField(
         text = value,
@@ -46,24 +48,24 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
-        label = state.label,
-        placeholder = state.placeholder,
-        supportingText = state.description,
+        label = currentState.label,
+        placeholder = currentState.placeholder,
+        supportingText = currentState.description,
         isError = false,
         isRequired = false,
         singleLine = true,
         interactionSource = interactionSource,
-        hasValueExpression = state.hasValueExpression
+        hasValueExpression = currentState.hasValueExpression
     ) {
         Switch(
             checked = checkedState,
             onCheckedChange = { newState ->
                 val code = if (newState) {
-                    state.onValue.code
+                    currentState.onValue.code
                 } else {
-                    state.offValue.code
+                    currentState.offValue.code
                 }
-                state.onValueChanged(code)
+                currentState.onValueChanged(code)
             },
             modifier = Modifier
                 .semantics { contentDescription = "switch" }
@@ -72,16 +74,16 @@ internal fun SwitchField(state: SwitchFieldState, modifier: Modifier = Modifier)
         )
     }
 
-    LaunchedEffect(codeValue) {
+    LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect {
             if (isEditable) {
                 if (it is PressInteraction.Release) {
                     val code = if (checkedState) {
-                        state.offValue.code
+                        currentState.offValue.code
                     } else {
-                        state.onValue.code
+                        currentState.onValue.code
                     }
-                    state.onValueChanged(code)
+                    currentState.onValueChanged(code)
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -45,39 +46,40 @@ internal fun DateTimeField(
     state: DateTimeFieldState,
     modifier: Modifier = Modifier
 ) {
+    val currentState by rememberUpdatedState(newValue = state)
     val dialogRequester = LocalDialogRequester.current
-    val isEditable by state.isEditable.collectAsState()
-    val isRequired by state.isRequired.collectAsState()
-    val value by state.value
+    val isEditable by currentState.isEditable.collectAsState()
+    val isRequired by currentState.isRequired.collectAsState()
+    val value by currentState.value
     val interactionSource = remember { MutableInteractionSource() }
     val isError = value.error !is ValidationErrorState.NoError
     // if any errors are present, show the error as the supporting text
     val supportingText = if (!isError) {
-        state.description
+        currentState.description
     } else {
         value.error.getString()
     }
 
     BaseTextField(
-        text = value.data?.formattedDateTime(state.shouldShowTime) ?: "",
+        text = value.data?.formattedDateTime(currentState.shouldShowTime) ?: "",
         onValueChange = {
             // the only allowable change is to clear the text
             if (it.isEmpty()) {
-                state.onValueChanged(null)
+                currentState.onValueChanged(null)
             }
         },
         modifier = modifier,
         readOnly = true,
         isEditable = isEditable,
-        label = state.label,
-        placeholder = state.placeholder.ifEmpty { stringResource(id = R.string.no_value) },
+        label = currentState.label,
+        placeholder = currentState.placeholder.ifEmpty { stringResource(id = R.string.no_value) },
         supportingText = supportingText,
         isError = isError,
         isRequired = isRequired,
         singleLine = true,
         interactionSource = interactionSource,
         trailingIcon = Icons.Rounded.EditCalendar,
-        onFocusChange = state::onFocusChanged,
+        onFocusChange = currentState::onFocusChanged,
         trailingContent =
         if (isRequired) {
             {
@@ -89,7 +91,7 @@ internal fun DateTimeField(
         } else {
             null
         },
-        hasValueExpression = state.hasValueExpression
+        hasValueExpression = currentState.hasValueExpression
     )
 
     LaunchedEffect(interactionSource) {
@@ -98,7 +100,7 @@ internal fun DateTimeField(
                 // request to show the date picker dialog only when the touch is released
                 // the dialog is responsible for updating the value on the state
                 if (isEditable) {
-                    dialogRequester.requestDialog(DialogType.DateTimeDialog(state.id))
+                    dialogRequester.requestDialog(DialogType.DateTimeDialog(currentState.id))
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/Markdown.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/Markdown.kt
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.text
+
+import android.util.Log
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.commonmark.ext.gfm.strikethrough.Strikethrough
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
+import org.commonmark.node.BulletList
+import org.commonmark.node.Code
+import org.commonmark.node.Emphasis
+import org.commonmark.node.HardLineBreak
+import org.commonmark.node.Heading
+import org.commonmark.node.Link
+import org.commonmark.node.ListBlock
+import org.commonmark.node.Node
+import org.commonmark.node.OrderedList
+import org.commonmark.node.Paragraph
+import org.commonmark.node.SoftLineBreak
+import org.commonmark.node.StrongEmphasis
+import org.commonmark.node.Text
+import org.commonmark.parser.Parser
+import org.commonmark.node.Document
+
+private const val URL_LINK = "URL_LINK"
+
+/**
+ * Renders a markdown formatted text.
+ *
+ * @param text The markdown formatted text.
+ * @param modifier The modifier to be applied to the composable.
+ */
+@Composable
+internal fun Markdown(text: String, modifier: Modifier = Modifier) {
+    val document = remember(text) {
+        Parser.builder()
+            .extensions(listOf(StrikethroughExtension.create()))
+            .build()
+            .parse(text)
+    }
+    Column(modifier = modifier) {
+        MarkdownTree(document)
+    }
+}
+
+/**
+ * Entry point for parsing and rendering the markdown tree.
+ *
+ * @param root The root node of the markdown tree. This can be a [Document] node.
+ */
+@Composable
+private fun MarkdownTree(root: Node) {
+    root.forEachChild { node ->
+        when (node) {
+            is Paragraph -> Paragraph(
+                paragraph = node,
+                modifier = Modifier.padding(vertical = 4.dp)
+            )
+
+            is Heading -> Heading(heading = node, modifier = Modifier.padding(vertical = 8.dp))
+            is BulletList -> ListNode(
+                node = node,
+                level = 0,
+                isOrdered = false,
+                modifier = Modifier.padding(vertical = 4.dp)
+            )
+
+            is OrderedList -> ListNode(
+                node = node,
+                level = 0,
+                isOrdered = true,
+                modifier = Modifier.padding(vertical = 4.dp)
+            )
+
+            else -> Log.w("Markdown", "Unsupported node type: ${node.javaClass.simpleName}")
+        }
+    }
+}
+
+/**
+ * Renders a markdown node and its children recursively. The tree is built as an [AnnotatedString]
+ * and displayed using a [Text] that supports tap gestures on links.
+ *
+ * @param node The markdown node to render.
+ * @param modifier The modifier to be applied to the composable.
+ * @param textStyle The text style to be applied to the text.
+ * @param prefix A prefix string that will be prepended to the text.
+ */
+@Composable
+private fun MarkdownNode(
+    node: Node,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = TextStyle.Default,
+    prefix: AnnotatedString? = null,
+) {
+    val uriHandler = LocalUriHandler.current
+    var layoutResult by remember {
+        mutableStateOf<TextLayoutResult?>(null)
+    }
+    val text = buildAnnotatedString {
+        withStyle(textStyle.toSpanStyle()) {
+            prefix?.let { append(it) }
+            parseMarkdownTree(node)
+        }
+    }
+    Text(
+        text = text,
+        modifier = modifier.pointerInput(Unit) {
+            detectTapGestures { offsetPosition ->
+                if (layoutResult != null) {
+                    val position = layoutResult!!.getOffsetForPosition(offsetPosition)
+                    text.getStringAnnotations(position, position).firstOrNull()?.let { annotation ->
+                        if (annotation.tag == URL_LINK) {
+                            uriHandler.openUri(annotation.item)
+                        }
+                    }
+                }
+            }
+        },
+        style = textStyle,
+        onTextLayout = { layoutResult = it }
+    )
+}
+
+/**
+ * Renders a markdown [Paragraph].
+ */
+@Composable
+private fun Paragraph(paragraph: Paragraph, modifier: Modifier = Modifier) {
+    MarkdownNode(
+        node = paragraph,
+        textStyle = MaterialTheme.typography.bodyMedium,
+        modifier = modifier
+    )
+}
+
+/**
+ * Renders a markdown [Heading].
+ */
+@Composable
+private fun Heading(heading: Heading, modifier: Modifier = Modifier) {
+    val typography = MaterialTheme.typography
+    val textStyle = when (heading.level) {
+        in 1..3 -> typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+        // Designer only supports 4, 5, and 6 levels of headings.
+        4 -> typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+        5 -> typography.titleMedium
+        6 -> typography.titleSmall
+        else -> typography.titleSmall
+    }
+    MarkdownNode(
+        node = heading,
+        textStyle = textStyle,
+        modifier = modifier
+    )
+}
+
+/**
+ * Renders a markdown [BulletList] or [OrderedList] based on the [isOrdered] flag. This also
+ * supports nested lists that are rendered recursively. For nested lists, the nesting level is
+ * determined by the [level] parameter.
+ *
+ * @param node The list node to render.
+ * @param level The nesting level of the list.
+ * @param isOrdered Flag to indicate if the list is ordered.
+ * @param modifier The modifier to be applied to the composable.
+ */
+@Composable
+private fun ListNode(
+    node: ListBlock,
+    level: Int,
+    isOrdered: Boolean,
+    modifier: Modifier = Modifier
+) {
+    var number = if (isOrdered) (node as OrderedList).startNumber else 0
+    Column(
+        modifier = modifier
+    ) {
+        node.forEachChild { child ->
+            val bullet = if (isOrdered) "${number++}. " else when (level % 3) {
+                0 -> "• "
+                1 -> "◦ "
+                else -> "▪ "
+            }
+            child.forEachChild { nestedChild ->
+                when (nestedChild) {
+                    is OrderedList -> ListNode(nestedChild, level + 1, true)
+                    is BulletList -> ListNode(nestedChild, level + 1, false)
+                    else -> MarkdownNode(
+                        node = nestedChild,
+                        textStyle = MaterialTheme.typography.bodyMedium,
+                        prefix = buildAnnotatedString {
+                            append("${" ".repeat((level + 1) * 4)}$bullet")
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Parses the markdown tree recursively and builds an [AnnotatedString] with the appropriate styles.
+ *
+ * @param parent The parent node to parse.
+ */
+@Composable
+private fun AnnotatedString.Builder.parseMarkdownTree(
+    parent: Node
+): AnnotatedString.Builder {
+    val colors = MaterialTheme.colorScheme
+    parent.forEachChild { node ->
+        when (node) {
+            is Text -> append(node.literal)
+            is Emphasis -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
+                parseMarkdownTree(node)
+            }
+
+            is StrongEmphasis -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                parseMarkdownTree(node)
+            }
+
+            is Strikethrough -> withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) {
+                parseMarkdownTree(node)
+            }
+
+            is Link -> withStyle(
+                SpanStyle(
+                    color = Color.Blue,
+                    textDecoration = TextDecoration.Underline
+                )
+            ) {
+                pushStringAnnotation(URL_LINK, node.destination)
+                parseMarkdownTree(node)
+                pop()
+            }
+
+
+            is Code -> withStyle(
+                SpanStyle(
+                    color = colors.onSurfaceVariant,
+                    fontFamily = FontFamily.Monospace,
+                    background = colors.surfaceVariant
+                )
+            ) {
+                append(node.literal)
+            }
+
+            is SoftLineBreak -> append(" ")
+            is HardLineBreak -> appendLine()
+            else -> Log.w("Markdown", "Unsupported node type: ${node.javaClass.simpleName}")
+        }
+    }
+    return this
+}
+
+/**
+ * Iterates over the children of a node and applies the specified action to each child.
+ */
+private inline fun Node.forEachChild(action: (Node) -> Unit) {
+    var node = firstChild
+    while (node != null) {
+        action(node)
+        node = node.next
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun MarkdownPreview() {
+    val markdownText = """
+        # General formatting
+
+        `Inline code formatting`  
+        **Bold text**  
+        _Italicized text_  
+        ~~Strikethrough text~~  
+        ***Bold and italicized text***
+        
+        [Link](https://www.arcgis.com)
+        
+        ## Lists
+
+        ### Numbered lists
+
+        Numbered lists using number + period format. Text with right paren `1)` will be converted to number + period format.
+
+        1.  one
+        2.  two
+        3.  three
+
+        Bulleted lists
+
+        1. Dog
+            1) German Shepherd
+            2) Belgian Shepherd
+                1. Malinois
+                2. Groenendael
+                3. Tervuren
+        2. Cat
+            1. Siberian
+            2. Siamese
+
+        Bulleted lists - Start a line with `*` or `-` followed by a space.
+
+        Lists using asterisks, including nested ones (authored by UI).  Dashes typed in will be converted to asterisks.
+
+        *   One
+            *   Won
+            *   Uno
+                * Hello
+                * There
+                    * Android
+                    * iOS
+        *   Two
+        *   Three
+
+        <DIV CLASS="foo">
+
+        *Markdown*
+
+        </DIV>
+    """.trimIndent()
+    LazyColumn {
+        item {
+            Markdown(text = markdownText, modifier = Modifier.padding(15.dp))
+        }
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElement.kt
@@ -16,19 +16,20 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.text
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.featureforms.FormTextFormat
+import com.arcgismaps.mapping.featureforms.TextFormElement
 import com.arcgismaps.toolkit.featureforms.theme.FeatureFormTheme
 import kotlinx.coroutines.flow.MutableStateFlow
-import com.arcgismaps.mapping.featureforms.TextFormElement
 
 /**
  * A composable that displays a [TextFormElement].
@@ -41,7 +42,11 @@ internal fun TextFormElement(state: TextFormElementState, modifier: Modifier = M
     val text by state.text.collectAsState()
     val visible by state.isVisible.collectAsState()
     if (visible) {
-        Column(modifier = modifier) {
+        // do not merge semantics for this composable so that each markdown/plain-text element
+        // is treated as a separate node in the semantic tree
+        Surface(
+            modifier = modifier.semantics(mergeDescendants = false) {}
+        ) {
             if (state.format == FormTextFormat.Markdown) {
                 Markdown(text = text)
             } else {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElement.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.text
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.arcgismaps.mapping.featureforms.FormTextFormat
+import com.arcgismaps.toolkit.featureforms.theme.FeatureFormTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+import com.arcgismaps.mapping.featureforms.TextFormElement
+
+/**
+ * A composable that displays a [TextFormElement].
+ *
+ * @param state The state of the [TextFormElement].
+ * @param modifier The modifier to be applied to the composable.
+ */
+@Composable
+internal fun TextFormElement(state: TextFormElementState, modifier: Modifier = Modifier) {
+    val text by state.text.collectAsState()
+    val visible by state.isVisible.collectAsState()
+    if (visible) {
+        Column(modifier = modifier) {
+            if (state.format == FormTextFormat.Markdown) {
+                Markdown(text = text)
+            } else {
+                Text(text = text)
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true, showSystemUi = true)
+internal fun TextFormElementPreview() {
+    FeatureFormTheme {
+        TextFormElement(
+            TextFormElementState(
+                id = 0,
+                label = "Label",
+                description = "Description",
+                isVisible = MutableStateFlow(true),
+                text = MutableStateFlow("A **Text form element**"),
+                format = FormTextFormat.Markdown
+            ),
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElementState.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.text
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.featureforms.FormTextFormat
+import com.arcgismaps.mapping.featureforms.TextFormElement
+import com.arcgismaps.toolkit.featureforms.internal.components.base.FormElementState
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Represents the state of a [TextFormElement].
+ *
+ * @param id Unique identifier for the form element.
+ * @param label The label of the form element.
+ * @param description The description of the form element.
+ * @param isVisible The visibility state of the form element.
+ * @property text The text to be displayed.
+ * @property format The format of the text.
+ */
+internal class TextFormElementState(
+    id: Int,
+    label: String,
+    description: String,
+    isVisible: StateFlow<Boolean>,
+    val text: StateFlow<String>,
+    val format: FormTextFormat,
+) : FormElementState(
+    id = id,
+    label = label,
+    description = description,
+    isVisible = isVisible
+) {
+    companion object {
+        fun Saver(
+            formElement: TextFormElement,
+        ): Saver<TextFormElementState, Any> = listSaver(
+            save = {
+                listOf(it.id)
+            },
+            restore = {
+                TextFormElementState(
+                    id = it[0],
+                    label = formElement.label,
+                    description = formElement.description,
+                    isVisible = formElement.isVisible,
+                    text = formElement.text,
+                    format = formElement.textFormat
+                )
+            }
+        )
+    }
+}
+
+@Composable
+internal fun rememberTextFormElementState(
+    element: TextFormElement,
+    featureForm: FeatureForm
+): TextFormElementState = rememberSaveable(
+    inputs = arrayOf(featureForm),
+    saver = TextFormElementState.Saver(element)
+) {
+    TextFormElementState(
+        id = element.hashCode(),
+        label = element.label,
+        description = element.description,
+        isVisible = element.isVisible,
+        text = element.text,
+        format = element.textFormat
+    )
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/TextFormElementState.kt
@@ -63,7 +63,7 @@ internal class TextFormElementState(
                     description = formElement.description,
                     isVisible = formElement.isVisible,
                     text = formElement.text,
-                    format = formElement.textFormat
+                    format = formElement.format
                 )
             }
         )
@@ -84,6 +84,6 @@ internal fun rememberTextFormElementState(
         description = element.description,
         isVisible = element.isVisible,
         text = element.text,
-        format = element.textFormat
+        format = element.format
     )
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Merge the latest feature form development into `v.next`.

### Summary of changes:

- Bumps the SDK ver to `4352`.
- New `TextFormElement` api support :
  - Consumes the new `TextFormElement` element type for the `FeatureForms` api.
  - Introduces a `TextFormElement` composable with markdown support. (Original [PR](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/pull/542))
  - Added the `commonMark` dependency for markdown rendering.
  - Added compose ui tests for `TextFormElement`.
  - Updated Kdoc.
- `SubTypeSubLayer` feature forms support :
  - `SubTypeSubLayer`s now support `FeatureForm`s where an `ArcGISFeature.getFeatureFormDefinition()` provides the appropriate `FeatureFormDefinition` based on its sub type.
  - Updated the Micro-app to identify features and to look at sub layer results to find the appropriate `FeatureFormDefinition` to use. If multiple features are identified, a dialog is shown with the features. Tapping on a feature from the list will then open a `FeatureForm`.
  - Updated Kdoc.
-  Fixed a bug with recomposition when a new `FeatureForm` api object is provided to the `FeatureForm` composable when it is already in the composition. More details in the original PR [here](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/pull/563).

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/93/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  