### PR TITLE
show feature edit results related refactor

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -250,9 +250,8 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
         }
 
         is UIState.Error -> {
-            val state = uiState as UIState.Error
             ErrorDialog(
-                error = state,
+                error = uiState as UIState.Error,
                 onContinue = {
                     mapViewModel.cancelCommit()
                 },

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -369,7 +369,7 @@ fun FeatureItem(
             ) {
                 bitmap?.let {
                     Image(
-                        bitmap = bitmap!!.asImageBitmap(),
+                        bitmap = it.asImageBitmap(),
                         contentDescription = null,
                         modifier = Modifier.padding(10.dp)
                     )

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -227,7 +227,6 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
     when (uiState) {
         is UIState.Validating, is UIState.FinishingEdits, is UIState.Committing -> {
             ProgressDialog()
-            //SubmitForm(state.errors, mapViewModel::setDefaultState)
         }
 
         is UIState.Switching -> {

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -48,6 +48,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.rounded.Warning
@@ -87,10 +89,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.window.core.layout.WindowSizeClass
 import androidx.window.layout.WindowMetricsCalculator
 import com.arcgismaps.data.ArcGISFeature
+import com.arcgismaps.data.FeatureEditResult
 import com.arcgismaps.exceptions.FeatureFormValidationException
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.layers.ArcGISSublayer
@@ -114,7 +118,6 @@ import kotlinx.coroutines.withContext
 @Composable
 fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () -> Unit = {}) {
     val uiState by mapViewModel.uiState
-    val context = LocalContext.current
     val (featureForm, errorVisibility) = remember(uiState) {
         when (uiState) {
             is UIState.Editing -> {
@@ -122,9 +125,24 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                 Pair(state.featureForm, state.validationErrorVisibility)
             }
 
+            is UIState.Validating -> {
+                val state = (uiState as UIState.Validating)
+                Pair(state.featureForm, ValidationErrorVisibility.Automatic)
+            }
+
+            is UIState.FinishingEdits -> {
+                val state = (uiState as UIState.FinishingEdits)
+                Pair(state.featureForm, ValidationErrorVisibility.Automatic)
+            }
+
             is UIState.Committing -> {
+                val state = (uiState as UIState.Committing)
+                Pair(state.featureForm, ValidationErrorVisibility.Automatic)
+            }
+
+            is UIState.Error -> {
                 Pair(
-                    (uiState as UIState.Committing).featureForm,
+                    (uiState as UIState.Error).featureForm,
                     ValidationErrorVisibility.Automatic
                 )
             }
@@ -157,21 +175,10 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                         showDiscardEditsDialog = true
                     },
                     onSave = {
-                        scope.launch {
-                            mapViewModel.commitEdits().onFailure {
-                                Log.w("Forms", "Applying edits failed : ${it.message}")
-                                withContext(Dispatchers.Main) {
-                                    Toast.makeText(
-                                        context,
-                                        "Applying edits failed : ${it.message}",
-                                        Toast.LENGTH_LONG
-                                    ).show()
-                                }
-                            }
-                        }
-                    }) {
-                    onBackPressed()
-                }
+                        scope.launch { mapViewModel.commitEdits() }
+                    },
+                    onBackPressed = onBackPressed
+                )
                 if (uiState is UIState.Loading) {
                     LinearProgressIndicator(
                         modifier = Modifier
@@ -218,10 +225,9 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
         }
     }
     when (uiState) {
-        is UIState.Committing -> {
-            SubmitForm(errors = (uiState as UIState.Committing).errors) {
-                mapViewModel.cancelCommit()
-            }
+        is UIState.Validating, is UIState.FinishingEdits, is UIState.Committing -> {
+            ProgressDialog()
+            //SubmitForm(state.errors, mapViewModel::setDefaultState)
         }
 
         is UIState.Switching -> {
@@ -239,6 +245,19 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                 onCancel = {
                     mapViewModel.setDefaultState()
                     onBackPressed()
+                }
+            )
+        }
+
+        is UIState.Error -> {
+            val state = uiState as UIState.Error
+            ErrorDialog(
+                error = state,
+                onContinue = {
+                    mapViewModel.cancelCommit()
+                },
+                onDismissRequest = {
+                    mapViewModel.rollbackEdits()
                 }
             )
         }
@@ -351,7 +370,11 @@ fun FeatureItem(
                 color = Color.White
             ) {
                 bitmap?.let {
-                    Image(bitmap = bitmap!!.asImageBitmap(), contentDescription = null, modifier = Modifier.padding(10.dp))
+                    Image(
+                        bitmap = bitmap!!.asImageBitmap(),
+                        contentDescription = null,
+                        modifier = Modifier.padding(10.dp)
+                    )
                 }
             }
         },
@@ -509,124 +532,61 @@ fun TopFormBar(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SubmitForm(errors: List<ErrorInfo>, onDismissRequest: () -> Unit) {
-    if (errors.isEmpty()) {
-        // show a progress dialog if no errors are present
-        BasicAlertDialog(onDismissRequest = { /* cannot be dismissed */ }) {
-            Card(modifier = Modifier.wrapContentSize()) {
-                Column(
-                    modifier = Modifier.padding(15.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    CircularProgressIndicator(modifier = Modifier.size(50.dp), strokeWidth = 5.dp)
-                    Spacer(modifier = Modifier.height(10.dp))
-                    Text(text = "Saving..")
-                }
+fun ProgressDialog() {
+    BasicAlertDialog(onDismissRequest = { /* cannot be dismissed */ }) {
+        Card(modifier = Modifier.wrapContentSize()) {
+            Column(
+                modifier = Modifier.padding(15.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(50.dp), strokeWidth = 5.dp)
+                Spacer(modifier = Modifier.height(10.dp))
+                Text(text = "Saving..")
             }
         }
-    } else {
-        // show all the validation errors in a dialog
-        AlertDialog(
-            onDismissRequest = onDismissRequest,
-            modifier = Modifier.heightIn(max = 600.dp),
-            confirmButton = {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    Button(onClick = onDismissRequest) {
-                        Text(text = stringResource(R.string.view))
-                    }
-                }
-            },
-            title = {
-                Column {
-                    Text(
-                        text = stringResource(R.string.the_form_has_errors),
-                        style = MaterialTheme.typography.titleLarge
-                    )
-                    Text(
-                        text = stringResource(R.string.errors_must_be_fixed_to_submit_this_form),
-                        fontWeight = FontWeight.Bold,
-                        style = MaterialTheme.typography.titleSmall
-                    )
-                }
-            },
-            text = {
-                Card(
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Column(modifier = Modifier.padding(15.dp)) {
-                        Text(
-                            text = stringResource(R.string.attributes_failed, errors.count()),
-                            color = MaterialTheme.colorScheme.error
-                        )
-                        Spacer(modifier = Modifier.height(10.dp))
-                        LazyColumn(
-                            modifier = Modifier,
-                            verticalArrangement = Arrangement.spacedBy(10.dp)
-                        ) {
-                            items(errors.count()) { index ->
-                                val errorString =
-                                    "${errors[index].fieldName} : ${errors[index].error.getString()}"
-                                Text(text = errorString, color = MaterialTheme.colorScheme.error)
-                            }
-                        }
-                    }
-                }
-            }
-        )
     }
 }
 
 @Composable
-fun FeatureFormValidationException.getString(): String {
-    return when (this) {
-        is FeatureFormValidationException.IncorrectValueTypeException -> {
-            stringResource(id = R.string.value_must_be_of_correct_type)
-        }
-
-        is FeatureFormValidationException.LessThanMinimumDateTimeException -> {
-            stringResource(id = R.string.date_less_than_minimum)
-        }
-
-        is FeatureFormValidationException.MaxCharConstraintException -> {
-            stringResource(id = R.string.maximum_character_length_exceeded)
-        }
-
-        is FeatureFormValidationException.MaxDateTimeConstraintException -> {
-            stringResource(id = R.string.date_exceeds_maximum)
-        }
-
-        is FeatureFormValidationException.MaxNumericConstraintException -> {
-            stringResource(id = R.string.exceeds_maximum_value)
-        }
-
-        is FeatureFormValidationException.MinCharConstraintException -> {
-            stringResource(id = R.string.minimum_character_length_not_met)
-        }
-
-        is FeatureFormValidationException.MinNumericConstraintException -> {
-            stringResource(id = R.string.less_than_minimum_value)
-        }
-
-        is FeatureFormValidationException.NullNotAllowedException -> {
-            stringResource(id = R.string.value_must_not_be_empty)
-        }
-
-        is FeatureFormValidationException.OutOfDomainException -> {
-            stringResource(id = R.string.value_must_be_within_domain)
-        }
-
-        is FeatureFormValidationException.RequiredException -> {
-            stringResource(id = R.string.required)
-        }
-
-        is FeatureFormValidationException.UnknownFeatureFormException -> {
-            stringResource(id = R.string.unknown_error)
-        }
-    }
+fun ErrorDialog(
+    error: UIState.Error,
+    onContinue: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            Button(onClick = onContinue) {
+                Text(text = stringResource(R.string.edit))
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.discard))
+            }
+        },
+        icon = {
+            Icon(
+                imageVector = Icons.Rounded.Warning,
+                contentDescription = "Warning",
+                tint = MaterialTheme.colorScheme.error
+            )
+        },
+        title = {
+            Column {
+                Text(text = error.title, style = MaterialTheme.typography.headlineMedium)
+                Text(text = error.subTitle, style = MaterialTheme.typography.titleMedium)
+            }
+        },
+        text = {
+            // enable scrolling for the error details
+            LazyColumn {
+                item { Text(text = error.details) }
+            }
+        },
+        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)
+    )
 }
 
 fun getWindowSize(context: Context): WindowSizeClass {

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -23,10 +23,14 @@ import android.widget.Toast
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import com.arcgismaps.data.ArcGISFeature
+import com.arcgismaps.data.FeatureEditResult
 import com.arcgismaps.data.ServiceFeatureTable
 import com.arcgismaps.exceptions.FeatureFormValidationException
 import com.arcgismaps.mapping.ArcGISMap
@@ -90,11 +94,24 @@ sealed class UIState {
     ) : UIState()
 
     /**
-     * Commit in progress state for the [featureForm] with validation errors [errors].
+     * Validating state for the [featureForm].
+     */
+    data class Validating(
+        val featureForm: FeatureForm
+    ) : UIState()
+
+    /**
+     * Finishing edits state for the [featureForm].
+     */
+    data class FinishingEdits(
+        val featureForm: FeatureForm
+    ) : UIState()
+
+    /**
+     * Committing the edits with the service for the [featureForm].
      */
     data class Committing(
-        val featureForm: FeatureForm,
-        val errors: List<ErrorInfo>
+        val featureForm: FeatureForm
     ) : UIState()
 
     /**
@@ -106,13 +123,25 @@ sealed class UIState {
         val features: Map<String, List<ArcGISFeature>>,
         val featureCount: Int
     ) : UIState()
+
+    /**
+     * Indicates an error state with the given [error].
+     */
+    data class Error(
+        val featureForm: FeatureForm,
+        val title: String,
+        val details: String,
+        val subTitle: String = ""
+    ) : UIState()
 }
 
 /**
  * Class that provides a validation error [error] for the field with name [fieldName]. To fetch
  * the actual message string use [FeatureFormValidationException.getString] in the composition.
  */
-data class ErrorInfo(val fieldName: String, val error: FeatureFormValidationException)
+data class ErrorInfo(val fieldName: String, val error: FeatureFormValidationException) {
+    override fun toString(): String = "$fieldName: ${error.getMessage()}"
+}
 
 /**
  * Base class for context aware AndroidViewModel. This class must have only a single application
@@ -174,68 +203,33 @@ class MapViewModel @Inject constructor(
      *
      * @return a Result indicating success, or any error encountered.
      */
-    suspend fun commitEdits(): Result<Unit> {
-        val state = (_uiState.value as? UIState.Editing)
-            ?: return Result.failure(IllegalStateException("Not in editing state"))
-        // build the list of errors
-        val featureForm = state.featureForm
-        // filter the errors to show only the appropriate ones
-        val errors = filterErrors(featureForm)
-        // set the state to committing with the errors if any
-        _uiState.value = UIState.Committing(
-            featureForm = featureForm,
-            errors = errors
-        )
-        // if there are no errors then update the feature
-        return if (errors.isEmpty()) {
-            val serviceFeatureTable =
-                featureForm.feature.featureTable as? ServiceFeatureTable ?: return Result.failure(
-                    IllegalStateException("cannot save feature edit without a ServiceFeatureTable")
-                )
-            var result = Result.success(Unit)
-            featureForm.finishEditing().onSuccess {
-                serviceFeatureTable.serviceGeodatabase?.let { database ->
-                    if (database.serviceInfo?.canUseServiceGeodatabaseApplyEdits == true) {
-                        database.applyEdits().onFailure {
-                            result = Result.failure(it)
-                        }
-                    } else {
-                        serviceFeatureTable.applyEdits().onFailure {
-                            result = Result.failure(it)
-                        }
-                    }
-                }
-                featureForm.feature.refresh()
-                // unselect the feature after the edits have been saved
-                (featureForm.feature.featureTable?.layer as FeatureLayer).clearSelection()
-            }.onFailure {
-                result = Result.failure(it)
-            }
-            // set the state to not editing since the feature was updated successfully
-            _uiState.value = UIState.NotEditing
-            result
-        } else {
-            // even though there are errors send a success result since the operation was successful
-            // and the control is back with the UI
-            Result.success(Unit)
-        }
+    suspend fun commitEdits() {
+        val editingState = _uiState.value as? UIState.Editing ?: return
+        validateEdits(editingState.featureForm)
+
+        val validatingState = _uiState.value as? UIState.Validating ?: return
+        finishEdits(validatingState.featureForm)
+
+        val finishingState = _uiState.value as? UIState.FinishingEdits ?: return
+        applyEditsToService(finishingState.featureForm)
     }
 
     /**
-     * Cancels the commit if the current state is [UIState.Committing] and sets the ui state to
-     * [UIState.Editing].
+     * Cancels the commit if the current state is [UIState.Error] and sets the ui state to
+     * [UIState.Editing]. This is useful when the user wants to cancel the commit and continue
+     * editing the feature.
      */
-    fun cancelCommit(): Result<Unit> {
-        val previousState = (_uiState.value as? UIState.Committing) ?: return Result.failure(
-            IllegalStateException("Not in committing state")
-        )
+    fun cancelCommit() {
+        val featureForm = when (val state = _uiState.value) {
+            is UIState.Error -> state.featureForm
+            else -> return
+        }
         // set the state back to an editing state while showing all errors using
         // ValidationErrorVisibility.Always
         _uiState.value = UIState.Editing(
-            previousState.featureForm,
+            featureForm,
             validationErrorVisibility = ValidationErrorVisibility.Visible
         )
-        return Result.success(Unit)
     }
 
     /**
@@ -260,22 +254,24 @@ class MapViewModel @Inject constructor(
     /**
      * Continues editing the previous feature from the [UIState.Switching] state.
      */
-    fun continueEditing() =
-        (_uiState.value as? UIState.Switching)?.let { prevState ->
-            _uiState.value = prevState.oldState
-        }
+    fun continueEditing() = (_uiState.value as? UIState.Switching)?.let { prevState ->
+        _uiState.value = prevState.oldState
+    }
 
     /**
-     * Rolls back the edits on the current feature and sets the UI state to not editing.
+     * Rolls back any edits on the current feature and sets the UI state to not editing.
      */
-    fun rollbackEdits(): Result<Unit> {
-        (_uiState.value as? UIState.Editing)?.let {
-            it.featureForm.discardEdits()
-            // unselect the feature
-            (it.featureForm.feature.featureTable?.layer as FeatureLayer).clearSelection()
-            _uiState.value = UIState.NotEditing
-            return Result.success(Unit)
-        } ?: return Result.failure(IllegalStateException("Not in editing state"))
+    fun rollbackEdits() {
+        val featureForm = when (val state = _uiState.value) {
+            is UIState.Editing -> state.featureForm
+            is UIState.Error -> state.featureForm
+            else -> return
+        }
+        // discard the edits
+        featureForm.discardEdits()
+        // unselect the feature
+        (featureForm.feature.featureTable?.layer as FeatureLayer).clearSelection()
+        _uiState.value = UIState.NotEditing
     }
 
     /**
@@ -337,7 +333,7 @@ class MapViewModel @Inject constructor(
      * then the state is switched to [UIState.Switching] to allow switching between features.
      */
     fun selectFeature(feature: ArcGISFeature) {
-        when(_uiState.value) {
+        when (_uiState.value) {
             is UIState.SelectFeature, UIState.NotEditing -> {
                 // if the current state is selecting a feature or not editing then select the feature
                 val layer = feature.featureTable!!.layer as FeatureLayer
@@ -353,6 +349,7 @@ class MapViewModel @Inject constructor(
                     }
                 }
             }
+
             is UIState.Editing -> {
                 // if the current state is editing then switch to the switching state
                 val currentState = _uiState.value as UIState.Editing
@@ -361,6 +358,7 @@ class MapViewModel @Inject constructor(
                     newFeature = feature
                 )
             }
+
             else -> return
         }
     }
@@ -369,6 +367,96 @@ class MapViewModel @Inject constructor(
      * Sets the UI state to not editing.
      */
     fun setDefaultState() {
+        _uiState.value = UIState.NotEditing
+    }
+
+    /**
+     * Validates the edits in the [featureForm] and sets the UI state to error if there are any
+     * validation errors.
+     */
+    private fun validateEdits(featureForm: FeatureForm) {
+        _uiState.value = UIState.Validating(featureForm)
+        val validationErrors = filterErrors(featureForm)
+        if (validationErrors.isNotEmpty()) {
+            val errorText = validationErrors.joinToString(separator = "\n\n") { "$it" }
+            _uiState.value = UIState.Error(
+                featureForm,
+                title = "The Form has errors",
+                subTitle = "There are ${validationErrors.count()} validation errors." +
+                    "These must be fixed to submit the form.",
+                details = errorText
+            )
+        }
+    }
+
+    /**
+     * Finishes the edits in the [featureForm] and sets the UI state to error if there are any
+     * errors.
+     */
+    private suspend fun finishEdits(featureForm: FeatureForm) {
+        _uiState.value = UIState.FinishingEdits(featureForm)
+        featureForm.finishEditing().onFailure {
+            _uiState.value = UIState.Error(
+                featureForm,
+                title = "Failed to save edits to the database",
+                details = it.message ?: it.javaClass.simpleName
+            )
+        }
+    }
+
+    /**
+     * Applies the edits in the [featureForm]'s table to the service and sets the UI state to error
+     * if there are any errors.
+     *
+     * If there are no errors, the feature is refreshed and the UI state is set to not editing.
+     */
+    private suspend fun applyEditsToService(featureForm: FeatureForm) {
+        _uiState.value = UIState.Committing(featureForm)
+        val serviceFeatureTable = featureForm.feature.featureTable as? ServiceFeatureTable ?: run {
+            _uiState.value = UIState.Error(
+                featureForm,
+                title = "Failed to sync edits with the service",
+                details = "Cannot save edits without a ServiceFeatureTable"
+            )
+            return
+        }
+        // check if the service supports applyEdits using the service geodatabase
+        val canUseServiceGeodatabaseApplyEdits =
+            serviceFeatureTable.serviceGeodatabase?.serviceInfo?.canUseServiceGeodatabaseApplyEdits == true
+        val errors = mutableListOf<Throwable>()
+        if (canUseServiceGeodatabaseApplyEdits) {
+            serviceFeatureTable.serviceGeodatabase!!.applyEdits()
+                .onSuccess { featureTableEditResults ->
+                    // build a list of edit results from the feature table edit results
+                    errors.addAll(
+                        featureTableEditResults.flatMap {
+                            it.editResults.asSequence()
+                        }.errors
+                    )
+                }
+                .onFailure { errors.add(it) }
+        } else {
+            serviceFeatureTable.applyEdits().onSuccess { featureEditResults ->
+                errors.addAll(featureEditResults.errors)
+            }.onFailure {
+                errors.add(it)
+            }
+        }
+        // if there are errors then set the UI state to error
+        if (errors.isNotEmpty()) {
+            val errorText = errors.joinToString(separator = "\n") { it.message ?: "Unknown error" }
+            _uiState.value = UIState.Error(
+                featureForm,
+                title = "Failed to sync edits with the service",
+                details = errorText
+            )
+            return
+        }
+        // refresh the feature after the edits have been saved
+        featureForm.feature.refresh()
+        // unselect the feature after the edits have been saved
+        (featureForm.feature.featureTable?.layer as FeatureLayer).clearSelection()
+        // set the UI state to not editing
         _uiState.value = UIState.NotEditing
     }
 
@@ -395,9 +483,11 @@ class MapViewModel @Inject constructor(
  */
 fun List<FormElement>.getFieldFormElement(fieldName: String): FieldFormElement? {
     for (element in this) {
-        when(element) {
+        when (element) {
             is FieldFormElement -> if (element.fieldName == fieldName) return element
-            is GroupFormElement -> element.elements.getFieldFormElement(fieldName)?.let { return it }
+            is GroupFormElement -> element.elements.getFieldFormElement(fieldName)
+                ?.let { return it }
+
             else -> continue
         }
     }
@@ -439,18 +529,45 @@ fun Map<String, List<ArcGISFeature>>.getFeatureCount(): Int {
  * If the layer is a [SubtypeFeatureLayer] then this function will return true if any of the sublayers
  * have a feature form definition.
  */
-private suspend fun Layer.hasFeatureFormDefinition(): Boolean = when(this) {
+suspend fun Layer.hasFeatureFormDefinition(): Boolean = when (this) {
     is SubtypeFeatureLayer -> {
         load()
         subtypeSublayers.any { it.featureFormDefinition != null }
     }
+
     is FeatureLayer -> {
         load()
         featureFormDefinition != null
     }
+
     is GroupLayer -> {
         load()
         layers.any { it.hasFeatureFormDefinition() }
     }
+
     else -> false
 }
+
+/**
+ * Returns the additional message if present or the message of the exception. If the exception is
+ * a [FeatureFormValidationException.RequiredException] then the message is "Field is required".
+ */
+fun FeatureFormValidationException.getMessage(): String {
+    return when (this) {
+        is FeatureFormValidationException.RequiredException -> "Field is required"
+        else -> additionalMessage ?: message
+    }
+}
+
+/**
+ * Returns a list of all the errors in the list of [FeatureEditResult]s that have an error
+ * including the attachment results that have an error.
+ */
+val List<FeatureEditResult>.errors: List<Throwable>
+    get() = mapNotNull { editResult ->
+        editResult.error
+    } + flatMap {
+        it.attachmentResults.mapNotNull { editResult ->
+            editResult.error
+        }
+    }

--- a/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
+++ b/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
@@ -50,4 +50,5 @@
     <string name="camera_permission_required">Camera permission is required for Attachments. This will result in limited functionality.</string>
     <string name="multiple_features">Multiple Features (%1$s)</string>
     <string name="select_a_feature_to_edit">Select a Feature to edit</string>
+    <string name="edit">Edit</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/784](https://devtopia.esri.com/runtime/apollo/issues/784)

<!-- link to design, if applicable -->

### Description:

When calling `ServiceGeodatabase.applyEdits()` the resulting `FeatureTableEditResult`s need to be inspected for any errors. This PR refactors the workflow to achieve this by dividing the committing edits flow into three distinct UI states.

1. **Validate edits** - FeatureForm validation.
2. **Finish Edits** - FeatureForm.applyEdits(), saves to the local database.
3. **Commit Edits** - Apply all local edits to the service.

A new Error state is introduced to keep track of any errors during the workflow. This eliminates the use of custom dialogs for each specific state.

Another major refactor involves making the `MapViewModel` public methods emit any change in state directly into the `uiState` instead of returning a result.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  