### PR TITLE
`Forms`:  Show value for out of domain CodedValue types

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
@@ -79,7 +79,7 @@ internal abstract class CodedValueFieldState(
     evaluateExpressions = evaluateExpressions
 ) {
     /**
-     * The list of coded values associated with this field.
+     * The map of coded values associated with this field.
      */
     val codedValues: Map<Any?, String> = properties.codedValues
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
@@ -38,7 +38,7 @@ internal open class CodedValueFieldProperties(
     editable: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
     val fieldType: FieldType,
-    val codedValues: List<CodedValue>,
+    val codedValues: Map<Any?, String>,
     val showNoValueOption: FormInputNoValueOption,
     val noValueLabel: String
 ) : FieldProperties<Any?>(label, placeholder, description, value, validationErrors, required, editable, visible)
@@ -46,6 +46,9 @@ internal open class CodedValueFieldProperties(
 /**
  * A class to handle the state of any coded value type. Essential properties are inherited
  * from the [BaseFieldState].
+ *
+ * When calling [CodedValueFieldState.onValueChanged], to indicate a no value option or clearing the
+ * value, pass in null.
  *
  * @param id Unique identifier for the field.
  * @param properties the [CodedValueFieldProperties] associated with this state.
@@ -78,7 +81,7 @@ internal abstract class CodedValueFieldState(
     /**
      * The list of coded values associated with this field.
      */
-    val codedValues: List<CodedValue> = properties.codedValues
+    val codedValues: Map<Any?, String> = properties.codedValues
 
     /**
      * This property defines whether to display a special "no value" option if this field is
@@ -97,12 +100,11 @@ internal abstract class CodedValueFieldState(
     val fieldType: FieldType = properties.fieldType
 
     /**
-     * Returns the name of the [code] if it is present in [codedValues] else returns an empty string.
+     * Returns the name of the [code] if it is present in [codedValues]. If not, it returns the
+     * [code] as a string. If [code] is null, it returns an empty string.
      */
     fun getNameForCodedValue(code: Any?): String {
-        return codedValues.find {
-            it.code.toString() == code.toString()
-        }?.name ?: ""
+        return codedValues[code] ?: code?.toString().orEmpty()
     }
 
     override fun typeConverter(input: Any?): Any? {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
@@ -169,7 +169,7 @@ internal fun ComboBoxDialog(
     val configuration = LocalConfiguration.current
     val windowSizeClass = computeWindowSizeClasses(LocalContext.current)
     // check if the initial value is out of the domain of the coded values
-    val outOfDomain = values[initialValue] == null
+    val outOfDomain = initialValue != null && !values.containsKey(initialValue)
     var searchText by rememberSaveable { mutableStateOf("") }
     val codedValues = if (!isRequired) {
         if (noValueOption == FormInputNoValueOption.Show) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxField.kt
@@ -66,10 +66,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -114,10 +116,10 @@ internal fun ComboBoxField(
     BaseTextField(
         text = currentState.getNameForCodedValue(value.data),
         onValueChange = {
-            // usually only triggered on a "clear" action
-            // this value will be an empty string and the type conversion must be handled
-            // by the state object
-            currentState.onValueChanged(it)
+            // only valid action on the field is to clear the value, so pass in null
+            if (it.isEmpty()) {
+                currentState.onValueChanged(null)
+            }
         },
         modifier = modifier,
         readOnly = true,
@@ -166,6 +168,8 @@ internal fun ComboBoxDialog(
 ) {
     val configuration = LocalConfiguration.current
     val windowSizeClass = computeWindowSizeClasses(LocalContext.current)
+    // check if the initial value is out of the domain of the coded values
+    val outOfDomain = values[initialValue] == null
     var searchText by rememberSaveable { mutableStateOf("") }
     val codedValues = if (!isRequired) {
         if (noValueOption == FormInputNoValueOption.Show) {
@@ -281,43 +285,48 @@ internal fun ComboBoxDialog(
                     items(filteredList.count()) {
                         val code = filteredList.keys.elementAt(it)
                         val name = filteredList.getValue(code)
-                        ListItem(
-                            headlineContent = {
-                                Text(
-                                    text = name,
-                                    style = if (name == noValueLabel) LocalTextStyle.current.copy(
-                                        fontStyle = FontStyle.Italic,
-                                        fontWeight = FontWeight.Light
-                                    )
-                                    else LocalTextStyle.current
-                                )
-                            },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    // if the no value label was selected, set the value to be empty
-                                    if (name == noValueLabel) {
-                                        onValueChange(null)
-                                    } else {
-                                        onValueChange(code)
-                                    }
-                                }
-                                .semantics {
-                                    contentDescription = if (name == noValueLabel) {
-                                        "no value row"
-                                    } else {
-                                        "$name list item"
-                                    }
-                                },
-                            trailingContent = {
-                                if ((code == initialValue) || ((name == noValueLabel) && (initialValue == null))) {
-                                    Icon(
-                                        imageVector = Icons.Outlined.Check,
-                                        contentDescription = "list item check"
-                                    )
+                        val textStyle = LocalTextStyle.current.copy(
+                            fontStyle = if (name == noValueLabel) FontStyle.Italic else FontStyle.Normal,
+                            fontWeight = if (name == noValueLabel) FontWeight.Light else FontWeight.Normal
+                        )
+                        ComboBoxListItem(
+                            name = name,
+                            textStyle = textStyle,
+                            isChecked = (code == initialValue) || ((name == noValueLabel) && (initialValue == null)),
+                            modifier = Modifier.semantics {
+                                contentDescription = if (name == noValueLabel) {
+                                    "no value row"
+                                } else {
+                                    "$name list item"
                                 }
                             }
-                        )
+                        ) {
+                            // if the no value label was selected, set the value to null
+                            if (name == noValueLabel) {
+                                onValueChange(null)
+                            } else {
+                                onValueChange(code)
+                            }
+                        }
+                    }
+                    if (outOfDomain) {
+                        item {
+                            HorizontalDivider()
+                            Column(
+                                modifier = Modifier.padding(10.dp)
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.unsupported_type),
+                                    style = MaterialTheme.typography.labelMedium
+                                )
+                                ComboBoxListItem(
+                                    name = initialValue.toString(),
+                                    isChecked = true,
+                                    textStyle = LocalTextStyle.current.copy(fontStyle = FontStyle.Italic),
+                                    onClick = {}
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -325,7 +334,38 @@ internal fun ComboBoxDialog(
     }
 }
 
-@Preview
+@Composable
+private fun ComboBoxListItem(
+    name: String,
+    isChecked: Boolean,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = LocalTextStyle.current,
+    onClick: () -> Unit
+) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = name,
+                style = textStyle
+            )
+        },
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable {
+                onClick()
+            },
+        trailingContent = {
+            if (isChecked) {
+                Icon(
+                    imageVector = Icons.Outlined.Check,
+                    contentDescription = "list item check"
+                )
+            }
+        }
+    )
+}
+
+@Preview(showBackground = true, device = Devices.PIXEL_7)
 @Composable
 private fun ComboBoxDialogPreview() {
     ComboBoxDialog(
@@ -364,7 +404,7 @@ private fun ComboBoxPreview() {
             required = MutableStateFlow(false),
             visible = MutableStateFlow(true),
             fieldType = FieldType.Text,
-            codedValues = listOf(),
+            codedValues = emptyMap(),
             showNoValueOption = FormInputNoValueOption.Show,
             noValueLabel = "No value"
         ),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/ComboBoxFieldState.kt
@@ -25,6 +25,7 @@ import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.FormExpressionEvaluationError
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
+import com.arcgismaps.toolkit.featureforms.internal.utils.toMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -70,7 +71,7 @@ internal class ComboBoxFieldState(
                         editable = formElement.isEditable,
                         required = formElement.isRequired,
                         visible = formElement.isVisible,
-                        codedValues = input.codedValues,
+                        codedValues = input.codedValues.toMap(),
                         showNoValueOption = input.noValueOption,
                         noValueLabel = input.noValueLabel,
                         fieldType = formElement.fieldType
@@ -109,7 +110,7 @@ internal fun rememberComboBoxFieldState(
             editable = field.isEditable,
             required = field.isRequired,
             visible = field.isVisible,
-            codedValues = input.codedValues,
+            codedValues = input.codedValues.toMap(),
             showNoValueOption = input.noValueOption,
             noValueLabel = input.noValueLabel,
             fieldType = field.fieldType

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonField.kt
@@ -66,7 +66,7 @@ internal fun RadioButtonField(
             description = state.description,
             value = value.data,
             required = required,
-            codedValues = state.codedValues.associateBy({ it.code }, { it.name }),
+            codedValues = state.codedValues,
             showNoValueOption = state.showNoValueOption,
             noValueLabel = noValueLabel,
             modifier = modifier,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/RadioButtonFieldState.kt
@@ -25,6 +25,7 @@ import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.FormExpressionEvaluationError
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
+import com.arcgismaps.toolkit.featureforms.internal.utils.toMap
 import kotlinx.coroutines.CoroutineScope
 
 internal typealias RadioButtonFieldProperties = CodedValueFieldProperties
@@ -49,14 +50,12 @@ internal class RadioButtonFieldState(
 
     /**
      * Returns true if the initial value is not in the [codedValues]. This should
-     * trigger a fallback to a ComboBox. If the [value] is false then this returns false.
+     * trigger a fallback to a ComboBox. If the [value] is null then this returns false.
      */
     val shouldFallback = if (initialValue == null) {
         false
     } else {
-        !codedValues.any {
-            it.name == value.value.data
-        }
+        !codedValues.contains(initialValue)
     }
 
     companion object {
@@ -88,7 +87,7 @@ internal class RadioButtonFieldState(
                         required = formElement.isRequired,
                         visible = formElement.isVisible,
                         fieldType = formElement.fieldType,
-                        codedValues = input.codedValues,
+                        codedValues = input.codedValues.toMap(),
                         showNoValueOption = input.noValueOption,
                         noValueLabel = input.noValueLabel
                     ),
@@ -125,7 +124,7 @@ internal fun rememberRadioButtonFieldState(
             required = field.isRequired,
             visible = field.isVisible,
             fieldType = field.fieldType,
-            codedValues = input.codedValues,
+            codedValues = input.codedValues.toMap(),
             showNoValueOption = input.noValueOption,
             noValueLabel = input.noValueLabel
         ),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/SwitchFieldState.kt
@@ -61,7 +61,10 @@ internal class SwitchFieldProperties(
     editable,
     visible,
     fieldType,
-    listOf(onValue, offValue),
+    mapOf(
+        onValue.code to onValue.name,
+        offValue.code to offValue.name
+    ),
     showNoValueOption,
     noValueLabel
 )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -178,7 +178,7 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
             }
             ComboBoxDialog(
                 initialValue = state.value.value.data,
-                values = state.codedValues.associateBy({ it.code }, { it.name }),
+                values = state.codedValues,
                 label = state.label,
                 description = state.description,
                 isRequired = state.isRequired.collectAsState().value,
@@ -357,7 +357,15 @@ internal fun computeWindowSizeClasses(context: Context): WindowSizeClass {
     val width = metrics.bounds.width()
     val height = metrics.bounds.height()
     val density = context.resources.displayMetrics.density
-    return WindowSizeClass.compute(width / density, height / density)
+    try {
+        val windowSizeClass = WindowSizeClass.compute(width / density, height / density)
+        return windowSizeClass
+    } catch (ex : IllegalArgumentException) {
+        // if the calculation has thrown an exception due to width or height being negative (like
+        // in a preview), then use a default size of 400x900dp which indicates a compact size
+        // representing 99.96% of phones in portrait
+        return WindowSizeClass.compute(400F, 900F)
+    }
 }
 
 internal fun showError(context: Context, message: String) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Utils.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Utils.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
+import com.arcgismaps.data.CodedValue
 
 /**
  * Changes the visual output of the placeholder and label properties of a TextField. Using this
@@ -84,3 +85,10 @@ internal fun Number?.format(digits: Int = 2): String =
         is Float -> "%.${digits}f".format(this)
         else -> "$this"
     }
+
+/**
+ * Converts a list of [CodedValue]s to a map of ([CodedValue.code],[CodedValue.name]).
+ */
+internal fun List<CodedValue>.toMap(): Map<Any?, String> {
+    return associateBy(CodedValue::code, CodedValue::name)
+}

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -117,4 +117,5 @@
     <string name="download_empty_file">Empty files cannot be downloaded</string>
     <string name="attachment_deleted">%1s was deleted successfully</string>
     <string name="attachment_size_limit_exceeded">Attachments larger than %1$s cannot be downloaded</string>
+    <string name="unsupported_type">Unsupported Type</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/838](https://devtopia.esri.com/runtime/apollo/issues/838)

<!-- link to design, if applicable -->

### Description:

The API `FieldFormElement.value` will now contain the `CodedValue.name` if the current value for the field is out of the allowed domain values. This PR consumes this change to show the out-of-domain value in a ComboBox field and also in the ComboBoxDialog.

### Summary of changes:

- Updated the `CodedValueFieldState.getNameForCodedValue` to return the code as a string if it is out of domain.
- To make the lookup more efficient, the `CodedValueFieldState.codedValues` is now a `Map<Any?,String>` instead of a `List<CodedValue>`.
- The above change also means less conversions from list -> map in other parts of the code.
- The `ComboBoxDialog` now shows any present out-of-domain value under a "Unsupported Type" section of the dialog. When a valid choice is made, this unsupported type is removed from the list.

<img width="300" alt="Screenshot 2024-09-20 at 3 45 34 PM" src="https://github.com/user-attachments/assets/2c381e71-e79b-4ad2-b672-834703a4bc43">


### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/107/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  