### PR TITLE
Associate graphic with Starting points

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -253,7 +253,7 @@ public class TraceState(
      * This private method is called from a suspend function and so swallows any failures except
      * CancellationExceptions.
      */
-    private fun processAndAddStartingPoint(feature: ArcGISFeature) = runCatchingCancellable {
+    private fun processAndAddStartingPoint(feature: ArcGISFeature, mapPoint: Point) = runCatchingCancellable {
         // TODO: add fraction-along to the element.
         // https://devtopia.esri.com/runtime/kotlin/issues/4491
         val utilityElement = utilityNetwork.createElementOrNull(feature)
@@ -264,6 +264,13 @@ public class TraceState(
             ?.getSymbol(feature)
             ?: throw IllegalArgumentException("could not create drawable from feature symbol")
 
+        val graphic = Graphic(
+            geometry = mapPoint,
+            symbol = SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Cross, Color.green, 20.0f)
+        )
+        graphicsOverlay.graphics.add(graphic)
+        currentTraceGraphics.add(graphic)
+
         _startingPoints.add(
             StartingPoint(
                 feature = feature,
@@ -271,7 +278,6 @@ public class TraceState(
                 symbol = symbol
             )
         )
-
     }
 
     private suspend fun identifyFeatures(mapPoint: Point, screenCoordinate: ScreenCoordinate) {
@@ -283,10 +289,10 @@ public class TraceState(
             if (identifyLayerResultList.isNotEmpty()) {
                 identifyLayerResultList.forEach { identifyLayerResult ->
                     identifyLayerResult.geoElements.filterIsInstance<ArcGISFeature>().forEach { feature ->
-                        processAndAddStartingPoint(feature)
+                        processAndAddStartingPoint(feature, mapPoint)
                     }
                 }
-                addTapLocationToGraphicsOverlay(mapPoint)
+//                addTapLocationToGraphicsOverlay(mapPoint)
                 _addStartingPointMode.value = AddStartingPointMode.Stopped
             }
         }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -102,9 +102,9 @@ public class TraceState(
      */
     public val selectedTraceConfiguration: State<UtilityNamedTraceConfiguration?> = _selectedTraceConfiguration
 
-    private val _startingPoints: SnapshotStateList<StartingPoint> = mutableStateListOf()
+    private val _currentTraceStartingPoints: SnapshotStateList<StartingPoint> = mutableStateListOf()
 
-    internal val startingPoints: List<StartingPoint> = _startingPoints
+    internal val currentTraceStartingPoints: List<StartingPoint> = _currentTraceStartingPoints
 
     private var _utilityNetwork: UtilityNetwork? = null
     private val utilityNetwork: UtilityNetwork
@@ -160,17 +160,17 @@ public class TraceState(
         // Run a trace
         val traceConfiguration = selectedTraceConfiguration.value ?: return false
 
-        if (startingPoints.isEmpty() && traceConfiguration.minimumStartingLocations == UtilityMinimumStartingLocations.One) {
+        if (currentTraceStartingPoints.isEmpty() && traceConfiguration.minimumStartingLocations == UtilityMinimumStartingLocations.One) {
             // TODO: Handle error
             return false
         }
 
-        if (startingPoints.size < 2 && traceConfiguration.minimumStartingLocations == UtilityMinimumStartingLocations.Many) {
+        if (currentTraceStartingPoints.size < 2 && traceConfiguration.minimumStartingLocations == UtilityMinimumStartingLocations.Many) {
             // TODO: Handle error
             return false
         }
 
-        val utilityTraceParameters = UtilityTraceParameters(traceConfiguration, startingPoints.map { it.utilityElement })
+        val utilityTraceParameters = UtilityTraceParameters(traceConfiguration, currentTraceStartingPoints.map { it.utilityElement })
 
         val traceResults = utilityNetwork.trace(utilityTraceParameters).getOrElse {
             //handle error
@@ -220,7 +220,6 @@ public class TraceState(
             graphics = currentTraceGraphics,
             featureResults = currentTraceElementResults,
             functionResults = currentTraceFunctionResults,
-            geometryResults = currentTraceGraphics
         )
         return true
     }
@@ -246,7 +245,13 @@ public class TraceState(
     }
 
     internal fun removeStartingPoint(startingPoint: StartingPoint) {
-        _startingPoints.remove(startingPoint)
+        _currentTraceStartingPoints.remove(startingPoint)
+        removeStartingPointGraphic(startingPoint.graphic)
+    }
+
+    private fun removeStartingPointGraphic(graphic: Graphic) {
+        currentTraceGraphics.remove(graphic)
+        graphicsOverlay.graphics.remove(graphic)
     }
 
     /**
@@ -258,6 +263,12 @@ public class TraceState(
         // https://devtopia.esri.com/runtime/kotlin/issues/4491
         val utilityElement = utilityNetwork.createElementOrNull(feature)
             ?: throw IllegalArgumentException("could not create utility element from ArcGISFeature")
+
+        // Check if the starting point already exists
+        if (_currentTraceStartingPoints.any { it.utilityElement.globalId == utilityElement.globalId }) {
+            // TODO: Handle error
+            throw IllegalArgumentException("starting point already exists")
+        }
 
         val symbol = (feature.featureTable?.layer as FeatureLayer)
             .renderer
@@ -271,11 +282,12 @@ public class TraceState(
         graphicsOverlay.graphics.add(graphic)
         currentTraceGraphics.add(graphic)
 
-        _startingPoints.add(
+        _currentTraceStartingPoints.add(
             StartingPoint(
                 feature = feature,
                 utilityElement = utilityElement,
-                symbol = symbol
+                symbol = symbol,
+                graphic = graphic
             )
         )
     }
@@ -292,19 +304,9 @@ public class TraceState(
                         processAndAddStartingPoint(feature, mapPoint)
                     }
                 }
-//                addTapLocationToGraphicsOverlay(mapPoint)
                 _addStartingPointMode.value = AddStartingPointMode.Stopped
             }
         }
-    }
-
-    private fun addTapLocationToGraphicsOverlay(mapPoint: Point) {
-        val graphic = Graphic(
-            geometry = mapPoint,
-            symbol = SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Cross, Color.green, 20.0f)
-        )
-        graphicsOverlay.graphics.add(graphic)
-        currentTraceGraphics.add(graphic)
     }
 
     /**
@@ -384,7 +386,7 @@ public sealed class AddStartingPointMode {
 }
 
 @Immutable
-internal data class StartingPoint(val feature: ArcGISFeature, val utilityElement: UtilityElement, val symbol: Symbol) {
+internal data class StartingPoint(val feature: ArcGISFeature, val utilityElement: UtilityElement, val symbol: Symbol, val graphic: Graphic) {
     val name: String = utilityElement.assetType.name
 
     suspend fun getDrawable(screenScale: Float): BitmapDrawable =
@@ -413,5 +415,4 @@ internal data class TraceRun(
     val graphics: List<Graphic>,
     val featureResults: List<UtilityElement>,
     val functionResults: List<UtilityTraceFunctionOutput>,
-    val geometryResults: List<Graphic>
 )

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -48,7 +48,7 @@ internal fun TraceNavHost(navController: NavHostController, traceState: TraceSta
             val configs = traceState.traceConfigurations.collectAsStateWithLifecycle()
             TraceOptionsScreen(
                 configurations = configs.value,
-                startingPoints = traceState.startingPoints,
+                startingPoints = traceState.currentTraceStartingPoints,
                 onPerformTraceButtonClicked = {
                     coroutineScope.launch {
                         try {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4633

<!-- link to design, if applicable -->

### Description:

We need to make sure that the Starting point graphic is removed from the graphicslayer when Starting point is deleted. 

### Summary of changes:

- Rename `startingPoints` to `currentTraceStartingPoints`
- Associate starting point graphic with each Starting point
- add logic to remove graphic from graphicslayer when Starting points are removed from CurrentTraceStartingPoint list
- Remove redundant `geometryResults` from `TraceRun` data class as it is the same as `graphics`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/109/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  