### PR TITLE
Make sure trace types work

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -182,10 +182,6 @@ public class TraceState(
             emptyList<UtilityElementTraceResult>()
             return false
         }
-        if (traceResults.isEmpty()) {
-            Log.i("TraceState --", "ERROR: no trace results")
-            return false
-        }
 
         val currentTraceFunctionResults : MutableList<UtilityTraceFunctionOutput> = mutableListOf()
         var currentTraceElementResults: List<UtilityElement> = emptyList()

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -17,6 +17,7 @@
 package com.arcgismaps.toolkit.utilitynetworks
 
 import android.graphics.drawable.BitmapDrawable
+import android.util.Log
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
@@ -162,11 +163,13 @@ public class TraceState(
 
         if (startingPoints.isEmpty() && traceConfiguration.minimumStartingLocations == UtilityMinimumStartingLocations.One) {
             // TODO: Handle error
+            Log.i("TraceState --", "ERROR: not enough starting points")
             return false
         }
 
         if (startingPoints.size < 2 && traceConfiguration.minimumStartingLocations == UtilityMinimumStartingLocations.Many) {
             // TODO: Handle error
+            Log.i("TraceState --", "ERROR: not enough starting points")
             return false
         }
 
@@ -175,7 +178,11 @@ public class TraceState(
         val traceResults = utilityNetwork.trace(utilityTraceParameters).getOrElse {
             //handle error
             println("ERROR: running trace" + it.message)
+            Log.i("TraceState --", "ERROR: running trace " + it.message)
             emptyList<UtilityElementTraceResult>()
+        }
+        if (traceResults.isEmpty()) {
+            Log.i("TraceState --", "ERROR: no trace results")
         }
 
         val currentTraceFunctionResults : MutableList<UtilityTraceFunctionOutput> = mutableListOf()

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -180,9 +180,11 @@ public class TraceState(
             println("ERROR: running trace" + it.message)
             Log.i("TraceState --", "ERROR: running trace " + it.message)
             emptyList<UtilityElementTraceResult>()
+            return false
         }
         if (traceResults.isEmpty()) {
             Log.i("TraceState --", "ERROR: no trace results")
+            return false
         }
 
         val currentTraceFunctionResults : MutableList<UtilityTraceFunctionOutput> = mutableListOf()

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -210,7 +210,7 @@ private fun formatDouble(value: Double): String {
     return if (value % 1.0 == 0.0) {
         value.toInt().toString() // Return as int string if decimal part is 0
     } else {
-        String.format("%.5f", value) // Return as double string with 4 decimal places
+        String.format("%.5f", value) // Return as double string with 5 decimal places
     }
 }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -210,7 +210,7 @@ private fun formatDouble(value: Double): String {
     return if (value % 1.0 == 0.0) {
         value.toInt().toString() // Return as int string if decimal part is 0
     } else {
-        String.format("%.4f", value) // Return as double string with 4 decimal places
+        String.format("%.5f", value) // Return as double string with 4 decimal places
     }
 }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.utilitynetworks.ui
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -191,7 +192,7 @@ private fun FunctionResult(functionResults: List<UtilityTraceFunctionOutput>) {
                                     color = Color.Gray
                                 )
                                 val result = when (functionResult.result) {
-                                    is Double -> (functionResult.result as Double).toInt().toString()
+                                    is Double -> formatDouble(functionResult.result as Double)
                                     else -> stringResource(R.string.not_available)
                                 }
                                 Text(text = result, style = MaterialTheme.typography.titleMedium)
@@ -201,6 +202,15 @@ private fun FunctionResult(functionResults: List<UtilityTraceFunctionOutput>) {
                 }
             }
         }
+    }
+}
+
+@SuppressLint("DefaultLocale")
+private fun formatDouble(value: Double): String {
+    return if (value % 1.0 == 0.0) {
+        value.toInt().toString() // Return as int string if decimal part is 0
+    } else {
+        String.format("%.4f", value) // Return as double string with 4 decimal places
     }
 }
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4651

<!-- link to design, if applicable -->

### Description:

make sure the all the trace types are working and we are getting results back. We currently are not reporting config errors to the user. This PR makes changes to not navigate to results screen if we get errors back and logs errors.

### Summary of changes:

- Return false from Trace() when we get error back, so navigation from the option screen to results screen will not happen
- update the formatting for function results

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/112/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  