### PR TITLE
redesign trace options

### DIFF
--- a/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCard.kt
+++ b/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -46,7 +47,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.ui.expandablecard.theme.DefaultThemeTokens.shapes
 import com.arcgismaps.toolkit.ui.expandablecard.theme.DefaultThemeTokens.typography
@@ -69,7 +69,7 @@ fun ExpandableCard(
     description: (@Composable () -> Unit)? = null,
     toggleable: Boolean = true,
     initialExpandedState: Boolean = true,
-    padding: Dp = 16.dp,
+    padding: PaddingValues = PaddingValues(16.dp),
     colorScheme: ExpandableCardColorScheme = ExpandableCardDefaults.colorScheme(),
     shapes: ExpandableCardShapes = ExpandableCardDefaults.shapes(),
     typography: ExpandableCardTypography = ExpandableCardDefaults.typography(),

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/Text.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/Text.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -44,7 +45,7 @@ import androidx.compose.ui.unit.sp
  * @since 200.6.0
  */
 private val style = TextStyle(
-    color = Color.Black,
+    color = Color.Unspecified,
     fontSize = 15.sp,
     fontWeight = FontWeight.SemiBold,
     fontStyle = FontStyle.Normal,
@@ -93,8 +94,7 @@ internal fun ReadOnlyTextField(
             ) {
                 Text(
                     text = text.ifEmpty { "--" },
-                    color = Color.Unspecified,
-                    style = style,
+                    style = style.copy(color = MaterialTheme.colorScheme.onBackground),
                     overflow = overflow,
                     maxLines = maxLines
                 )

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/Text.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/Text.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.utilitynetworks.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -68,7 +69,8 @@ internal fun ReadOnlyTextField(
     modifier: Modifier = Modifier,
     overflow: TextOverflow = TextOverflow.Ellipsis,
     maxLines: Int = 1,
-    leadingIcon: (@Composable () -> Unit)? = null
+    leadingIcon: (@Composable () -> Unit)? = null,
+    trailingIcon: (@Composable () -> Unit)? = null
 ) {
     Row(
         modifier = modifier
@@ -81,13 +83,24 @@ internal fun ReadOnlyTextField(
         SelectionContainer(
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
         ) {
-            Text(
-                text = text.ifEmpty { "--" },
-                color = Color.Unspecified,
-                style = style,
-                overflow = overflow,
-                maxLines = maxLines
-            )
+            Row(
+                modifier = modifier
+                    .fillMaxWidth()
+                    // merge descendants semantics to make them part of the parent node
+                    .semantics(mergeDescendants = true) {},
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = text.ifEmpty { "--" },
+                    color = Color.Unspecified,
+                    style = style,
+                    overflow = overflow,
+                    maxLines = maxLines
+                )
+                trailingIcon?.invoke()
+            }
         }
+
     }
 }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -123,7 +123,7 @@ internal fun TraceOptionsScreen(
                 item {
                     Spacer(modifier = Modifier
                         .fillMaxWidth()
-                        .height(6.dp))
+                        .height(10.dp))
                 }
                 item {
                     StartingPoints(
@@ -135,7 +135,7 @@ internal fun TraceOptionsScreen(
                 item {
                     Spacer(modifier = Modifier
                         .fillMaxWidth()
-                        .height(5.dp))
+                        .height(10.dp))
                 }
                 item {
                     AdvancedOptions()
@@ -278,7 +278,7 @@ private fun StartingPoints(
                 }
             }
         },
-        padding = 4.dp
+        padding = PaddingValues(horizontal = 4.dp)
     ) {
         Column {
             startingPoints.forEach {
@@ -307,7 +307,7 @@ internal fun AdvancedOptions(
         title = stringResource(id = R.string.advanced_options),
         toggleable = true,
         initialExpandedState = false,
-        padding = 4.dp
+        padding = PaddingValues(horizontal = 4.dp)
     ) {
         Column {
             if (showName) {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -184,7 +184,6 @@ private fun TraceConfigurations(
                 .clickable {
                     showDropdown = !showDropdown
                 },
-            //horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             ReadOnlyTextField(

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -177,7 +177,7 @@ private fun TraceConfigurations(
                 color = MaterialTheme.colorScheme.outline.copy(alpha = 0.6f),
                 shape = RoundedCornerShape(5.dp)
             )
-            .background(color = MaterialTheme.colorScheme.background)//, shape = RoundedCornerShape(5.dp))
+            .background(color = MaterialTheme.colorScheme.background)
     ) {
         Row (
             modifier = Modifier
@@ -254,36 +254,33 @@ private fun StartingPoints(
     showAddStartingPointScreen: () -> Unit,
     onStartingPointRemoved: (StartingPoint) -> Unit
 ) {
-       ExpandableCard(
-        title = "${stringResource(id = R.string.starting_points)} (${startingPoints.size})",
-        description = {
-            Row(
+    Column {
+
+            ElevatedButton(
+                onClick = {
+                    showAddStartingPointScreen()
+                },
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
+                shape = RoundedCornerShape(8.dp)
             ) {
-                ElevatedButton(
-                    onClick = {
-                        showAddStartingPointScreen()
-                    },
-                    shape = RoundedCornerShape(8.dp)
-                ) {
-                    Text(
-                        text = stringResource(id = R.string.add_starting_point),
-                        color = LocalExpandableCardColorScheme.current.headerTextColor,
-                        style = LocalExpandableCardTypography.current.descriptionStyle,
-                        fontWeight = FontWeight.Normal,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
+                Text(
+                    text = stringResource(id = R.string.add_starting_point),
+                    color = LocalExpandableCardColorScheme.current.headerTextColor,
+                    style = LocalExpandableCardTypography.current.descriptionStyle,
+                    fontWeight = FontWeight.Normal,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
-        },
-        padding = PaddingValues(horizontal = 4.dp)
-    ) {
-        Column {
-            startingPoints.forEach {
-                StartingPointRow(it) {
-                    onStartingPointRemoved(it)
+        ExpandableCard(
+            title = "${stringResource(id = R.string.starting_points)} (${startingPoints.size})",
+            padding = PaddingValues(horizontal = 4.dp)
+        ) {
+            Column {
+                startingPoints.forEach {
+                    StartingPointRow(it) {
+                        onStartingPointRemoved(it)
+                    }
                 }
             }
         }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedButton
@@ -69,15 +70,12 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.ui.expandablecard.ExpandableCard
-import com.arcgismaps.toolkit.ui.expandablecard.theme.LocalExpandableCardColorScheme
-import com.arcgismaps.toolkit.ui.expandablecard.theme.LocalExpandableCardTypography
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.StartingPoint
 import com.arcgismaps.utilitynetworks.UtilityNamedTraceConfiguration
@@ -168,7 +166,7 @@ private fun TraceConfigurations(
     var showDropdown by rememberSaveable {
         mutableStateOf(false)
     }
-    ReadOnlyTextField(stringResource(id = R.string.trace_configuration), modifier = Modifier.padding(horizontal = 6.dp))
+    ReadOnlyTextField(stringResource(id = R.string.trace_configuration), modifier = Modifier.padding(horizontal = 4.dp))
     Column(
         modifier = Modifier
             .padding(horizontal = 4.dp)
@@ -243,6 +241,36 @@ private fun TraceConfigsPreview() {
     TraceConfigurations(listOf("Foo", "Bar"), "Foo") {}
 }
 
+@Preview(showBackground = true)
+@Composable
+private fun AddStartingPointButtonPreview() {
+    Column {
+        AddStartingPointButton {
+
+        }
+    }
+}
+
+@Composable
+private fun AddStartingPointButton(showAddStartingPointScreen: () -> Unit) {
+    ElevatedButton(
+        onClick = {
+            showAddStartingPointScreen()
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(PaddingValues(horizontal = 4.dp)),
+        colors = ButtonDefaults.elevatedButtonColors().copy(containerColor = MaterialTheme.colorScheme.surfaceContainerLowest),
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Text(
+            text = stringResource(id = R.string.add_starting_point),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
 /**
  * A composable used to add starting points for the trace.
  *
@@ -255,23 +283,12 @@ private fun StartingPoints(
     onStartingPointRemoved: (StartingPoint) -> Unit
 ) {
     Column {
-
-            ElevatedButton(
-                onClick = {
-                    showAddStartingPointScreen()
-                },
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(8.dp)
-            ) {
-                Text(
-                    text = stringResource(id = R.string.add_starting_point),
-                    color = LocalExpandableCardColorScheme.current.headerTextColor,
-                    style = LocalExpandableCardTypography.current.descriptionStyle,
-                    fontWeight = FontWeight.Normal,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+        AddStartingPointButton {
+            showAddStartingPointScreen()
+        }
+        Spacer(modifier = Modifier
+            .height(4.dp)
+            .fillMaxWidth())
         ExpandableCard(
             title = "${stringResource(id = R.string.starting_points)} (${startingPoints.size})",
             padding = PaddingValues(horizontal = 4.dp)

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -16,6 +16,7 @@
 package com.arcgismaps.toolkit.utilitynetworks.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -24,6 +25,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -37,6 +39,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -112,10 +115,15 @@ internal fun TraceOptionsScreen(
                 item {
                     TraceConfigurations(
                         configurations,
-                        selectedConfig
+                        selectedConfig,
                     ) { newConfig ->
                         onConfigSelected(newConfig)
                     }
+                }
+                item {
+                    Spacer(modifier = Modifier
+                        .fillMaxWidth()
+                        .height(6.dp))
                 }
                 item {
                     StartingPoints(
@@ -123,6 +131,11 @@ internal fun TraceOptionsScreen(
                         onAddStartingPointButtonClicked,
                         onStartingPointRemoved
                     )
+                }
+                item {
+                    Spacer(modifier = Modifier
+                        .fillMaxWidth()
+                        .height(5.dp))
                 }
                 item {
                     AdvancedOptions()
@@ -135,42 +148,99 @@ internal fun TraceOptionsScreen(
     }
 }
 
-/**
- * A composable used to display the available trace types.
- *
- * @since 200.6.0
- */
 @Composable
-private fun TraceConfigurations(configs: List<UtilityNamedTraceConfiguration>, selectedConfig: UtilityNamedTraceConfiguration?, onTraceSelected: (UtilityNamedTraceConfiguration) -> Unit) {
-    ExpandableCard(
-        title = stringResource(id = R.string.trace_configuration),
-        padding = 4.dp
+private fun TraceConfigurations(
+    configs: List<UtilityNamedTraceConfiguration>,
+    selectedConfig: UtilityNamedTraceConfiguration?,
+    onTraceSelected: (UtilityNamedTraceConfiguration) -> Unit
+) {
+    TraceConfigurations(configs.map { it.name }, selectedConfigName = selectedConfig?.name ?: "") { index ->
+        onTraceSelected(configs[index])
+    }
+}
+
+@Composable
+private fun TraceConfigurations(
+    configs: List<String>,
+    selectedConfigName: String?,
+    onTraceSelected: (Int) -> Unit
+) {
+    var showDropdown by rememberSaveable {
+        mutableStateOf(false)
+    }
+    ReadOnlyTextField(stringResource(id = R.string.trace_configuration), modifier = Modifier.padding(horizontal = 6.dp))
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 4.dp)
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outline.copy(alpha = 0.6f),
+                shape = RoundedCornerShape(5.dp)
+            )
+            .background(color = MaterialTheme.colorScheme.background)//, shape = RoundedCornerShape(5.dp))
     ) {
-        Column {
-            configs.forEachIndexed { index, item ->
-                ReadOnlyTextField(
-                    text = item.name,
-                    leadingIcon = if (item.name == selectedConfig?.name) {
-                        {
-                            Icon(
-                                imageVector = Icons.Filled.Done,
-                                contentDescription = "Done icon",
-                                modifier = Modifier.size(FilterChipDefaults.IconSize)
-                            )
-                        }
-                    } else {
-                        null
+        Row (
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp)
+                .clickable {
+                    showDropdown = !showDropdown
+                },
+            //horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            ReadOnlyTextField(
+                text = selectedConfigName ?: "",
+                modifier = Modifier.clickable {
+                    showDropdown = !showDropdown
+                },
+                trailingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.MoreVert,
+                        contentDescription = "Edit icon",
+                        modifier = Modifier.size(FilterChipDefaults.IconSize)
+                    )
+                }
+            )
+        }
+    }
+    MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = RoundedCornerShape(16.dp))) {
+        DropdownMenu(
+            expanded = showDropdown,
+            offset = DpOffset.Zero,
+            onDismissRequest = { showDropdown = false }) {
+            configs.forEachIndexed { index, name ->
+                DropdownMenuItem(
+                    text = {
+                        ReadOnlyTextField(
+                            text = name, leadingIcon = if (name == selectedConfigName) {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Filled.Done,
+                                        contentDescription = "Done icon",
+                                        modifier = Modifier.size(FilterChipDefaults.IconSize)
+                                    )
+                                }
+                            } else {
+                                null
+                            }
+                        )
                     },
-                    modifier = Modifier
-                        .padding(horizontal = 8.dp)
-                        .fillMaxWidth()
-                        .clickable {
-                            onTraceSelected(configs[index])
-                        }
+                    onClick = {
+                        onTraceSelected(index)
+                        showDropdown = false
+                    },
+                    contentPadding = PaddingValues(vertical = 0.dp, horizontal = 10.dp)
                 )
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TraceConfigsPreview() {
+    TraceConfigurations(listOf("Foo", "Bar"), "Foo") {}
 }
 
 /**

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -220,7 +221,7 @@ internal fun TraceResultSection(title: String, value: String, content: @Composab
         ExpandableCard(
             initialExpandedState = false,
             title = value,
-            padding = 0.dp,
+            padding = PaddingValues(0.dp),
             modifier = Modifier.padding(horizontal = 16.dp)
         ) {
             content()


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4598

<!-- link to design, if applicable -->

### Description:

A bit more than the issue specifies:
* make trace confugrations use a dropdown menu as opposed to an expandable card
* show the selected trace configuration when not focused

starting points:
* move `add new starting point` button out of the ExpandableCard header.
* add a standalone button for adding new starting points

theme
* fix dark mode text color of ReadOnlyTextFields so that it changes with the mode



### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/114/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  