### PR TITLE
Changes to make advanced options work

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -121,7 +121,14 @@ public class TraceState(
 
     private val completedTraces: MutableList<TraceRun> = mutableListOf()
 
-    private var currentTraceName: String? = null
+    private var _currentTraceName: MutableState<String> = mutableStateOf("")
+    /**
+     * The default name of the trace.
+     *
+     * @since 200.6.0
+     */
+    public val currentTraceName: State<String> = _currentTraceName
+
     private var currentTraceGraphicsColor: Color = Color.green
     public val currentTraceGraphicsColorAsComposeColor: androidx.compose.ui.graphics.Color
         get() = androidx.compose.ui.graphics.Color(
@@ -131,7 +138,8 @@ public class TraceState(
             currentTraceGraphicsColor.alpha
         )
 
-    private var currentTraceZoomToResults: Boolean = false
+    private var _currentTraceZoomToResults: MutableState<Boolean> = mutableStateOf(false)
+    public var currentTraceZoomToResults: State<Boolean> = _currentTraceZoomToResults
 
     private val currentTraceResultGeometriesExtent: Envelope?
     get() {
@@ -186,6 +194,7 @@ public class TraceState(
 
     internal fun setSelectedTraceConfiguration(config: UtilityNamedTraceConfiguration) {
         _selectedTraceConfiguration.value = config
+        _currentTraceName.value = "${config.name} ${(completedTraces.count { it.configuration.name == config.name } + 1)}"
     }
 
     internal fun showScreen(screen: TraceNavRoute) {
@@ -262,7 +271,7 @@ public class TraceState(
             }
         }
         _currentTraceRun.value = TraceRun(
-            name = getTraceName(),
+            name = _currentTraceName.value,
             configuration = traceConfiguration,
             graphics = currentTraceGeometryResultsGraphics,
             featureResults = currentTraceElementResults,
@@ -270,7 +279,7 @@ public class TraceState(
             geometryTraceResult = currentTraceGeometryResults
         ).also { completedTraces.add(it) }
 
-        if (currentTraceZoomToResults) {
+        if (_currentTraceZoomToResults.value) {
             currentTraceResultGeometriesExtent?.let {
                 mapViewProxy.setViewpointAnimated(
                     Viewpoint(it),
@@ -281,21 +290,6 @@ public class TraceState(
         }
 
         return true
-    }
-
-    /**
-     * Returns the name of the trace set by the user using the advanced options, else it auto-populates
-     * the name.
-     *
-     * @return the name of the trace
-     * @since 200.6.0
-     */
-    private fun getTraceName(): String {
-        currentTraceName?.let {
-            return it
-        }
-        val name = "${_selectedTraceConfiguration.value?.name} ${(completedTraces.count { it.configuration.name == _selectedTraceConfiguration.value?.name } + 1)}"
-        return name
     }
 
     private fun createGraphicForSimpleLineSymbol(geometry: Geometry, style: SimpleLineSymbolStyle, color: Color) =
@@ -397,7 +391,7 @@ public class TraceState(
      * @since 200.6.0
      */
     internal fun setTraceName(name: String) {
-        currentTraceName = name
+        _currentTraceName.value = name
     }
 
     /**
@@ -434,7 +428,7 @@ public class TraceState(
      * @since 200.6.0
      */
     internal fun setZoomToResults(zoom: Boolean) {
-        currentTraceZoomToResults = zoom
+        _currentTraceZoomToResults.value = zoom
     }
 }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -123,6 +123,14 @@ public class TraceState(
 
     private var currentTraceName: String? = null
     private var currentTraceGraphicsColor: Color = Color.green
+    public val currentTraceGraphicsColorAsComposeColor: androidx.compose.ui.graphics.Color
+        get() = androidx.compose.ui.graphics.Color(
+            currentTraceGraphicsColor.red,
+            currentTraceGraphicsColor.green,
+            currentTraceGraphicsColor.blue,
+            currentTraceGraphicsColor.alpha
+        )
+
     private var currentTraceZoomToResults: Boolean = false
 
     private val currentTraceResultGeometriesExtent: Envelope?
@@ -412,10 +420,7 @@ public class TraceState(
         }
         // update the color of the trace results graphics
         currentTraceGeometryResultsGraphics.forEach { graphic ->
-            if (graphic.symbol is SimpleMarkerSymbol) {
-                val symbol = graphic.symbol as SimpleMarkerSymbol
-                symbol.color = currentTraceGraphicsColor
-            } else if (graphic.symbol is SimpleLineSymbol) {
+            if (graphic.symbol is SimpleLineSymbol) {
                 val symbol = graphic.symbol as SimpleLineSymbol
                 symbol.color = currentTraceGraphicsColor
             }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -275,6 +275,13 @@ public class TraceState(
         return true
     }
 
+    /**
+     * Returns the name of the trace set by the user using the advanced options, else it auto-populates
+     * the name.
+     *
+     * @return the name of the trace
+     * @since 200.6.0
+     */
     private fun getTraceName(): String {
         currentTraceName?.let {
             return it

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -284,7 +284,7 @@ public class TraceState(
                 mapViewProxy.setViewpointAnimated(
                     Viewpoint(it),
                     2.0.seconds,
-                    AnimationCurve.Linear
+                    AnimationCurve.EaseOutCirc
                 )
             }
         }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -125,7 +125,7 @@ public class TraceState(
     private var currentTraceGraphicsColor: Color = Color.green
     private var currentTraceZoomToResults: Boolean = false
 
-    private val resultExtent: Envelope?
+    private val currentTraceResultGeometriesExtent: Envelope?
     get() {
         val utilityGeometryTraceResult = _currentTraceRun.value?.geometryTraceResult ?: return null
 
@@ -263,7 +263,7 @@ public class TraceState(
         ).also { completedTraces.add(it) }
 
         if (currentTraceZoomToResults) {
-            resultExtent?.let {
+            currentTraceResultGeometriesExtent?.let {
                 mapViewProxy.setViewpointAnimated(
                     Viewpoint(it),
                     2.0.seconds,

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -65,6 +65,15 @@ internal fun TraceNavHost(traceState: TraceState) {
                 onStartingPointRemoved = { traceState.removeStartingPoint(it) },
                 onConfigSelected = { newConfig ->
                     traceState.setSelectedTraceConfiguration(newConfig)
+                },
+                onNameChange = {
+                    traceState.setTraceName(it)
+                               },
+                onColorChanged = {
+                    traceState.setGraphicsColor(it)
+                                 },
+                onZoomRequested = {
+                    traceState.setZoomToResults(it)
                 }
             )
         }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -45,7 +45,9 @@ internal fun TraceNavHost(traceState: TraceState) {
             TraceOptionsScreen(
                 configurations = configs,
                 startingPoints = traceState.currentTraceStartingPoints,
+                defaultTraceName = traceState.currentTraceName.value,
                 selectedColor = traceState.currentTraceGraphicsColorAsComposeColor,
+                zoomToResult = traceState.currentTraceZoomToResults.value,
                 onPerformTraceButtonClicked = {
                     coroutineScope.launch {
                         try {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -45,6 +45,7 @@ internal fun TraceNavHost(traceState: TraceState) {
             TraceOptionsScreen(
                 configurations = configs,
                 startingPoints = traceState.currentTraceStartingPoints,
+                selectedColor = traceState.currentTraceGraphicsColorAsComposeColor,
                 onPerformTraceButtonClicked = {
                     coroutineScope.launch {
                         try {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -92,7 +92,9 @@ internal fun TraceOptionsScreen(
     configurations: List<UtilityNamedTraceConfiguration>,
     startingPoints: List<StartingPoint>,
     selectedConfig: UtilityNamedTraceConfiguration?,
+    defaultTraceName: String,
     selectedColor: Color,
+    zoomToResult: Boolean,
     onStartingPointRemoved: (StartingPoint) -> Unit,
     onConfigSelected: (UtilityNamedTraceConfiguration) -> Unit,
     onPerformTraceButtonClicked: () -> Unit,
@@ -132,7 +134,9 @@ internal fun TraceOptionsScreen(
                     AdvancedOptions(
                         onNameChange = onNameChange,
                         onColorChanged = onColorChanged,
+                        defaultTraceName = defaultTraceName,
                         selectedColor = selectedColor,
+                        zoomToResult = zoomToResult,
                         onZoomRequested = onZoomRequested
                     )
                 }
@@ -242,7 +246,9 @@ internal fun AdvancedOptions(
     @Suppress("unused_parameter") modifier: Modifier = Modifier,
     showName: Boolean = true,
     showZoomToResult: Boolean = true,
+    defaultTraceName: String,
     selectedColor: Color,
+    zoomToResult: Boolean,
     onNameChange: (String) -> Unit = {},
     onColorChanged: (Color) -> Unit = {},
     onZoomRequested: (Boolean) -> Unit = {}
@@ -264,7 +270,7 @@ internal fun AdvancedOptions(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    var text by rememberSaveable { mutableStateOf("") }
+                    var text by rememberSaveable { mutableStateOf(defaultTraceName) }
                     TextField(
                         value = text,
                         onValueChange = { newValue ->
@@ -289,7 +295,7 @@ internal fun AdvancedOptions(
             }
 
             if (showZoomToResult) {
-                var isEnabled by rememberSaveable { mutableStateOf(false) }
+                var isEnabled by rememberSaveable { mutableStateOf(zoomToResult) }
                 val interactionSource = remember { MutableInteractionSource() }
                 LaunchedEffect(Unit) {
                     interactionSource.interactions.collect {
@@ -418,7 +424,7 @@ private fun AdvancedOptionsRow(name: String, modifier: Modifier = Modifier, trai
 @Preview
 @Composable
 private fun AdvancedOptionsPreview() {
-    AdvancedOptions(selectedColor = Color.Green)
+    AdvancedOptions(defaultTraceName = "", selectedColor = Color.Green, zoomToResult = false)
 }
 
 @Preview

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -92,6 +92,7 @@ internal fun TraceOptionsScreen(
     configurations: List<UtilityNamedTraceConfiguration>,
     startingPoints: List<StartingPoint>,
     selectedConfig: UtilityNamedTraceConfiguration?,
+    selectedColor: Color,
     onStartingPointRemoved: (StartingPoint) -> Unit,
     onConfigSelected: (UtilityNamedTraceConfiguration) -> Unit,
     onPerformTraceButtonClicked: () -> Unit,
@@ -131,6 +132,7 @@ internal fun TraceOptionsScreen(
                     AdvancedOptions(
                         onNameChange = onNameChange,
                         onColorChanged = onColorChanged,
+                        selectedColor = selectedColor,
                         onZoomRequested = onZoomRequested
                     )
                 }
@@ -240,6 +242,7 @@ internal fun AdvancedOptions(
     @Suppress("unused_parameter") modifier: Modifier = Modifier,
     showName: Boolean = true,
     showZoomToResult: Boolean = true,
+    selectedColor: Color,
     onNameChange: (String) -> Unit = {},
     onColorChanged: (Color) -> Unit = {},
     onZoomRequested: (Boolean) -> Unit = {}
@@ -282,7 +285,7 @@ internal fun AdvancedOptions(
 
             // Color picker
             AdvancedOptionsRow(name = stringResource(id = R.string.color)) {
-                ColorPicker(onColorChanged)
+                ColorPicker(selectedColor, onColorChanged)
             }
 
             if (showZoomToResult) {
@@ -323,8 +326,8 @@ internal fun AdvancedOptions(
  * @since 200.6.0
  */
 @Composable
-internal fun ColorPicker(onColorChanged: (Color) -> Unit = {}) {
-    var currentSelectedColor by rememberSaveable(saver = ColorSaver.Saver()) { mutableStateOf(Color.Red) }
+internal fun ColorPicker(selectedColor: Color, onColorChanged: (Color) -> Unit = {}) {
+    var currentSelectedColor by rememberSaveable(saver = ColorSaver.Saver()) { mutableStateOf(selectedColor) }
     var displayPicker by rememberSaveable { mutableStateOf(false) }
     Box {
         TraceColors.SpectralRing(
@@ -415,7 +418,7 @@ private fun AdvancedOptionsRow(name: String, modifier: Modifier = Modifier, trai
 @Preview
 @Composable
 private fun AdvancedOptionsPreview() {
-    AdvancedOptions()
+    AdvancedOptions(selectedColor = Color.Green)
 }
 
 @Preview

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -48,10 +47,10 @@ import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -354,7 +353,7 @@ internal fun AdvancedOptions(
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     var text by rememberSaveable { mutableStateOf(defaultTraceName) }
-                    TextField(
+                    OutlinedTextField(
                         value = text,
                         onValueChange = { newValue ->
                             text = newValue
@@ -504,13 +503,13 @@ private fun AdvancedOptionsRow(name: String, modifier: Modifier = Modifier, trai
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun AdvancedOptionsPreview() {
     AdvancedOptions(defaultTraceName = "", selectedColor = Color.Green, zoomToResult = false)
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun AdvancedOptionsRowPreview() {
     var isEnabled by remember { mutableStateOf(false) }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4644

<!-- link to design, if applicable -->

### Description:

Make sure selections made by the user in Advanced options work when a trace is executed

### Summary of changes:

- Rename `currentTraceGraphics` to `currentTraceGeometryResultGraphics` to reflect the usage of the parameter, also don't add starting point graphic to it
- Hook up the UI to update the `TraceState` with the user selected values for name, trace graphic colors and zoom to result 
- add logic to determine the Name for the trace, update graphic colors and zoom to result

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/117/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  