### PR TITLE
`Forms`: consume new api

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4352
+sdkBuildNumber=4376

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -236,18 +236,6 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
             )
         }
 
-        is UIState.NoFeatureFormDefinition -> {
-            NoFormDefinitionDialog(
-                onConfirm = {
-                    mapViewModel.setDefaultState()
-                },
-                onCancel = {
-                    mapViewModel.setDefaultState()
-                    onBackPressed()
-                }
-            )
-        }
-
         is UIState.Error -> {
             ErrorDialog(
                 error = uiState as UIState.Error,
@@ -445,40 +433,6 @@ fun DiscardEditsDialog(onConfirm: () -> Unit, onCancel: () -> Unit) {
         },
         text = {
             Text(text = stringResource(R.string.all_changes_will_be_lost))
-        }
-    )
-}
-
-@Composable
-fun NoFormDefinitionDialog(
-    onConfirm: () -> Unit,
-    onCancel: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = {},
-        title = {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.no_featureform_found),
-                    modifier = Modifier.weight(1f)
-                )
-                Image(imageVector = Icons.Rounded.Warning, contentDescription = null)
-            }
-        },
-        confirmButton = {
-            Button(onClick = onConfirm) {
-                Text(text = stringResource(R.string.okay))
-            }
-        },
-        dismissButton = {
-            Button(onClick = onCancel) {
-                Text(text = stringResource(R.string.exit))
-            }
-        },
-        text = {
-            Text(text = stringResource(R.string.no_featureform_description))
         }
     )
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Consumes the new FeatureForm constructor which can generate a new `FeatureFormDefinition` if one is not authored.

### Summary of changes:

- Replace usages of the deprecated `FeatureForm` constructor with the new one.
- Removed `NoFormDefinition` UI state since a `FeatureForm` is now generated if no definition is found.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  