### PR TITLE
Starting point details screen

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -54,6 +54,7 @@ import com.arcgismaps.utilitynetworks.UtilityMinimumStartingLocations
 import com.arcgismaps.utilitynetworks.UtilityNamedTraceConfiguration
 import com.arcgismaps.utilitynetworks.UtilityNetwork
 import com.arcgismaps.utilitynetworks.UtilityNetworkSourceType
+import com.arcgismaps.utilitynetworks.UtilityTerminal
 import com.arcgismaps.utilitynetworks.UtilityTraceFunctionOutput
 import com.arcgismaps.utilitynetworks.UtilityTraceParameters
 import kotlinx.coroutines.CancellationException
@@ -260,6 +261,14 @@ public class TraceState(
         }
     }
 
+    /**
+     * Sets the terminal for the starting point.
+     *
+     * @since 200.6.0
+     */
+    internal fun setTerminal(startingPoint: StartingPoint, terminal: UtilityTerminal) {
+        startingPoint.utilityElement.terminal = terminal
+    }
 
     /**
      * Run a trace on the Utility Network using the selected trace configuration and starting points.
@@ -375,6 +384,16 @@ public class TraceState(
     internal fun removeStartingPoint(startingPoint: StartingPoint) {
         _currentTraceStartingPoints.remove(startingPoint)
         graphicsOverlay.graphics.remove(startingPoint.graphic)
+    }
+
+    internal suspend fun zoomToStartingPoint(startingPoint: StartingPoint) {
+        startingPoint.graphic.geometry?.let {
+            mapViewProxy.setViewpointAnimated(
+                Viewpoint(it),
+                1.0.seconds,
+                AnimationCurve.EaseOutCirc
+            )
+        }
     }
 
     /**

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.utilitynetworks.R
 
 @Composable
-internal fun Title(name: String, onZoomToResults: () -> Unit, onDeleteResult: () -> Unit) {
+internal fun Title(name: String, onZoomTo: () -> Unit, onDelete: () -> Unit) {
     var expanded by remember { mutableStateOf(false) }
     Row(
         modifier = Modifier
@@ -58,19 +58,19 @@ internal fun Title(name: String, onZoomToResults: () -> Unit, onDeleteResult: ()
                         expanded = false
                     }) {
                     DropdownMenuItem(
-                        text = { Text(stringResource(R.string.zoom_to_result)) },
-                        onClick = onZoomToResults,
+                        text = { Text(stringResource(R.string.zoom_to)) },
+                        onClick = onZoomTo,
                         leadingIcon = { Icon(
                             Icons.Outlined.LocationOn, contentDescription = stringResource(
-                                R.string.zoom_to_trace_result)
+                                R.string.zoom_to)
                         ) }
                     )
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.delete)) },
-                        onClick = onDeleteResult,
+                        onClick = onDelete,
                         leadingIcon = { Icon(
                             Icons.Outlined.Clear, contentDescription = stringResource(
-                                R.string.delete_trace_result)
+                                R.string.delete)
                         ) }
                     )
                 }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,7 +31,7 @@ import com.arcgismaps.toolkit.utilitynetworks.R
 
 @Composable
 internal fun Title(name: String, onZoomTo: () -> Unit, onDelete: () -> Unit) {
-    var expanded by remember { mutableStateOf(false) }
+    var expanded by rememberSaveable { mutableStateOf(false) }
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
@@ -57,7 +57,9 @@ internal fun Title(name: String, onZoomTo: () -> Unit, onDelete: () -> Unit) {
                 expanded = !expanded
             }, verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    modifier = Modifier.padding(start = 10.dp, end = 10.dp),
+                    modifier = Modifier
+                        .padding(start = 10.dp, end = 10.dp)
+                        .weight(1f),
                     text = name,
                     style = MaterialTheme.typography.titleLarge,
                     maxLines = 1,

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.utilitynetworks.R
 
@@ -41,11 +42,14 @@ internal fun Title(name: String, onZoomTo: () -> Unit, onDelete: () -> Unit) {
                 expanded = !expanded
             }, verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    modifier = Modifier.padding(end = 8.dp),
+                    modifier = Modifier.padding(start = 10.dp, end = 10.dp),
                     text = name,
-                    style = MaterialTheme.typography.headlineSmall
+                    style = MaterialTheme.typography.titleLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
                 Icon(
+                    modifier = Modifier.padding(end = 10.dp),
                     imageVector = Icons.Outlined.MoreVert,
                     contentDescription = ""
                 )

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2024 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.arcgismaps.toolkit.utilitynetworks.internal.util
 
 import androidx.compose.foundation.clickable
@@ -19,7 +34,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -64,7 +78,10 @@ internal fun Title(name: String, onZoomTo: () -> Unit, onDelete: () -> Unit) {
                     }) {
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.zoom_to)) },
-                        onClick = onZoomTo,
+                        onClick = {
+                            expanded = false
+                            onZoomTo()
+                        },
                         leadingIcon = { Icon(
                             Icons.Outlined.LocationOn, contentDescription = stringResource(
                                 R.string.zoom_to)
@@ -72,7 +89,10 @@ internal fun Title(name: String, onZoomTo: () -> Unit, onDelete: () -> Unit) {
                     )
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.delete)) },
-                        onClick = onDelete,
+                        onClick = {
+                            expanded = false
+                            onDelete()
+                        },
                         leadingIcon = { Icon(
                             Icons.Outlined.Clear, contentDescription = stringResource(
                                 R.string.delete)

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TitleRow.kt
@@ -1,0 +1,80 @@
+package com.arcgismaps.toolkit.utilitynetworks.internal.util
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Clear
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.arcgismaps.toolkit.utilitynetworks.R
+
+@Composable
+internal fun Title(name: String, onZoomToResults: () -> Unit, onDeleteResult: () -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Box {
+            Row(modifier = Modifier.clickable {
+                expanded = !expanded
+            }, verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    modifier = Modifier.padding(end = 8.dp),
+                    text = name,
+                    style = MaterialTheme.typography.headlineSmall
+                )
+                Icon(
+                    imageVector = Icons.Outlined.MoreVert,
+                    contentDescription = ""
+                )
+            }
+            MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = RoundedCornerShape(16.dp))) {
+                DropdownMenu(
+                    modifier = Modifier.padding(start = 8.dp, end = 16.dp),
+                    expanded = expanded,
+                    onDismissRequest = {
+                        expanded = false
+                    }) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.zoom_to_result)) },
+                        onClick = onZoomToResults,
+                        leadingIcon = { Icon(
+                            Icons.Outlined.LocationOn, contentDescription = stringResource(
+                                R.string.zoom_to_trace_result)
+                        ) }
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.delete)) },
+                        onClick = onDeleteResult,
+                        leadingIcon = { Icon(
+                            Icons.Outlined.Clear, contentDescription = stringResource(
+                                R.string.delete_trace_result)
+                        ) }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/UpButton.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/UpButton.kt
@@ -40,7 +40,7 @@ internal fun UpButton(title: String,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
-            modifier = Modifier.padding(start = 16.dp),
+            modifier = Modifier.padding(start = 10.dp),
             imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
             contentDescription = "back",
             tint = MaterialTheme.colorScheme.primary

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/UpButton.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/UpButton.kt
@@ -1,0 +1,56 @@
+/**
+ *  Copyright 2024 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.arcgismaps.toolkit.utilitynetworks.internal.util
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun UpButton(title: String,
+                     onBackPressed: () -> Unit
+) {
+    Row(
+        modifier = Modifier.clickable { onBackPressed() },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            modifier = Modifier.padding(start = 16.dp),
+            imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
+            contentDescription = "back",
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.utilitynetworks.ui
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -34,9 +33,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
-import androidx.compose.material.icons.automirrored.sharp.ArrowBack
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
@@ -56,7 +52,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
@@ -65,6 +60,7 @@ import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.StartingPoint
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.Title
+import com.arcgismaps.toolkit.utilitynetworks.internal.util.UpButton
 import com.arcgismaps.toolkit.utilitynetworks.ui.material3.Slider
 import com.arcgismaps.utilitynetworks.UtilityNetworkSourceType
 import com.arcgismaps.utilitynetworks.UtilityTerminal
@@ -75,19 +71,22 @@ import com.arcgismaps.utilitynetworks.UtilityTerminal
  * @since 200.6.0
  */
 @Composable
-internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
-                                        showResultsTab: Boolean,
-                                        onBackToResults: () -> Unit,
-                                        onZoomTo: () -> Unit,
-                                        onDelete: () -> Unit,
-                                        onFractionChanged: (StartingPoint, Float) -> Unit,
-                                        onTerminalSelected: (UtilityTerminal) -> Unit,
-                                        onBackPressed: () -> Unit) {
+internal fun StartingPointDetailsScreen(
+    startingPoint: StartingPoint,
+    showResultsTab: Boolean,
+    onBackToResults: () -> Unit,
+    onZoomTo: () -> Unit,
+    onDelete: () -> Unit,
+    onFractionChanged: (StartingPoint, Float) -> Unit,
+    onTerminalSelected: (UtilityTerminal) -> Unit,
+    onBackPressed: () -> Unit
+) {
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.Top) {
+            verticalArrangement = Arrangement.Top
+        ) {
 
             if (showResultsTab) {
                 TabRow(onBackToResults, 0)
@@ -98,7 +97,7 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
                 )
             }
 
-            BackButton(onBackPressed)
+            UpButton(stringResource(id = R.string.starting_points), onBackPressed)
 
             Spacer(
                 modifier = Modifier
@@ -114,8 +113,9 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
                     .height(10.dp)
             )
 
-            LazyColumn(modifier = Modifier
-                .padding(vertical = 3.dp),
+            LazyColumn(
+                modifier = Modifier
+                    .padding(vertical = 3.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 if (startingPoint.utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Edge) {
@@ -139,32 +139,10 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
 }
 
 @Composable
-private fun BackButton(
-    onBackPressed: () -> Unit
+private fun FractionAlongEdgeSlider(
+    startingPoint: StartingPoint,
+    onFractionChanged: (StartingPoint, Float) -> Unit
 ) {
-    Row(
-        modifier = Modifier.clickable { onBackPressed() },
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            modifier = Modifier.padding(start = 16.dp),
-            imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
-            contentDescription = "back",
-            tint = MaterialTheme.colorScheme.primary
-        )
-        Text(
-            text = stringResource(id = R.string.starting_points),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.primary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-    }
-}
-
-@Composable
-private fun FractionAlongEdgeSlider(startingPoint: StartingPoint, onFractionChanged: (StartingPoint, Float) -> Unit) {
     var sliderValue by remember { mutableFloatStateOf(startingPoint.utilityElement.fractionAlongEdge.toFloat()) }
     Column {
         Spacer(modifier = Modifier
@@ -172,7 +150,7 @@ private fun FractionAlongEdgeSlider(startingPoint: StartingPoint, onFractionChan
             .height(10.dp))
 
         Text(
-            modifier = Modifier.padding(start = 25.dp),
+            modifier = Modifier.padding(start = 24.dp),
             text = stringResource(id = R.string.fraction_along_edge),
             style = MaterialTheme.typography.titleMedium,
         )
@@ -205,7 +183,7 @@ private fun Attributes(startingPoint: StartingPoint) {
                 .height(10.dp)
         )
         Text(
-            modifier = Modifier.padding(start = 25.dp),
+            modifier = Modifier.padding(start = 24.dp),
             text = stringResource(id = R.string.attributes),
             style = MaterialTheme.typography.titleMedium,
         )
@@ -251,7 +229,10 @@ private fun Attributes(startingPoint: StartingPoint) {
 }
 
 @Composable
-private fun TerminalConfiguration(startingPoint: StartingPoint, onTerminalSelected: (UtilityTerminal) -> Unit) {
+private fun TerminalConfiguration(
+    startingPoint: StartingPoint,
+    onTerminalSelected: (UtilityTerminal) -> Unit
+) {
     var showDropdown by rememberSaveable {
         mutableStateOf(false)
     }
@@ -264,7 +245,12 @@ private fun TerminalConfiguration(startingPoint: StartingPoint, onTerminalSelect
         Spacer(modifier = Modifier
             .fillMaxWidth()
             .height(10.dp))
-        ReadOnlyTextField(stringResource(id = R.string.terminal_configuration), modifier = Modifier.padding(horizontal = 10.dp))
+
+        Text(
+            modifier = Modifier.padding(start = 24.dp),
+            text = stringResource(id = R.string.terminal_configuration),
+            style = MaterialTheme.typography.titleMedium,
+        )
         Column(
             modifier = Modifier
                 .padding(horizontal = 16.dp)

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.sharp.ArrowBack
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
@@ -89,7 +90,7 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Image(
-                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                    imageVector = Icons.AutoMirrored.Sharp.ArrowBack,
                     contentDescription = "back"
                 )
                 Text(
@@ -108,9 +109,14 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
 
             Title(startingPoint.name, onZoomTo, onDelete)
 
-            LazyColumn(
+            Spacer(
                 modifier = Modifier
-                    .padding(10.dp, 3.dp),
+                    .fillMaxWidth()
+                    .height(10.dp)
+            )
+
+            LazyColumn(modifier = Modifier
+                .padding(vertical = 3.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 if (startingPoint.utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Edge) {
@@ -140,10 +146,8 @@ private fun FractionAlongEdgeSlider(startingPoint: StartingPoint, onFractionChan
         Spacer(modifier = Modifier
             .fillMaxWidth()
             .height(10.dp))
-        Text(text = stringResource(id = R.string.fraction_along_edge),
-            color = Color.Gray,
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(start = 16.dp))
+
+        ReadOnlyTextField(stringResource(id = R.string.fraction_along_edge), modifier = Modifier.padding(horizontal = 10.dp))
         Box (modifier = Modifier
             .padding(horizontal = 16.dp)
             .background(color = MaterialTheme.colorScheme.background)) {
@@ -166,12 +170,7 @@ private fun Attributes(startingPoint: StartingPoint) {
                 .fillMaxWidth()
                 .height(10.dp)
         )
-        Text(
-            text = stringResource(id = R.string.attributes),
-            color = Color.Gray,
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(start = 16.dp)
-        )
+        ReadOnlyTextField(stringResource(id = R.string.attributes), modifier = Modifier.padding(horizontal = 10.dp))
         Column(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
@@ -183,27 +182,27 @@ private fun Attributes(startingPoint: StartingPoint) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 3.dp)
+                        .padding(vertical = 10.dp)
                         .background(color = MaterialTheme.colorScheme.background),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Text(
-                        modifier = Modifier.padding(start = 5.dp),
+                        modifier = Modifier.padding(start = 10.dp),
                         text = attribute.first,
-                        style = MaterialTheme.typography.bodyLarge,
+                        style = MaterialTheme.typography.titleMedium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
                     Text(
-                        modifier = Modifier.padding(end = 5.dp),
+                        modifier = Modifier.padding(end = 10.dp),
                         text = attribute.second as? String ?: "",
-                        style = MaterialTheme.typography.bodyLarge,
+                        style = MaterialTheme.typography.titleMedium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
                 }
                 if (index < attributes.size - 1) {
-                    HorizontalDivider(modifier = Modifier.padding(horizontal = 5.dp))
+                    HorizontalDivider(modifier = Modifier.padding(horizontal = 10.dp))
                 }
             }
         }
@@ -224,13 +223,10 @@ private fun TerminalConfiguration(startingPoint: StartingPoint, onTerminalSelect
         Spacer(modifier = Modifier
             .fillMaxWidth()
             .height(10.dp))
-        Text(text = stringResource(id = R.string.terminal_configuration),
-            color = Color.Gray,
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(start = 16.dp))
+        ReadOnlyTextField(stringResource(id = R.string.terminal_configuration), modifier = Modifier.padding(horizontal = 10.dp))
         Column(
             modifier = Modifier
-                .padding(horizontal = 4.dp)
+                .padding(horizontal = 16.dp)
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outline.copy(alpha = 0.6f),
@@ -241,7 +237,7 @@ private fun TerminalConfiguration(startingPoint: StartingPoint, onTerminalSelect
             Row (
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(4.dp)
+                    .padding(horizontal = 4.dp)
                     .clickable {
                         showDropdown = !showDropdown
                     },
@@ -265,7 +261,7 @@ private fun TerminalConfiguration(startingPoint: StartingPoint, onTerminalSelect
         MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = RoundedCornerShape(16.dp))) {
             DropdownMenu(
                 expanded = showDropdown,
-                offset = DpOffset.Zero,
+                offset = DpOffset(16.dp, 0.dp),
                 onDismissRequest = { showDropdown = false }) {
                 startingPoint.utilityElement.assetType.terminalConfiguration?.terminals?.forEach { utilityTerminal ->
                     DropdownMenuItem(

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
@@ -84,22 +84,8 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.Top) {
-            Row(
-                modifier = Modifier.clickable { onBackPressed() },
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Image(
-                    imageVector = Icons.AutoMirrored.Sharp.ArrowBack,
-                    contentDescription = "back"
-                )
-                Text(
-                    text = stringResource(id = R.string.starting_points),
-                    style = MaterialTheme.typography.titleMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+
+            BackButton(onBackPressed)
 
             Spacer(
                 modifier = Modifier
@@ -136,6 +122,30 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun BackButton(
+    onBackPressed: () -> Unit
+) {
+    Row(
+        modifier = Modifier.clickable { onBackPressed() },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            modifier = Modifier.padding(start = 12.dp),
+            imageVector = Icons.AutoMirrored.Sharp.ArrowBack,
+            contentDescription = "back"
+        )
+        Text(
+            modifier = Modifier.padding(start = 8.dp),
+            text = stringResource(id = R.string.starting_points),
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
@@ -17,32 +17,47 @@
 package com.arcgismaps.toolkit.utilitynetworks.ui
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import com.arcgismaps.geometry.Polyline
-import com.arcgismaps.toolkit.utilitynetworks.ui.material3.Slider
+import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.StartingPoint
+import com.arcgismaps.toolkit.utilitynetworks.internal.util.Title
+import com.arcgismaps.toolkit.utilitynetworks.ui.material3.Slider
+import com.arcgismaps.utilitynetworks.UtilityNetworkSourceType
 
 
 @Composable
-internal fun StartingPointDetailsScreen(startingPoint: StartingPoint?,
+internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
+                                        onZoomToResults: () -> Unit,
+                                        onClearAllResults: () -> Unit,
                                         onFractionChanged: (StartingPoint, Float) -> Unit,
                                         onBackPressed: () -> Unit) {
     Surface(modifier = Modifier.fillMaxSize()) {
@@ -62,27 +77,138 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint?,
             ReadOnlyTextField(
                 text = stringResource(id = R.string.starting_points))
             }
-        }
 
-        startingPoint?.let { point ->
-            val geometry = point.feature.geometry
+            Spacer(modifier = Modifier
+                .fillMaxWidth()
+                .height(10.dp))
 
-            if (geometry != null && geometry is Polyline ) {
-                FractionAlongEdgeSlider(point, onFractionChanged)
+            Title(startingPoint.name, onZoomToResults, onClearAllResults)
+
+            if (startingPoint.utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Edge) {
+                FractionAlongEdgeSlider(startingPoint, onFractionChanged)
+            } else if (startingPoint.utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Junction
+                && startingPoint.utilityElement.terminal != null
+                && !startingPoint.utilityElement.assetType.terminalConfiguration?.terminals.isNullOrEmpty()
+            ) {
+                TerminalConfiguration(startingPoint)
             }
+            Spacer(modifier = Modifier
+                .fillMaxWidth()
+                .height(10.dp))
+            Attributes(startingPoint)
         }
-
     }
 }
 
 @Composable
 private fun FractionAlongEdgeSlider(startingPoint: StartingPoint, onFractionChanged: (StartingPoint, Float) -> Unit) {
     var sliderValue by remember { mutableFloatStateOf(startingPoint.utilityElement.fractionAlongEdge.toFloat()) }
-    Slider(
-        value = sliderValue,
-        onValueChange = { newValue ->
-            sliderValue = newValue
-            onFractionChanged(startingPoint, newValue)
+    Column {
+        Spacer(modifier = Modifier
+            .fillMaxWidth()
+            .height(10.dp))
+        Text(text = stringResource(id = R.string.fraction_along_edge),
+            color = Color.Gray,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 16.dp))
+        Box (modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .background(color = MaterialTheme.colorScheme.background)) {
+            Slider(
+                value = sliderValue,
+                onValueChange = { newValue ->
+                    sliderValue = newValue
+                    onFractionChanged(startingPoint, newValue)
+                }
+            )
         }
-    )
+    }
+}
+
+@Composable
+private fun Attributes(startingPoint: StartingPoint) {
+    Column {
+        Text(text = stringResource(id = R.string.attributes),
+            color = Color.Gray,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 16.dp))
+        Box(modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth()
+            .background(color = MaterialTheme.colorScheme.background)) {
+            LazyColumn(
+                modifier = Modifier
+                    .padding(10.dp, 3.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                startingPoint.feature.attributes.toSortedMap().forEach() { attribute ->
+                    item {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 3.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = attribute.key,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Text(
+                                text = attribute.value as? String ?: "",
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TerminalConfiguration(startingPoint: StartingPoint) {
+    var showDropdown by rememberSaveable {
+        mutableStateOf(false)
+    }
+    Column {
+        Spacer(modifier = Modifier
+            .fillMaxWidth()
+            .height(10.dp))
+        Text(text = stringResource(id = R.string.terminal_configuration),
+            color = Color.Gray,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 16.dp))
+//        MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = RoundedCornerShape(16.dp))) {
+//            DropdownMenu(
+//                expanded = showDropdown,
+//                offset = DpOffset.Zero,
+//                onDismissRequest = { showDropdown = false }) {
+//                startingPoint.utilityElement.assetType.terminalConfiguration?.terminals?.forEachIndexed { index, utilityTerminal ->
+//                    DropdownMenuItem(
+//                        text = {
+//                            ReadOnlyTextField(
+//                                text = utilityTerminal.name, leadingIcon = if (utilityTerminal.name == selectedConfigName) {
+//                                    {
+//                                        Icon(
+//                                            imageVector = Icons.Filled.Done,
+//                                            contentDescription = "Done icon",
+//                                            modifier = Modifier.size(FilterChipDefaults.IconSize)
+//                                        )
+//                                    }
+//                                } else {
+//                                    null
+//                                }
+//                            )
+//                        },
+//                        onClick = {
+//                            onTraceSelected(index)
+//                            showDropdown = false
+//                        },
+//                        contentPadding = PaddingValues(vertical = 0.dp, horizontal = 10.dp)
+//                    )
+//                }
+//            }
+//        }
+    }
 }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
@@ -83,9 +83,11 @@ internal fun StartingPointDetailsScreen(
 ) {
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp),
             horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.Top
+            verticalArrangement = Arrangement.Top,
         ) {
 
             if (showResultsTab) {
@@ -93,7 +95,7 @@ internal fun StartingPointDetailsScreen(
                 Spacer(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(20.dp)
+                        .height(25.dp)
                 )
             }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
 import androidx.compose.material.icons.automirrored.sharp.ArrowBack
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.MoreVert
@@ -62,6 +63,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.StartingPoint
+import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.Title
 import com.arcgismaps.toolkit.utilitynetworks.ui.material3.Slider
 import com.arcgismaps.utilitynetworks.UtilityNetworkSourceType
@@ -74,6 +76,8 @@ import com.arcgismaps.utilitynetworks.UtilityTerminal
  */
 @Composable
 internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
+                                        showResultsTab: Boolean,
+                                        onBackToResults: () -> Unit,
                                         onZoomTo: () -> Unit,
                                         onDelete: () -> Unit,
                                         onFractionChanged: (StartingPoint, Float) -> Unit,
@@ -84,6 +88,15 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.Top) {
+
+            if (showResultsTab) {
+                TabRow(onBackToResults, 0)
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(20.dp)
+                )
+            }
 
             BackButton(onBackPressed)
 
@@ -134,15 +147,16 @@ private fun BackButton(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Image(
-            modifier = Modifier.padding(start = 12.dp),
-            imageVector = Icons.AutoMirrored.Sharp.ArrowBack,
-            contentDescription = "back"
+        Icon(
+            modifier = Modifier.padding(start = 16.dp),
+            imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
+            contentDescription = "back",
+            tint = MaterialTheme.colorScheme.primary
         )
         Text(
-            modifier = Modifier.padding(start = 8.dp),
             text = stringResource(id = R.string.starting_points),
             style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
@@ -157,11 +171,21 @@ private fun FractionAlongEdgeSlider(startingPoint: StartingPoint, onFractionChan
             .fillMaxWidth()
             .height(10.dp))
 
-        ReadOnlyTextField(stringResource(id = R.string.fraction_along_edge), modifier = Modifier.padding(horizontal = 10.dp))
-        Box (modifier = Modifier
-            .padding(horizontal = 16.dp)
-            .background(color = MaterialTheme.colorScheme.background)) {
+        Text(
+            modifier = Modifier.padding(start = 25.dp),
+            text = stringResource(id = R.string.fraction_along_edge),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Box(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    shape = RoundedCornerShape(15.dp)
+                )
+        ) {
             Slider(
+                modifier = Modifier.padding(start = 10.dp, end = 10.dp),
                 value = sliderValue,
                 onValueChange = { newValue ->
                     sliderValue = newValue
@@ -180,12 +204,19 @@ private fun Attributes(startingPoint: StartingPoint) {
                 .fillMaxWidth()
                 .height(10.dp)
         )
-        ReadOnlyTextField(stringResource(id = R.string.attributes), modifier = Modifier.padding(horizontal = 10.dp))
+        Text(
+            modifier = Modifier.padding(start = 25.dp),
+            text = stringResource(id = R.string.attributes),
+            style = MaterialTheme.typography.titleMedium,
+        )
         Column(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .fillMaxWidth()
-                .background(color = MaterialTheme.colorScheme.background)
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    shape = RoundedCornerShape(15.dp)
+                )
         ) {
             val attributes = startingPoint.feature.attributes.toSortedMap().toList()
             attributes.forEachIndexed { index, attribute ->
@@ -193,7 +224,7 @@ private fun Attributes(startingPoint: StartingPoint) {
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = 10.dp)
-                        .background(color = MaterialTheme.colorScheme.background),
+                        .background(color = MaterialTheme.colorScheme.surfaceContainerHigh),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Text(

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
@@ -29,8 +29,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -46,6 +49,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.StartingPoint
@@ -53,7 +58,11 @@ import com.arcgismaps.toolkit.utilitynetworks.internal.util.Title
 import com.arcgismaps.toolkit.utilitynetworks.ui.material3.Slider
 import com.arcgismaps.utilitynetworks.UtilityNetworkSourceType
 
-
+/**
+ * A composable screen that shows the details of a starting point for a trace.
+ *
+ * @since 200.6.0
+ */
 @Composable
 internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
                                         onZoomToResults: () -> Unit,
@@ -70,32 +79,47 @@ internal fun StartingPointDetailsScreen(startingPoint: StartingPoint,
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-            Image(
-                imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                contentDescription = "back"
-            )
-            ReadOnlyTextField(
-                text = stringResource(id = R.string.starting_points))
+                Image(
+                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                    contentDescription = "back"
+                )
+                Text(
+                    text = stringResource(id = R.string.starting_points),
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
 
-            Spacer(modifier = Modifier
-                .fillMaxWidth()
-                .height(10.dp))
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(10.dp)
+            )
 
             Title(startingPoint.name, onZoomToResults, onClearAllResults)
 
-            if (startingPoint.utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Edge) {
-                FractionAlongEdgeSlider(startingPoint, onFractionChanged)
-            } else if (startingPoint.utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Junction
-                && startingPoint.utilityElement.terminal != null
-                && !startingPoint.utilityElement.assetType.terminalConfiguration?.terminals.isNullOrEmpty()
+            LazyColumn(
+                modifier = Modifier
+                    .padding(10.dp, 3.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                TerminalConfiguration(startingPoint)
+                if (startingPoint.utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Edge) {
+                    item {
+                        FractionAlongEdgeSlider(startingPoint, onFractionChanged)
+                    }
+                } else if (startingPoint.utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Junction
+                    && startingPoint.utilityElement.terminal != null
+                    && !startingPoint.utilityElement.assetType.terminalConfiguration?.terminals.isNullOrEmpty()
+                ) {
+                    item {
+                        TerminalConfiguration(startingPoint)
+                    }
+                }
+                item {
+                    Attributes(startingPoint)
+                }
             }
-            Spacer(modifier = Modifier
-                .fillMaxWidth()
-                .height(10.dp))
-            Attributes(startingPoint)
         }
     }
 }
@@ -128,38 +152,49 @@ private fun FractionAlongEdgeSlider(startingPoint: StartingPoint, onFractionChan
 @Composable
 private fun Attributes(startingPoint: StartingPoint) {
     Column {
-        Text(text = stringResource(id = R.string.attributes),
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(10.dp)
+        )
+        Text(
+            text = stringResource(id = R.string.attributes),
             color = Color.Gray,
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(start = 16.dp))
-        Box(modifier = Modifier
-            .padding(horizontal = 16.dp)
-            .fillMaxWidth()
-            .background(color = MaterialTheme.colorScheme.background)) {
-            LazyColumn(
-                modifier = Modifier
-                    .padding(10.dp, 3.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                startingPoint.feature.attributes.toSortedMap().forEach() { attribute ->
-                    item {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 3.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Text(
-                                text = attribute.key,
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                            Text(
-                                text = attribute.value as? String ?: "",
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                        }
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                    }
+            modifier = Modifier.padding(start = 16.dp)
+        )
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .fillMaxWidth()
+                .background(color = MaterialTheme.colorScheme.background)
+        ) {
+            val attributes = startingPoint.feature.attributes.toSortedMap().toList()
+            attributes.forEachIndexed { index, attribute ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 3.dp)
+                        .background(color = MaterialTheme.colorScheme.background),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        modifier = Modifier.padding(start = 5.dp),
+                        text = attribute.first,
+                        style = MaterialTheme.typography.bodyLarge,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        modifier = Modifier.padding(end = 5.dp),
+                        text = attribute.second as? String ?: "",
+                        style = MaterialTheme.typography.bodyLarge,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                if (index < attributes.size - 1) {
+                    HorizontalDivider(modifier = Modifier.padding(horizontal = 5.dp))
                 }
             }
         }
@@ -179,36 +214,36 @@ private fun TerminalConfiguration(startingPoint: StartingPoint) {
             color = Color.Gray,
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(start = 16.dp))
-//        MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = RoundedCornerShape(16.dp))) {
-//            DropdownMenu(
-//                expanded = showDropdown,
-//                offset = DpOffset.Zero,
-//                onDismissRequest = { showDropdown = false }) {
-//                startingPoint.utilityElement.assetType.terminalConfiguration?.terminals?.forEachIndexed { index, utilityTerminal ->
-//                    DropdownMenuItem(
-//                        text = {
-//                            ReadOnlyTextField(
-//                                text = utilityTerminal.name, leadingIcon = if (utilityTerminal.name == selectedConfigName) {
-//                                    {
-//                                        Icon(
-//                                            imageVector = Icons.Filled.Done,
-//                                            contentDescription = "Done icon",
-//                                            modifier = Modifier.size(FilterChipDefaults.IconSize)
-//                                        )
-//                                    }
-//                                } else {
-//                                    null
-//                                }
-//                            )
-//                        },
-//                        onClick = {
-//                            onTraceSelected(index)
-//                            showDropdown = false
-//                        },
-//                        contentPadding = PaddingValues(vertical = 0.dp, horizontal = 10.dp)
-//                    )
-//                }
-//            }
-//        }
+        MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = RoundedCornerShape(16.dp))) {
+            DropdownMenu(
+                expanded = showDropdown,
+                offset = DpOffset.Zero,
+                onDismissRequest = { showDropdown = false }) {
+                startingPoint.utilityElement.assetType.terminalConfiguration?.terminals?.forEachIndexed { index, utilityTerminal ->
+                    DropdownMenuItem(
+                        text = {
+                            ReadOnlyTextField(
+                                text = utilityTerminal.name, leadingIcon = if (utilityTerminal.name == selectedConfigName) {
+                                    {
+                                        Icon(
+                                            imageVector = Icons.Filled.Done,
+                                            contentDescription = "Done icon",
+                                            modifier = Modifier.size(FilterChipDefaults.IconSize)
+                                        )
+                                    }
+                                } else {
+                                    null
+                                }
+                            )
+                        },
+                        onClick = {
+                            onTraceSelected(index)
+                            showDropdown = false
+                        },
+                        contentPadding = PaddingValues(vertical = 0.dp, horizontal = 10.dp)
+                    )
+                }
+            }
+        }
     }
 }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -123,6 +123,8 @@ internal fun TraceNavHost(traceState: TraceState) {
             require(startingPoint != null)
             StartingPointDetailsScreen(
                 startingPoint,
+                showResultsTab = traceState.completedTraces.isNotEmpty(),
+                onBackToResults = { traceState.showScreen(TraceNavRoute.TraceResults) },
                 onZoomTo = {
                     coroutineScope.launch {
                         traceState.zoomToStartingPoint(startingPoint)

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -111,6 +111,11 @@ internal fun TraceNavHost(traceState: TraceState) {
             require(startingPoint != null)
             StartingPointDetailsScreen(
                 startingPoint,
+                onZoomToResults = {
+
+                }, onClearAllResults = {
+
+                },
                 onFractionChanged = { point, newValue ->
                     traceState.setFractionAlongEdge(
                         point,

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -107,19 +107,29 @@ internal fun TraceNavHost(traceState: TraceState) {
             )
         }
         composable(TraceNavRoute.StartingPointDetails.name) {
+            val coroutineScope = rememberCoroutineScope()
             val startingPoint = traceState.selectedStartingPoint.value
             require(startingPoint != null)
             StartingPointDetailsScreen(
                 startingPoint,
-                onZoomToResults = {
-
-                }, onClearAllResults = {
-
+                onZoomTo = {
+                    coroutineScope.launch {
+                        traceState.zoomToStartingPoint(startingPoint)
+                    }
+                }, onDelete = {
+                    traceState.removeStartingPoint(startingPoint)
+                    traceState.showScreen(TraceNavRoute.TraceOptions)
                 },
                 onFractionChanged = { point, newValue ->
                     traceState.setFractionAlongEdge(
                         point,
                         newValue.toDouble()
+                    )
+                },
+                onTerminalSelected = { utilityTerminal ->
+                    traceState.setTerminal(
+                        startingPoint,
+                        utilityTerminal
                     )
                 },
                 onBackPressed = { traceState.showScreen(TraceNavRoute.TraceOptions) })

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.ui.expandablecard.ExpandableCard
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.TraceRun
+import com.arcgismaps.toolkit.utilitynetworks.internal.util.Title
 import com.arcgismaps.utilitynetworks.UtilityElement
 import com.arcgismaps.utilitynetworks.UtilityTraceFunctionOutput
 
@@ -71,7 +72,7 @@ internal fun TraceResultScreen(
     Surface(modifier = Modifier.fillMaxSize()) {
         LazyColumn {
             item {
-                TraceTitle(traceRun.name, onZoomToResults = onZoomToResults, onDeleteResult = onDeleteResult)
+                Title(traceRun.name, onZoomToResults = onZoomToResults, onDeleteResult = onDeleteResult)
             }
             item {
                 FeatureResult(traceRun.featureResults)
@@ -81,52 +82,6 @@ internal fun TraceResultScreen(
             }
             item {
                 ClearAllResultsButton(onClearAllResults)
-            }
-        }
-    }
-}
-
-@Composable
-private fun TraceTitle(traceName: String, onZoomToResults: () -> Unit, onDeleteResult: () -> Unit) {
-    var expanded by remember { mutableStateOf(false) }
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 16.dp),
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Box {
-            Row(modifier = Modifier.clickable {
-                expanded = !expanded
-            }, verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    modifier = Modifier.padding(end = 8.dp),
-                    text = traceName,
-                    style = MaterialTheme.typography.headlineMedium
-                )
-                Icon(
-                    imageVector = Icons.Outlined.MoreVert,
-                    contentDescription = ""
-                )
-            }
-            MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = RoundedCornerShape(16.dp))) {
-                DropdownMenu(
-                    modifier = Modifier.padding(start = 8.dp, end = 16.dp),
-                    expanded = expanded,
-                    onDismissRequest = {
-                        expanded = false
-                    }) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.zoom_to_result)) },
-                        onClick = onZoomToResults,
-                        leadingIcon = { Icon(Icons.Outlined.LocationOn, contentDescription = stringResource(R.string.zoom_to_trace_result)) }
-                    )
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.delete)) },
-                        onClick = onDeleteResult,
-                        leadingIcon = { Icon(Icons.Outlined.Clear, contentDescription = stringResource(R.string.delete_trace_result)) }
-                    )
-                }
             }
         }
     }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -26,13 +26,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
 import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
-import androidx.compose.material.icons.outlined.Clear
-import androidx.compose.material.icons.outlined.LocationOn
-import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -48,8 +44,8 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.ui.expandablecard.ExpandableCard
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.TraceRun
-import com.arcgismaps.toolkit.utilitynetworks.internal.util.Title
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
+import com.arcgismaps.toolkit.utilitynetworks.internal.util.Title
 import com.arcgismaps.utilitynetworks.UtilityElement
 import com.arcgismaps.utilitynetworks.UtilityTraceFunctionOutput
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -17,9 +17,7 @@
 package com.arcgismaps.toolkit.utilitynetworks.ui
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -27,24 +25,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Clear
-import androidx.compose.material.icons.outlined.LocationOn
-import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -72,7 +58,7 @@ internal fun TraceResultScreen(
     Surface(modifier = Modifier.fillMaxSize()) {
         LazyColumn {
             item {
-                Title(traceRun.name, onZoomToResults = onZoomToResults, onDeleteResult = onDeleteResult)
+                Title(traceRun.name, onZoomTo = onZoomToResults, onDelete = onDeleteResult)
             }
             item {
                 FeatureResult(traceRun.featureResults)

--- a/toolkit/utilitynetworks/src/main/res/values/strings.xml
+++ b/toolkit/utilitynetworks/src/main/res/values/strings.xml
@@ -34,4 +34,7 @@
     <string name="not_available">Not available</string>
     <string name="zoom_to_trace_result">Zoom to trace result</string>
     <string name="delete_trace_result">Delete trace result</string>
+    <string name="fraction_along_edge">Fraction Along Edge</string>
+    <string name="attributes">Attributes</string>
+    <string name="terminal_configuration">Terminal Configuration</string>
 </resources>

--- a/toolkit/utilitynetworks/src/main/res/values/strings.xml
+++ b/toolkit/utilitynetworks/src/main/res/values/strings.xml
@@ -32,8 +32,7 @@
     <string name="clear_all_results">Clear all results</string>
     <string name="delete">Delete</string>
     <string name="not_available">Not available</string>
-    <string name="zoom_to_trace_result">Zoom to trace result</string>
-    <string name="delete_trace_result">Delete trace result</string>
+    <string name="zoom_to">Zoom to</string>
     <string name="fraction_along_edge">Fraction Along Edge</string>
     <string name="attributes">Attributes</string>
     <string name="terminal_configuration">Terminal Configuration</string>

--- a/toolkit/utilitynetworks/src/main/res/values/strings.xml
+++ b/toolkit/utilitynetworks/src/main/res/values/strings.xml
@@ -46,5 +46,4 @@
     <string name="could_not_create_utility_element_from_arcgisfeature">Could not create utility element from ArcGISFeature.</string>
     <string name="one_or_more_starting_points_already_exists">One or more starting points already exist.</string>
     <string name="could_not_create_drawable_from_feature_symbol">Could not create drawable from feature symbol.</string>
->>>>>>> feature-branches/utilitynetworktrace
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4677

<!-- link to design, if applicable -->

### Description:

Adds implementation to StartingPointDetails screen

### Summary of changes:

- Move the Title from Results screen so that it could be shared between the StartingPointDetails screen and the ResultsScreen
- Add functionality to zoom to a startingpoint and link the option to remove it to the existing implementation
- add dropdown menu so user can select the terminal type for a starting point, if it supported by it

https://github.com/user-attachments/assets/bfb88938-68f4-4b49-b9a8-15e407791db0

- add Column to show all the attributes and attribute values

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/132/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  