### PR TITLE
`Forms` : Reinstate UI tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4379
+sdkBuildNumber=4389

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FeatureFormTestRunner.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FeatureFormTestRunner.kt
@@ -64,9 +64,6 @@ open class FeatureFormTestRunner(
         val featureLayer = map.operationalLayers.first() as? FeatureLayer
         assertThat(featureLayer).isNotNull()
         featureLayer!!.assertIsLoaded()
-        // Get the feature form definition
-        val featureFormDefinition = featureLayer.featureFormDefinition
-        assertThat(featureFormDefinition).isNotNull()
         // Query the feature
         val parameters = QueryParameters().also {
             it.objectIds.add(objectId)
@@ -80,7 +77,7 @@ open class FeatureFormTestRunner(
         assertThat(feature).isNotNull()
         feature!!.assertIsLoaded()
         // Initialize the feature form
-        featureForm = FeatureForm(feature, featureFormDefinition!!)
+        featureForm = FeatureForm(feature)
         featureForm.evaluateExpressions()
     }
 }

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldNumericTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldNumericTests.kt
@@ -34,7 +34,7 @@ import org.junit.Test
  * Tests for FormTextFields whose backing FormFeatureElement is associated with a numeric field and attribute type.
  */
 class FormTextFieldNumericTests : FeatureFormTestRunner(
-    uri = "https://www.arcgis.com/home/item.html?id=355f37b49dca42c38ed1e156c1a23d26",
+    uri = "https://www.arcgis.com/home/item.html?id=ba55368fb465488b82076aec4077ec70",
     objectId = 1
 ) {
     private val supportingTextSemanticLabel = "supporting text"

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldRangeNumericTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldRangeNumericTests.kt
@@ -34,7 +34,7 @@ import org.junit.Test
  * Tests for FormTextFields whose backing FormFeatureElement is associated with a numeric field and attribute type.
  */
 class FormTextFieldRangeNumericTests : FeatureFormTestRunner(
-    uri = "https://www.arcgis.com/home/item.html?id=225ffaf1091d48fcbe31be0146808b2b",
+    uri = "https://www.arcgis.com/home/item.html?id=c6a4789e5dd64bc48941d8478c5940d2",
     objectId = 1
 ) {
     private val supportingTextSemanticLabel = "supporting text"

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/ThemingTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/ThemingTests.kt
@@ -37,7 +37,7 @@ import org.junit.Rule
 import org.junit.Test
 
 class ThemingTests : FeatureFormTestRunner(
-    uri = "https://www.arcgis.com/home/item.html?id=615e8fe546ef4d139fb9298515c2f40a",
+    uri = "https://www.arcgis.com/home/item.html?id=9c7ee7cd979c434896684bf507cca75d",
     objectId = 1
 ) {
     @get:Rule


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/912](https://devtopia.esri.com/runtime/apollo/issues/912)

<!-- link to design, if applicable -->

### Description:

Updates some of the test maps that have been moved to a new account. The remaining maps although have a new owner retain their original URL.

Credentials for the tests have been updated in the vtest environment.

### Summary of changes:

- Updated usage of `FeatureForm` in the `FeatureFormTestRunner`.
- Updated webmap urls for certain tests.
- Bump SDK version.

Note that one of the tests is failing in the vtest below. It seems to be a bug and an open issue for it is [here](https://devtopia.esri.com/runtime/apollo/issues/918). Due to the bug, a read-only field shows up as editable.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/138/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  