### PR TITLE
`Forms`: Barcode enhancements

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
@@ -166,8 +166,8 @@ internal abstract class BaseFieldState<T>(
         // infer that a value change event comes from a user interaction and hence treat it as a
         // focus event
         wasFocused = true
-        // set the ui state immediately
-        _value.value = Value(input)
+        // set the ui state immediately with the current error if any
+        _value.value = Value(input, _value.value.error)
         // update the attributes
         updateValue(typeConverter(input))
         // evaluate expressions

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -339,7 +339,6 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
             BarcodeScanner(
                 onScan = {
                     state.onValueChanged(it)
-                    state.onFocusChanged(true)
                     dialogRequester.dismissDialog()
                 },
                 onDismiss = {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/914](https://devtopia.esri.com/runtime/apollo/issues/914), [apollo/915](https://devtopia.esri.com/runtime/apollo/issues/915)

<!-- link to design, if applicable -->

### Description:

Adds more barcode scanner enhancements.

### Summary of changes:

- Added tap to focus on the barcode scanner frame.
    - Since the `BarcodeFrame` canvas sits on top of the `PreviewView`, it blocks all pointer events if the `pointerInput` modifier is added. Hence, the `BarcodeFrame` provides a lambda instead with the tap point which can be used to request focus action.
- Fixed a bug in `BaseFieldState`, where if the field value has a validation error and the same value is set again, the error is discarded.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/142/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  