### PR TITLE
UN Trace Tool: Fix exceptions thrown when processing selected points

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -448,7 +448,7 @@ public class TraceState(
         val featureGeometry = feature.geometry
         if (utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Edge && featureGeometry is Polyline) {
             utilityElement.fractionAlongEdge =
-                fractionAlongEdge(featureGeometry, mapPoint).takeIf { !it.isNaN() } ?: return@runCatchingCancellable
+                fractionAlongEdge(featureGeometry, mapPoint).takeIf { !it.isNaN() } ?: 0.5
         } else if (utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Junction &&
             (utilityElement.assetType.terminalConfiguration?.terminals?.size ?: 0) > 1
         ) {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -437,17 +437,14 @@ public class TraceState(
         val utilityElement = utilityNetwork.createElementOrNull(feature)
             ?: return@runCatchingCancellable
 
-        // Check if the starting point already exists
-        if (_currentTraceStartingPoints.any { it.utilityElement.globalId == utilityElement.globalId }) {
-            throw TraceToolException(TraceError.STARTING_POINT_ALREADY_EXISTS)
-        }
-
         val symbol = (feature.featureTable?.layer as FeatureLayer).renderer?.getSymbol(feature)
             ?: throw TraceToolException(TraceError.COULD_NOT_CREATE_DRAWABLE)
 
         val featureGeometry = feature.geometry
         if (utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Edge && featureGeometry is Polyline) {
-            utilityElement.fractionAlongEdge = fractionAlongEdge(featureGeometry, mapPoint)
+            fractionAlongEdge(featureGeometry, mapPoint).takeIf { !it.isNaN() }?.let {
+                utilityElement.fractionAlongEdge = it
+            }
         } else if (utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Junction &&
             (utilityElement.assetType.terminalConfiguration?.terminals?.size ?: 0) > 1
         ) {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -437,14 +437,18 @@ public class TraceState(
         val utilityElement = utilityNetwork.createElementOrNull(feature)
             ?: return@runCatchingCancellable
 
+        // Check if the starting point already exists
+        if (_currentTraceStartingPoints.any { it.utilityElement.globalId == utilityElement.globalId }) {
+            return@runCatchingCancellable
+        }
+
         val symbol = (feature.featureTable?.layer as FeatureLayer).renderer?.getSymbol(feature)
             ?: throw TraceToolException(TraceError.COULD_NOT_CREATE_DRAWABLE)
 
         val featureGeometry = feature.geometry
         if (utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Edge && featureGeometry is Polyline) {
-            fractionAlongEdge(featureGeometry, mapPoint).takeIf { !it.isNaN() }?.let {
-                utilityElement.fractionAlongEdge = it
-            }
+            utilityElement.fractionAlongEdge =
+                fractionAlongEdge(featureGeometry, mapPoint).takeIf { !it.isNaN() } ?: return@runCatchingCancellable
         } else if (utilityElement.networkSource.sourceType == UtilityNetworkSourceType.Junction &&
             (utilityElement.assetType.terminalConfiguration?.terminals?.size ?: 0) > 1
         ) {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #4754

<!-- link to design, if applicable -->

### Summary of changes:
- While processing the selected points, we don't want to show a warning when: 
   - User has already selected a Point
   - User selects a polyline where the `fractionAlong` calculation returns a `NaN`. 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/144/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  