### PR TITLE
Make properties internal that don't need to be public

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -146,10 +146,10 @@ public class TraceState(
      *
      * @since 200.6.0
      */
-    public val currentTraceName: State<String> = _currentTraceName
+    internal val currentTraceName: State<String> = _currentTraceName
 
     private var currentTraceGraphicsColor: Color = Color.green
-    public val currentTraceGraphicsColorAsComposeColor: androidx.compose.ui.graphics.Color
+    internal val currentTraceGraphicsColorAsComposeColor: androidx.compose.ui.graphics.Color
         get() = androidx.compose.ui.graphics.Color(
             currentTraceGraphicsColor.red,
             currentTraceGraphicsColor.green,
@@ -158,7 +158,7 @@ public class TraceState(
         )
 
     private var _currentTraceZoomToResults: MutableState<Boolean> = mutableStateOf(true)
-    public var currentTraceZoomToResults: State<Boolean> = _currentTraceZoomToResults
+    internal var currentTraceZoomToResults: State<Boolean> = _currentTraceZoomToResults
 
     private val currentTraceResultGeometriesExtent: Envelope?
         get() {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4709

<!-- link to design, if applicable -->

### Description:



### Summary of changes:

- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/145/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  