### PR TITLE
Compass micro app improvement

### DIFF
--- a/microapps/CompassApp/app/src/main/java/com/arcgismaps/toolkit/compassapp/screens/MainScreen.kt
+++ b/microapps/CompassApp/app/src/main/java/com/arcgismaps/toolkit/compassapp/screens/MainScreen.kt
@@ -73,12 +73,15 @@ fun MainScreen(modifier: Modifier) {
         ) {
             val coroutineScope = rememberCoroutineScope()
             // show the compass and pass the mapRotation state data
-            Compass(rotation = mapRotation) {
-                // reset the Composable MapView viewpoint rotation to point north
-                coroutineScope.launch {
-                    mapViewProxy.setViewpointRotation(0.0)
+            Compass(
+                rotation = mapRotation,
+                onClick = {
+                    // reset the Composable MapView viewpoint rotation to point north
+                    coroutineScope.launch {
+                        mapViewProxy.setViewpointRotation(0.0)
+                    }
                 }
-            }
+            )
         }
     }
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

<!-- link to design, if applicable -->

### Description:

Currently the Compass `onClick` event is handled as a trailing lambda in the Compass micro app. It has been pointed out that this makes the code harder to read, since one could assume that this is a "content lambda" instead of a lambda that handles the click event. Ideally, the `onClick` parameter in the `Compass()` function would not be the last parameter, so it cannot be used with trailing lambda, but changing that would break the API. This change makes the micro app code more readable by using a named parameter for the `onClick` lambda.


### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/148/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  