### PR TITLE
Adds ExpandableCard State and uses it in TraceOptions

### DIFF
--- a/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCard.kt
+++ b/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCard.kt
@@ -37,11 +37,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -225,39 +220,5 @@ private fun ExpandableCardPreview() {
             style = MaterialTheme.typography.headlineLarge,
             modifier = Modifier.padding(16.dp)
         )
-    }
-}
-
-/**
- * State object that can be hoisted to control the [ExpandableCard].
- *
- * In most cases, this will be created using [rememberExpandableCardState].
- * @since 200.6.0
- */
-class ExpandableCardState constructor(initialExpandedSttate: Boolean) {
-    /**
-     * The expanded state of the [ExpandableCard].
-     * @since 200.6.0
-     */
-    var isExpanded by mutableStateOf(initialExpandedSttate)
-}
-
-/**
- * Remember the state of [ExpandableCard].
- *
- * @param isExpanded the initial expanded state
- * @since 200.6.0
- */
-@Composable
-fun rememberExpandableCardState(
-    isExpanded: Boolean = true
-): ExpandableCardState {
-    return rememberSaveable(
-        saver = Saver(
-            save = { it.isExpanded},
-            restore = { ExpandableCardState(it) }
-        )
-    ) {
-        ExpandableCardState(isExpanded)
     }
 }

--- a/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCard.kt
+++ b/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCard.kt
@@ -97,7 +97,7 @@ fun ExpandableCard(
                     isExpanded = expandableCardState.isExpanded,
                 ) {
                     if (toggleable) {
-                        expandableCardState.isExpanded = !expandableCardState.isExpanded
+                        expandableCardState.toggle()
                     }
                 }
 

--- a/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCard.kt
+++ b/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCard.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -68,15 +69,13 @@ fun ExpandableCard(
     title: String = "",
     description: (@Composable () -> Unit)? = null,
     toggleable: Boolean = true,
-    initialExpandedState: Boolean = true,
+    expandableCardState: ExpandableCardState = rememberExpandableCardState(),
     padding: PaddingValues = PaddingValues(16.dp),
     colorScheme: ExpandableCardColorScheme = ExpandableCardDefaults.colorScheme(),
     shapes: ExpandableCardShapes = ExpandableCardDefaults.shapes(),
     typography: ExpandableCardTypography = ExpandableCardDefaults.typography(),
     content: @Composable () -> Unit = {}
 ) {
-    var expanded by rememberSaveable { mutableStateOf(initialExpandedState) }
-
     ExpandableCardTheme(
         colorScheme = colorScheme,
         shapes = shapes,
@@ -100,14 +99,14 @@ fun ExpandableCard(
                     colors = colorScheme,
                     shapes = shapes,
                     typography = typography,
-                    isExpanded = expanded
+                    isExpanded = expandableCardState.isExpanded,
                 ) {
                     if (toggleable) {
-                        expanded = !expanded
+                        expandableCardState.isExpanded = !expandableCardState.isExpanded
                     }
                 }
 
-                AnimatedVisibility(visible = expanded) {
+                AnimatedVisibility(visible = expandableCardState.isExpanded) {
                     content()
                 }
 
@@ -226,5 +225,39 @@ private fun ExpandableCardPreview() {
             style = MaterialTheme.typography.headlineLarge,
             modifier = Modifier.padding(16.dp)
         )
+    }
+}
+
+/**
+ * State object that can be hoisted to control the [ExpandableCard].
+ *
+ * In most cases, this will be created using [rememberExpandableCardState].
+ * @since 200.6.0
+ */
+class ExpandableCardState constructor(initialExpandedSttate: Boolean) {
+    /**
+     * The expanded state of the [ExpandableCard].
+     * @since 200.6.0
+     */
+    var isExpanded by mutableStateOf(initialExpandedSttate)
+}
+
+/**
+ * Remember the state of [ExpandableCard].
+ *
+ * @param isExpanded the initial expanded state
+ * @since 200.6.0
+ */
+@Composable
+fun rememberExpandableCardState(
+    isExpanded: Boolean = true
+): ExpandableCardState {
+    return rememberSaveable(
+        saver = Saver(
+            save = { it.isExpanded},
+            restore = { ExpandableCardState(it) }
+        )
+    ) {
+        ExpandableCardState(isExpanded)
     }
 }

--- a/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCardState.kt
+++ b/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCardState.kt
@@ -29,7 +29,7 @@ import androidx.compose.runtime.setValue
  * In most cases, this will be created using [rememberExpandableCardState].
  * @since 200.6.0
  */
-class ExpandableCardState constructor(initialExpandedState: Boolean) {
+class ExpandableCardState internal constructor(initialExpandedState: Boolean) {
     /**
      * The expanded state of the [ExpandableCard].
      * @since 200.6.0

--- a/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCardState.kt
+++ b/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCardState.kt
@@ -29,12 +29,22 @@ import androidx.compose.runtime.setValue
  * In most cases, this will be created using [rememberExpandableCardState].
  * @since 200.6.0
  */
-class ExpandableCardState constructor(initialExpandedSttate: Boolean) {
+class ExpandableCardState constructor(initialExpandedState: Boolean) {
     /**
      * The expanded state of the [ExpandableCard].
      * @since 200.6.0
      */
-    var isExpanded by mutableStateOf(initialExpandedSttate)
+    internal var isExpanded by mutableStateOf(initialExpandedState)
+        private set
+    
+    /**
+     * Toggles the expanded state of the [ExpandableCard].
+     *
+     * @since 200.6.0
+     */
+    fun toggle() {
+        isExpanded = !isExpanded
+    }
 }
 
 /**

--- a/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCarsState.kt
+++ b/toolkit/sharedlib/src/main/java/com/arcgismaps/toolkit/ui/expandablecard/ExpandableCarsState.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.ui.expandablecard
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+
+/**
+ * State object that can be hoisted to control the [ExpandableCard].
+ *
+ * In most cases, this will be created using [rememberExpandableCardState].
+ * @since 200.6.0
+ */
+class ExpandableCardState constructor(initialExpandedSttate: Boolean) {
+    /**
+     * The expanded state of the [ExpandableCard].
+     * @since 200.6.0
+     */
+    var isExpanded by mutableStateOf(initialExpandedSttate)
+}
+
+/**
+ * Remember the state of [ExpandableCard].
+ *
+ * @param isExpanded the initial expanded state
+ * @since 200.6.0
+ */
+@Composable
+fun rememberExpandableCardState(
+    isExpanded: Boolean = true
+): ExpandableCardState {
+    return rememberSaveable(
+        saver = Saver(
+            save = { it.isExpanded},
+            restore = { ExpandableCardState(it) }
+        )
+    ) {
+        ExpandableCardState(isExpanded)
+    }
+}

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/ExpandableCardWithLabel.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/ExpandableCardWithLabel.kt
@@ -43,19 +43,17 @@ internal fun ExpandableCardWithLabel(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 16.dp)
     ) {
         Text(
             labelText,
             color = MaterialTheme.colorScheme.tertiary,
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(start = 20.dp, bottom = 8.dp)
+            modifier = Modifier.padding(start = 16.dp, bottom = 8.dp)
         )
         ExpandableCard(
             expandableCardState = expandableCardState,
             title = contentTitle,
             padding = PaddingValues(0.dp),
-            modifier = Modifier.padding(horizontal = 4.dp)
         ) {
             content()
         }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/ExpandableCardWithLabel.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/ExpandableCardWithLabel.kt
@@ -25,9 +25,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.ui.expandablecard.ExpandableCard
+import com.arcgismaps.toolkit.ui.expandablecard.rememberExpandableCardState
 
 @Composable
 internal fun ExpandableCardWithLabel(title: String, value: String, content: @Composable () -> Unit) {
+    val expandedCardState = rememberExpandableCardState(false)
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -40,7 +42,7 @@ internal fun ExpandableCardWithLabel(title: String, value: String, content: @Com
             modifier = Modifier.padding(start = 20.dp, bottom = 8.dp)
         )
         ExpandableCard(
-            initialExpandedState = false,
+            expandableCardState = expandedCardState,
             title = value,
             padding = PaddingValues(0.dp),
             modifier = Modifier.padding(horizontal = 4.dp)

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/ExpandableCardWithLabel.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/ExpandableCardWithLabel.kt
@@ -25,25 +25,35 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.ui.expandablecard.ExpandableCard
+import com.arcgismaps.toolkit.ui.expandablecard.ExpandableCardState
 import com.arcgismaps.toolkit.ui.expandablecard.rememberExpandableCardState
 
+/**
+ * Composable that displays an expandable card with a label and its content.
+ *
+ * @since 200.6.0
+ */
 @Composable
-internal fun ExpandableCardWithLabel(title: String, value: String, content: @Composable () -> Unit) {
-    val expandedCardState = rememberExpandableCardState(false)
+internal fun ExpandableCardWithLabel(
+    labelText: String,
+    contentTitle: String,
+    expandableCardState: ExpandableCardState = rememberExpandableCardState(false),
+    content: @Composable () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 16.dp)
     ) {
         Text(
-            title,
+            labelText,
             color = MaterialTheme.colorScheme.tertiary,
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(start = 20.dp, bottom = 8.dp)
         )
         ExpandableCard(
-            expandableCardState = expandedCardState,
-            title = value,
+            expandableCardState = expandableCardState,
+            title = contentTitle,
             padding = PaddingValues(0.dp),
             modifier = Modifier.padding(horizontal = 4.dp)
         ) {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/FeatureResultsDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/FeatureResultsDetailsScreen.kt
@@ -109,7 +109,7 @@ internal fun FeatureResultsDetailsScreen(
 private fun FeatureList(assetTypeList: List<UtilityElement>, onFeatureSelected: (UtilityElement) -> Unit) {
     Surface(modifier = Modifier.fillMaxWidth()) {
         Column {
-            ExpandableCardWithLabel(assetTypeList[0].assetType.name, value = assetTypeList.size.toString()) {
+            ExpandableCardWithLabel(assetTypeList[0].assetType.name, contentTitle = assetTypeList.size.toString()) {
                 Column {
                     assetTypeList.forEach { utilityElement ->
                         HorizontalDivider()

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.ui.expandablecard.ExpandableCard
+import com.arcgismaps.toolkit.ui.expandablecard.rememberExpandableCardState
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.StartingPoint
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
@@ -356,7 +357,7 @@ internal fun AdvancedOptions(
     ExpandableCard(
         title = stringResource(id = R.string.advanced_options),
         toggleable = true,
-        initialExpandedState = false,
+        expandableCardState = rememberExpandableCardState(isExpanded = false),
         padding = PaddingValues(horizontal = 4.dp)
     ) {
         Column {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -63,7 +63,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.ui.expandablecard.ExpandableCard
 import com.arcgismaps.toolkit.ui.expandablecard.rememberExpandableCardState
@@ -233,7 +232,7 @@ private fun TraceConfiguration(
                 if (isSelected) {
                     Icon(
                         imageVector = Icons.Filled.Done,
-                        contentDescription = "Selected icon",
+                        contentDescription = stringResource(R.string.selected_icon),
                         modifier = Modifier.size(FilterChipDefaults.IconSize)
                     )
                 }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -153,7 +153,7 @@ private fun FeatureResult(featureResults: List<UtilityElement>, onFeatureAssetGr
 
     Surface(modifier = Modifier.fillMaxWidth()) {
         Column {
-            ExpandableCardWithLabel(stringResource(R.string.feature_results), value = featureResults.size.toString()) {
+            ExpandableCardWithLabel(stringResource(R.string.feature_results), contentTitle = featureResults.size.toString()) {
                 Column {
                     assetGroupNames.forEach { assetGroupName ->
                         HorizontalDivider()
@@ -196,7 +196,7 @@ private fun elementsInAssetGroup(assetGroup: String, featureResults: List<Utilit
 private fun FunctionResult(functionResults: List<UtilityTraceFunctionOutput>) {
     Surface(modifier = Modifier.fillMaxWidth()) {
         Column {
-            ExpandableCardWithLabel(stringResource(R.string.function_results), value = functionResults.size.toString()) {
+            ExpandableCardWithLabel(stringResource(R.string.function_results), contentTitle = functionResults.size.toString()) {
                 Column {
                     functionResults.forEach { functionResult ->
                         HorizontalDivider()

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.ui.expandablecard.ExpandableCard
+import com.arcgismaps.toolkit.ui.expandablecard.rememberExpandableCardState
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.TraceRun
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.AdvancedOptionsRow
@@ -269,7 +270,7 @@ internal fun AdvancedOptions(
     ExpandableCard(
         title = stringResource(id = R.string.advanced_options),
         toggleable = true,
-        initialExpandedState = false,
+        expandableCardState = rememberExpandableCardState(false),
         padding = PaddingValues(horizontal = 4.dp)
     ) {
         Column {

--- a/toolkit/utilitynetworks/src/main/res/values/strings.xml
+++ b/toolkit/utilitynetworks/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="cancel">Cancel</string>
     <string name="clear_all_results_confirmation">All trace results will be lost.</string>
     <string name="object_id">Object ID: %s</string>
-    <string name="selected_icon">Selected Icon</string>
+    <string name="selected_icon">Selected</string>
 <!--Trace Tool Errors-->
     <string name="no_utility_network_found">No Utility Network found.</string>
     <string name="no_trace_configurations_found">No trace configurations found.</string>

--- a/toolkit/utilitynetworks/src/main/res/values/strings.xml
+++ b/toolkit/utilitynetworks/src/main/res/values/strings.xml
@@ -48,4 +48,5 @@
     <string name="could_not_create_utility_element_from_arcgisfeature">Could not create utility element from ArcGISFeature.</string>
     <string name="one_or_more_starting_points_already_exists">One or more starting points already exist.</string>
     <string name="could_not_create_drawable_from_feature_symbol">Could not create drawable from feature symbol.</string>
+    <string name="no_configuration_selected">No Configuration Selected</string>
 </resources>

--- a/toolkit/utilitynetworks/src/main/res/values/strings.xml
+++ b/toolkit/utilitynetworks/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="cancel">Cancel</string>
     <string name="clear_all_results_confirmation">All trace results will be lost.</string>
     <string name="object_id">Object ID: %s</string>
+    <string name="selected_icon">Selected Icon</string>
 <!--Trace Tool Errors-->
     <string name="no_utility_network_found">No Utility Network found.</string>
     <string name="no_trace_configurations_found">No trace configurations found.</string>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: kotlin#4797

<!-- link to design, if applicable -->

### Summary of changes:
- Adds a state holder class for Expandable card - this gives the option to manage the state outside or inside the composable.
- Makes use of this state class in ExpandableCardWithLabel
- Changes TraceOptions to use the new ExpandableCardWithLabel 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/150/Test_20Report_20-_20Integration/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  