### PR TITLE
`Forms` : More Barcode Scanner Improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4389
+sdkBuildNumber=4395

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4395
+sdkBuildNumber=4398

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeScanner.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeScanner.kt
@@ -30,7 +30,6 @@ import androidx.camera.core.resolutionselector.ResolutionStrategy.FALLBACK_RULE_
 import androidx.camera.view.CameraController
 import androidx.camera.view.LifecycleCameraController
 import androidx.camera.view.PreviewView
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -59,7 +58,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -478,7 +476,7 @@ private fun hasCameraPermissions(context: Context): Boolean = ContextCompat.chec
 ) == PackageManager.PERMISSION_GRANTED
 
 @Composable
-@Preview(showBackground = false, widthDp = 420, heightDp = 933)
+@Preview(showBackground = true, widthDp = 420, heightDp = 933)
 private fun BarcodeFramePreview() {
     val frame = getFrameRect(SCANNER_FRAME_PADDING_HORIZONTAL.dp, SCANNER_FRAME_PADDING_VERTICAL.dp)
     // draw the frame in preview mode

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeScanner.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeScanner.kt
@@ -199,7 +199,7 @@ internal fun BarcodeScanner(
         cameraController?.setImageAnalysisAnalyzer(
             executor,
             BarcodeImageAnalyzer(scannerFrame) { barcodes ->
-                barcodeInfoList = barcodes.toList()
+                barcodeInfoList = barcodes
                 // set the auto-scan barcode if only one barcode is detected
                 if (barcodeInfoList.count() == 1) {
                     // compare the current auto-scan barcode with the detected barcode to avoid setting

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeScanner.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeScanner.kt
@@ -96,8 +96,8 @@ import com.arcgismaps.toolkit.featureforms.R
 import kotlinx.coroutines.delay
 import java.util.concurrent.TimeUnit
 
-private const val SCANNER_FRAME_PADDING_HORIZONTAL = 50
-private const val SCANNER_FRAME_PADDING_VERTICAL = 50
+private const val SCANNER_FRAME_PADDING_HORIZONTAL = 25
+private const val SCANNER_FRAME_PADDING_VERTICAL = 25
 private const val AUTO_SCAN_DELAY_MS = 1000L
 
 /**

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -121,4 +121,5 @@
     <string name="barcode_permission_denied">Camera permissions are required to scan barcodes. Please enable camera permissions in your device settings.</string>
     <string name="unsupported_type">Unsupported Type</string>
     <string name="tap_to_scan">Tap to scan</string>
+    <string name="unable_to_open_the_camera">Unable to open the camera</string>
 </resources>

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -120,4 +120,5 @@
     <string name="barcode_tooltip">Point your camera at a barcode</string>
     <string name="barcode_permission_denied">Camera permissions are required to scan barcodes. Please enable camera permissions in your device settings.</string>
     <string name="unsupported_type">Unsupported Type</string>
+    <string name="tap_to_scan">Tap to scan</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/929](https://devtopia.esri.com/runtime/apollo/issues/929)

<!-- link to design, if applicable -->

### Description:

Removed the visual frame and expanded its size to include most of the barcode scanner screen. This is to accommodate barcodes that are longer in length but visually smaller. With a larger scanning area, the device can get closer to the barcode. 

### Summary of changes:

- The frame is no longer displayed and takes up most of the view but with some padding.
- Added exception handling to `rememberCameraController()` which can throw on `bindToLifeCycle()`. This state will now show an error dialog.
- Updated `BarcodeImageAnalyzer` to use an experimental method `ImageProxy.getImage`.
    - This method to directly analyze using the `InputImage` is ~35% faster. Based on benchmarks, this method can analyze at ~25fps compared to only ~18fps using the `ImageProxy.toBitmap()` method which was inherently slow.
    - The new `MLKItAnalyzer` internally also [uses](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:camera/camera-mlkit-vision/src/main/java/androidx/camera/mlkit/vision/MlKitAnalyzer.java;drc=89db5ac5f4fbce7fb36e117bf341bfbe562e8641;l=207) this experimental method without requiring an opt-in. Even the guide [doc](https://developers.google.com/ml-kit/vision/barcode-scanning/android#using-a-media.image) suggests this API which leads me to believe there are other reasons this is experimental.
- The `BarcodeImageAnalyzer` now maintains a map of detected barcodes and only clears then when they have not been detected for 4 consecutive frames. This is to reduce the amount of jerkiness in the barcode tracking when the barcode goes in and out of detection. 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  