### PR TITLE
UN Trace Tool: Refactor TabRow

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -101,7 +101,7 @@ public fun Trace(
                             Text(errorMessage, color = MaterialTheme.colorScheme.error)
                         }
                     }
-                    if (traceState.showResults()) {
+                    if (traceState.showTabRow()) {
                         TabRow(
                             selectedTabIndex,
                             onNavigateTo = {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -63,6 +63,7 @@ public fun Trace(
     val initializationStatus by traceState.initializationStatus
     val localContext = LocalContext.current
     var selectedTabIndex by rememberSaveable { mutableIntStateOf(1) }
+    var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
 
     LaunchedEffect(traceState) {
         traceState.initialize()

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -33,12 +33,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
 import com.arcgismaps.toolkit.utilitynetworks.ui.TraceNavHost
 
 internal const val traceSurfaceContentDescription: String = "trace component surface"
@@ -58,6 +62,7 @@ public fun Trace(
 ) {
     val initializationStatus by traceState.initializationStatus
     val localContext = LocalContext.current
+    var selectedTabIndex by rememberSaveable { mutableIntStateOf(1) }
 
     LaunchedEffect(traceState) {
         traceState.initialize()
@@ -79,6 +84,7 @@ public fun Trace(
                     CircularProgressIndicator()
                 }
             }
+
             else -> {
                 Column(
                     modifier = Modifier
@@ -95,7 +101,21 @@ public fun Trace(
                             Text(errorMessage, color = MaterialTheme.colorScheme.error)
                         }
                     }
-                    TraceNavHost(traceState)
+                    if (traceState.showResults()) {
+                        TabRow(
+                            selectedTabIndex,
+                            onNavigateTo = {
+                                selectedTabIndex = it.first
+                                traceState.showScreen(it.second)
+                            }
+                        )
+                    }
+                    TraceNavHost(
+                        traceState,
+                        onTabSwitch = {
+                            selectedTabIndex = it
+                        }
+                    )
                 }
             }
         }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -62,7 +62,6 @@ public fun Trace(
 ) {
     val initializationStatus by traceState.initializationStatus
     val localContext = LocalContext.current
-    var selectedTabIndex by rememberSaveable { mutableIntStateOf(1) }
     var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
 
     LaunchedEffect(traceState) {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -661,11 +661,11 @@ public class TraceState(
     }
 
     /**
-     * Signal if the result screen should be shown.
+     * Signal if the TabRow should be shown.
      *
      * @since 200.6.0
      */
-    internal fun showResults(): Boolean {
+    internal fun showTabRow(): Boolean {
         return _completedTraces.isNotEmpty()
     }
 }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -71,6 +71,7 @@ public class TraceState(
     private val graphicsOverlay: GraphicsOverlay,
     private val mapViewProxy: MapViewProxy
 ) {
+    private val fullScreenNavRoutes = listOf(TraceNavRoute.AddStartingPoint)
 
     private var _currentError: Throwable? = null
     internal val currentError: Throwable?
@@ -142,6 +143,10 @@ public class TraceState(
     internal val selectedCompletedTraceIndex: State<Int> = _selectedCompletedTraceIndex
 
     private var _currentTraceName: MutableState<String> = mutableStateOf("")
+
+    private var _currentScreen: MutableState<TraceNavRoute> = mutableStateOf(TraceNavRoute.TraceOptions)
+    private val currentScreen: State<TraceNavRoute> = _currentScreen
+
     /**
      * The default name of the trace.
      *
@@ -218,6 +223,7 @@ public class TraceState(
     }
 
     internal fun showScreen(screen: TraceNavRoute) {
+        _currentScreen.value = screen
         navigateToRoute?.invoke(screen)
     }
 
@@ -666,7 +672,7 @@ public class TraceState(
      * @since 200.6.0
      */
     internal fun showTabRow(): Boolean {
-        return _completedTraces.isNotEmpty()
+        return _completedTraces.isNotEmpty() && !fullScreenNavRoutes.contains(currentScreen.value)
     }
 }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -58,6 +58,9 @@ import com.arcgismaps.utilitynetworks.UtilityTerminal
 import com.arcgismaps.utilitynetworks.UtilityTraceFunctionOutput
 import com.arcgismaps.utilitynetworks.UtilityTraceParameters
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -658,6 +661,15 @@ public class TraceState(
      */
     internal fun setCurrentError(error: Throwable) {
         _currentError = error
+    }
+
+    /**
+     * Signal if the result screen should be shown.
+     *
+     * @since 200.6.0
+     */
+    internal fun showResults(): Boolean {
+        return _completedTraces.isNotEmpty()
     }
 }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -58,9 +58,6 @@ import com.arcgismaps.utilitynetworks.UtilityTerminal
 import com.arcgismaps.utilitynetworks.UtilityTraceFunctionOutput
 import com.arcgismaps.utilitynetworks.UtilityTraceParameters
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
 
 /**

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -71,7 +71,7 @@ public class TraceState(
     private val graphicsOverlay: GraphicsOverlay,
     private val mapViewProxy: MapViewProxy
 ) {
-    private val fullScreenNavRoutes = listOf(TraceNavRoute.AddStartingPoint)
+    private val navRoutesWithNoTabRow = listOf(TraceNavRoute.AddStartingPoint)
 
     private var _currentError: Throwable? = null
     internal val currentError: Throwable?
@@ -672,7 +672,7 @@ public class TraceState(
      * @since 200.6.0
      */
     internal fun showTabRow(): Boolean {
-        return _completedTraces.isNotEmpty() && !fullScreenNavRoutes.contains(currentScreen.value)
+        return _completedTraces.isNotEmpty() && !navRoutesWithNoTabRow.contains(currentScreen.value)
     }
 }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TabRow.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TabRow.kt
@@ -18,35 +18,31 @@ package com.arcgismaps.toolkit.utilitynetworks.internal.util
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import androidx.compose.material3.TabRow
 import com.arcgismaps.toolkit.utilitynetworks.R
+import com.arcgismaps.toolkit.utilitynetworks.TraceNavRoute
 
 @Composable
 internal fun TabRow(
-    onTabSelected: () -> Unit,
-    selectedIndex: Int
+    selectedIndex: Int,
+    onNavigateTo: (Pair<Int, TraceNavRoute>) -> Unit
 ) {
-    var selectedTabIndex by rememberSaveable { mutableIntStateOf(selectedIndex) }
-    val newTrace = stringResource(R.string.new_trace)
-    val results = stringResource(R.string.results)
-    val tabItems = rememberSaveable { listOf(newTrace, results) }
+    val tabItems = listOf(
+        stringResource(R.string.new_trace) to TraceNavRoute.TraceOptions,
+        stringResource(R.string.results) to TraceNavRoute.TraceResults
+    )
 
-    TabRow(selectedTabIndex = selectedTabIndex) {
-        tabItems.forEachIndexed { index, title ->
+    TabRow(selectedTabIndex = selectedIndex) {
+        tabItems.forEachIndexed { index, tab ->
             Tab(
-                selected = index == selectedTabIndex,
+                selected = index == selectedIndex,
                 onClick = {
-                    if (index != selectedTabIndex) {
-                        onTabSelected()
-                        selectedTabIndex = index
+                    if (index != selectedIndex) {
+                        onNavigateTo(index to tab.second)
                     }
                 },
-                text = { Text(title) }
+                text = { Text(tab.first) }
             )
         }
     }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/FeatureResultsDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/FeatureResultsDetailsScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.ExpandableCardWithLabel
-import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.UpButton
 import com.arcgismaps.utilitynetworks.UtilityElement
 
@@ -55,7 +54,6 @@ internal fun FeatureResultsDetailsScreen(
     selectedGroupName: String,
     elementListWithSelectedGroupName: List<UtilityElement>,
     onFeatureSelected: (UtilityElement) -> Unit,
-    onBackToNewTrace: () -> Unit,
     onBackToResults: () -> Unit
 ) {
     BackHandler {
@@ -67,8 +65,6 @@ internal fun FeatureResultsDetailsScreen(
                 .fillMaxSize()
                 .padding(horizontal = 10.dp)
         ) {
-
-            TabRow(onBackToNewTrace, 1)
 
             Spacer(
                 modifier = Modifier

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/FeatureResultsDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/FeatureResultsDetailsScreen.kt
@@ -59,6 +59,7 @@ internal fun FeatureResultsDetailsScreen(
     BackHandler {
         onBackToResults()
     }
+
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
@@ -82,6 +82,7 @@ internal fun StartingPointDetailsScreen(
     BackHandler {
         onBackPressed()
     }
+
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/StartingPointDetailsScreen.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.StartingPoint
-import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.Title
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.UpButton
 import com.arcgismaps.utilitynetworks.UtilityNetworkSourceType
@@ -74,8 +73,6 @@ import com.arcgismaps.utilitynetworks.UtilityTerminal
 @Composable
 internal fun StartingPointDetailsScreen(
     startingPoint: StartingPoint,
-    showResultsTab: Boolean,
-    onBackToResults: () -> Unit,
     onZoomTo: () -> Unit,
     onDelete: () -> Unit,
     onFractionChanged: (StartingPoint, Float) -> Unit,
@@ -93,15 +90,6 @@ internal fun StartingPointDetailsScreen(
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.Top,
         ) {
-
-            if (showResultsTab) {
-                TabRow(onBackToResults, 0)
-                Spacer(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(25.dp)
-                )
-            }
 
             UpButton(stringResource(id = R.string.starting_points), onBackPressed)
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -113,8 +113,8 @@ internal fun TraceNavHost(traceState: TraceState, onTabSwitch: (Int) -> Unit) {
                 },
                 onDeleteResult = {
                     if (traceState.completedTraces.size == 1) {
-                        traceState.clearSelectedTraceResult()
                         traceState.showScreen(TraceNavRoute.TraceOptions)
+                        traceState.clearSelectedTraceResult()
                     } else {
                         traceState.clearSelectedTraceResult()
                     }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -113,8 +113,8 @@ internal fun TraceNavHost(traceState: TraceState, onTabSwitch: (Int) -> Unit) {
                 },
                 onDeleteResult = {
                     if (traceState.completedTraces.size == 1) {
-                        traceState.showScreen(TraceNavRoute.TraceOptions)
                         traceState.clearSelectedTraceResult()
+                        traceState.showScreen(TraceNavRoute.TraceOptions)
                     } else {
                         traceState.clearSelectedTraceResult()
                     }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -59,10 +59,10 @@ internal fun TraceNavHost(traceState: TraceState, onTabSwitch: (Int) -> Unit) {
                     coroutineScope.launch {
                         traceState.trace().onSuccess {
                             traceState.showScreen(TraceNavRoute.TraceResults)
+                            onTabSwitch(1)
                             if (traceState.currentTraceZoomToResults.value) {
                                 traceState.zoomToSelectedTrace()
                             }
-                            onTabSwitch(1)
                         }.onFailure {
                             traceState.setCurrentError(it)
                             traceState.showScreen(TraceNavRoute.TraceError)

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceNavigation.kt
@@ -28,7 +28,6 @@ import androidx.navigation.compose.rememberNavController
 import com.arcgismaps.toolkit.utilitynetworks.AddStartingPointMode
 import com.arcgismaps.toolkit.utilitynetworks.TraceNavRoute
 import com.arcgismaps.toolkit.utilitynetworks.TraceState
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 /**

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -73,7 +73,6 @@ import com.arcgismaps.toolkit.utilitynetworks.R
 import com.arcgismaps.toolkit.utilitynetworks.StartingPoint
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.AdvancedOptionsRow
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.ColorPicker
-import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
 import com.arcgismaps.utilitynetworks.UtilityNamedTraceConfiguration
 import com.arcgismaps.utilitynetworks.UtilityNetwork
 
@@ -92,10 +91,8 @@ internal fun TraceOptionsScreen(
     defaultTraceName: String,
     selectedColor: Color,
     zoomToResult: Boolean,
-    showResultsTab: Boolean,
     onStartingPointRemoved: (StartingPoint) -> Unit,
     onStartingPointSelected: (StartingPoint) -> Unit,
-    onBackToResults: () -> Unit,
     onConfigSelected: (UtilityNamedTraceConfiguration) -> Unit,
     onPerformTraceButtonClicked: () -> Unit,
     onAddStartingPointButtonClicked: () -> Unit,
@@ -113,14 +110,6 @@ internal fun TraceOptionsScreen(
 
             var currentSelectedColor by remember { mutableStateOf(selectedColor) }
 
-            if (showResultsTab) {
-                TabRow(onBackToResults, 0)
-                Spacer(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(15.dp)
-                )
-            }
             LazyColumn(
                 modifier = Modifier
                     .padding(vertical = 3.dp)

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -17,6 +17,7 @@
 package com.arcgismaps.toolkit.utilitynetworks.ui
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -54,7 +55,6 @@ import com.arcgismaps.toolkit.utilitynetworks.TraceRun
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.AdvancedOptionsRow
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.ColorPicker
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.ExpandableCardWithLabel
-import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
 import com.arcgismaps.toolkit.utilitynetworks.internal.util.Title
 import com.arcgismaps.utilitynetworks.UtilityElement
 import com.arcgismaps.utilitynetworks.UtilityTraceFunctionOutput
@@ -88,8 +88,6 @@ internal fun TraceResultScreen(
 
             val selectedTraceRun = remember(selectedTraceRunIndex) { traceResults[selectedTraceRunIndex] }
             var selectedColor by remember(selectedTraceRunIndex) { mutableStateOf(selectedTraceRun.resultGraphicColor) }
-
-            TabRow(onBackToNewTrace, 1)
 
             Row(modifier = Modifier.align(Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -17,7 +17,6 @@
 package com.arcgismaps.toolkit.utilitynetworks.ui
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: Kotlin #4773

<!-- link to design, if applicable -->

### Summary of changes:
- Remove usages of TabRow within composables and factor it out
- Display it only when there are results available  

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/161/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  