### PR TITLE
Update Result screen UI when the First element in the list is getting deleted

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -648,6 +648,8 @@ public class TraceState(
         if (_selectedCompletedTraceIndex.value - 1 >= 0) {
             _selectedCompletedTraceIndex.value -= 1
             updateSelectedStateForTraceResultsGraphics(_selectedCompletedTraceIndex.value, true)
+        } else if (_selectedCompletedTraceIndex.value == 0 && _completedTraces.isNotEmpty()) {
+            updateSelectedStateForTraceResultsGraphics(_selectedCompletedTraceIndex.value, true)
         }
     }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -645,10 +645,10 @@ public class TraceState(
         selectedTrace.geometryResultsGraphics.forEach { graphicsOverlay.graphics.remove(it) }
         selectedTrace.startingPoints.forEach { it.graphic.isSelected = false }
         _completedTraces.removeAt(_selectedCompletedTraceIndex.value)
-        if (_selectedCompletedTraceIndex.value - 1 >= 0) {
-            _selectedCompletedTraceIndex.value -= 1
-            updateSelectedStateForTraceResultsGraphics(_selectedCompletedTraceIndex.value, true)
-        } else if (_selectedCompletedTraceIndex.value == 0 && _completedTraces.isNotEmpty()) {
+        if (_selectedCompletedTraceIndex.value > 0 || (_selectedCompletedTraceIndex.value == 0 && _completedTraces.isNotEmpty())) {
+            if (_selectedCompletedTraceIndex.value > 0) {
+                _selectedCompletedTraceIndex.value -= 1
+            }
             updateSelectedStateForTraceResultsGraphics(_selectedCompletedTraceIndex.value, true)
         }
     }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -79,50 +79,58 @@ internal fun TraceResultScreen(
         onBackToNewTrace()
     }
 
-    Surface(modifier = Modifier.fillMaxSize()) {
-        Column {
+    if (traceResults.isNotEmpty()) {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Column {
 
-            if (traceResults.isEmpty()) {
-                return@Column
-            }
-
-            val selectedTraceRun = traceResults[selectedTraceRunIndex]
-            var selectedColor by remember(selectedTraceRunIndex) { mutableStateOf(selectedTraceRun.resultGraphicColor) }
-
-            if (traceResults.size > 1) {
-                TraceResultPager(
-                    selectedTraceRunIndex,
-                    traceResults.size,
-                    onSelectPreviousTraceResult,
-                    onSelectNextTraceResult
-                )
-            }
-
-            Title(
-                selectedTraceRun.name,
-                onZoomTo = onZoomToResults,
-                onDelete = onDeleteResult,
-                showZoomToOption = selectedTraceRun.geometryTraceResult != null
-            )
-            LazyColumn {
-                item {
-                    FeatureResult(selectedTraceRun.featureResults, onFeatureGroupSelected)
-                }
-                item {
-                    FunctionResult(selectedTraceRun.functionResults)
-                }
-                item {
-                    AdvancedOptions(
-                        selectedColor = selectedColor,
-                        onColorChanged = {
-                            selectedColor = it
-                            onColorChanged(it)
-                        }
+                val selectedTraceRun = traceResults[selectedTraceRunIndex]
+                var selectedColor by remember(selectedTraceRunIndex) {
+                    mutableStateOf(
+                        selectedTraceRun.resultGraphicColor
                     )
                 }
-                item {
-                    ClearAllResultsButton(onClearAllResults)
+
+                if (traceResults.size > 1) {
+                    TraceResultPager(
+                        selectedTraceRunIndex,
+                        traceResults.size,
+                        onSelectPreviousTraceResult,
+                        onSelectNextTraceResult
+                    )
                 }
+
+                Title(
+                    selectedTraceRun.name,
+                    onZoomTo = onZoomToResults,
+                    onDelete = onDeleteResult,
+                    showZoomToOption = selectedTraceRun.geometryTraceResult != null
+                )
+                LazyColumn {
+                    item {
+                        FeatureResult(selectedTraceRun.featureResults, onFeatureGroupSelected)
+                    }
+                    item {
+                        FunctionResult(selectedTraceRun.functionResults)
+                    }
+                    item {
+                        AdvancedOptions(
+                            selectedColor = selectedColor,
+                            onColorChanged = {
+                                selectedColor = it
+                                onColorChanged(it)
+                            }
+                        )
+                    }
+                    item {
+                        ClearAllResultsButton(onClearAllResults)
+                    }
+                }
+            }
+        }
+    } else {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Column {
+                // Don't show anything if there are no trace results
             }
         }
     }
@@ -137,7 +145,8 @@ private fun TraceResultPager(
 ) {
     Row(
         modifier = Modifier
-            .fillMaxWidth().padding(bottom = 16.dp),
+            .fillMaxWidth()
+            .padding(bottom = 16.dp),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -87,7 +87,11 @@ internal fun TraceResultScreen(
             .fillMaxSize()
             .padding(horizontal = 10.dp)) {
 
-            val selectedTraceRun = remember(selectedTraceRunIndex) { traceResults[selectedTraceRunIndex] }
+            if (traceResults.isEmpty()) {
+                return@Column
+            }
+
+            val selectedTraceRun = traceResults[selectedTraceRunIndex]
             var selectedColor by remember(selectedTraceRunIndex) { mutableStateOf(selectedTraceRun.resultGraphicColor) }
 
             TabRow(onBackToNewTrace, 1)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4844

<!-- link to design, if applicable -->

### Description:

The Result screen UI does not update when deleting the First result

### Summary of changes:

- We are remembering the selectedTraceRunIndex in the result screen, the value of which does not change when we delete the 0th element cause the UI to not refresh
- Also we were not highlighting the graphic of the next element that becomes the 0th element when the previous element is deleted.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/162/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  