### PR TITLE
Show chevron pagers only when more than one result is available

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -89,15 +89,18 @@ internal fun TraceResultScreen(
             val selectedTraceRun = remember(selectedTraceRunIndex) { traceResults[selectedTraceRunIndex] }
             var selectedColor by remember(selectedTraceRunIndex) { mutableStateOf(selectedTraceRun.resultGraphicColor) }
 
-            Row(modifier = Modifier.align(Alignment.CenterHorizontally),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                TraceResultPager(
-                    selectedTraceRunIndex,
-                    traceResults.size,
-                    onSelectPreviousTraceResult,
-                    onSelectNextTraceResult
-                )
+            if (traceResults.size > 1) {
+                Row(
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TraceResultPager(
+                        selectedTraceRunIndex,
+                        traceResults.size,
+                        onSelectPreviousTraceResult,
+                        onSelectNextTraceResult
+                    )
+                }
             }
 
             Title(


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4846

<!-- link to design, if applicable -->

### Description:

We don't want to show cheveron pagers when only one result is present

### Summary of changes:

- Add check to render cheveron pagers only when more than one result present

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/167/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  