### PR TITLE
`Forms` : Add validation for guid fields

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,4 @@ artifactoryPassword=""
 # A final build before release is such a special build, in which case these SDK version numbers
 # are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4399
+sdkBuildNumber=4404

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/FieldValidation.kt
@@ -41,6 +41,7 @@ internal sealed class ValidationErrorState(
     data object NotAWholeNumber : ValidationErrorState()
     data object NotInCodedValueDomain : ValidationErrorState()
     data object NullNotAllowed : ValidationErrorState()
+    data object NotAGuid : ValidationErrorState()
 
     @ReadOnlyComposable
     @Composable
@@ -109,6 +110,10 @@ internal sealed class ValidationErrorState(
 
             is NotAWholeNumber -> {
                 stringResource(id = R.string.value_must_be_a_whole_number)
+            }
+
+            is NotAGuid -> {
+                stringResource(id = R.string.value_must_be_a_guid)
             }
 
             NotInCodedValueDomain -> {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.base
 
+import com.arcgismaps.data.FieldType
 import com.arcgismaps.data.RangeDomain
 import com.arcgismaps.exceptions.FeatureFormValidationException
 import com.arcgismaps.mapping.featureforms.BarcodeScannerFormInput
@@ -110,10 +111,16 @@ private fun createValidationErrorStates(
                 }
 
                 is FeatureFormValidationException.IncorrectValueTypeException -> {
-                    if (formElement.fieldType.isFloatingPoint) {
-                        add(ValidationErrorState.NotANumber)
-                    } else if (formElement.fieldType.isIntegerType) {
-                        add(ValidationErrorState.NotAWholeNumber)
+                    when {
+                        formElement.fieldType.isFloatingPoint -> {
+                            add(ValidationErrorState.NotANumber)
+                        }
+                        formElement.fieldType.isIntegerType -> {
+                            add(ValidationErrorState.NotAWholeNumber)
+                        }
+                        formElement.fieldType is FieldType.Guid -> {
+                            add(ValidationErrorState.NotAGuid)
+                        }
                     }
                 }
 

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -122,4 +122,5 @@
     <string name="unsupported_type">Unsupported Type</string>
     <string name="tap_to_scan">Tap to scan</string>
     <string name="unable_to_open_the_camera">Unable to open the camera</string>
+    <string name="value_must_be_a_guid">Value must be a valid GUID</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/923](https://devtopia.esri.com/runtime/apollo/issues/923)

<!-- link to design, if applicable -->

### Description:

Adds validation error messages for GUID type fields.

### Summary of changes:

- Core now accepts a `String` value for a `FieldType.GUID` when `FieldFormElement.updateValue` is called. 
- If the `String` cannot be converted into a valid `GUID`, the `validationErrors` property will contain a validation error of type. `IncorrectValueTypeException`.
- This PR adds logic to display an appropriate message of this error type for guid fields.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/170/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  