### PR TITLE
fix for refreshing Advanced Options Name field everytime a new TraceC…

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -145,11 +145,10 @@ public class TraceState(
     private var _isTaskInProgress: MutableState<Boolean> = mutableStateOf(false)
     internal val isTaskInProgress: State<Boolean> = _isTaskInProgress
 
-    private var _currentTraceName: MutableState<String> = mutableStateOf("")
-
     private var _currentScreen: MutableState<TraceNavRoute> = mutableStateOf(TraceNavRoute.TraceOptions)
     private val currentScreen: State<TraceNavRoute> = _currentScreen
 
+    private var _currentTraceName: MutableState<String> = mutableStateOf("")
     /**
      * The default name of the trace.
      *

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -344,7 +344,7 @@ internal fun AdvancedOptions(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    var text by rememberSaveable { mutableStateOf(defaultTraceName) }
+                    var text by remember(defaultTraceName) { mutableStateOf(defaultTraceName) }
                     OutlinedTextField(
                         value = text,
                         onValueChange = { newValue ->


### PR DESCRIPTION
…onfiguration is selected

<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4858

<!-- link to design, if applicable -->

### Description:

Changes to refresh the Name field every time a new Trace configuration is selected

### Summary of changes:

- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/171/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  