### PR TITLE
Fix for unchecking the TraceConfiguration in the expandable card once…

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/TraceState.kt
@@ -211,7 +211,7 @@ public class TraceState(
             _initializationStatus.value = InitializationStatus.FailedToInitialize(error)
             throw error
         }
-        _traceConfigurations.value = traceConfigResult.getOrThrow()
+        _traceConfigurations.value = traceConfigResult.getOrThrow().sortedBy { it.name }
 
         _initializationStatus.value = InitializationStatus.Initialized
     }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceOptionsScreen.kt
@@ -192,7 +192,7 @@ private fun TraceConfigurations(
     onTraceSelected: (Int) -> Unit
 ) {
     val expandableCardState = rememberExpandableCardState(false)
-    var selectedConfigIndex by rememberSaveable { mutableIntStateOf(-1) }
+    var selectedConfigIndex by remember(selectedConfigName) { mutableIntStateOf(configs.indexOf(selectedConfigName)) }
     ExpandableCardWithLabel(
         expandableCardState = expandableCardState,
         labelText = stringResource(id = R.string.trace_configuration),


### PR DESCRIPTION
… trace is done

<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/4843

<!-- link to design, if applicable -->

### Description:

The trace configuration should not be checked after a trace is done

### Summary of changes:

- Sort the list of available trace configurations
- Hook up the Selected config index with selectedConfigName, so when it is reset the check mark also gets reset

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/172/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  