### PR TITLE
Adds Trace Container composable

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -67,7 +67,7 @@ public fun Trace(
         traceState.initialize()
     }
 
-    TraceContainer(
+    TraceScaffold(
         initializationStatus = initializationStatus,
         displayLinearProgressIndicator = traceState.isTaskInProgress.value,
         modifier = modifier,
@@ -95,7 +95,7 @@ public fun Trace(
 }
 
 @Composable
-private fun TraceContainer(
+private fun TraceScaffold(
     initializationStatus: InitializationStatus,
     displayLinearProgressIndicator: Boolean,
     modifier: Modifier = Modifier,

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -108,7 +108,6 @@ private fun TraceContainer(
         modifier = modifier
             .fillMaxSize()
             .padding(horizontal = 16.dp)
-            .fillMaxSize()
             .semantics { contentDescription = localContext.getString(R.string.trace_component) }
     ) {
         Column(

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -116,7 +116,10 @@ private fun TraceScaffold(
         ) {
             when (initializationStatus) {
                 is InitializationStatus.NotInitialized, InitializationStatus.Initializing -> {
-                    Box(contentAlignment = Alignment.Center) {
+                    Box(
+                        modifier = modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
                         CircularProgressIndicator()
                     }
                 }

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -49,7 +49,7 @@ import com.arcgismaps.toolkit.utilitynetworks.internal.util.TabRow
 import com.arcgismaps.toolkit.utilitynetworks.ui.TraceNavHost
 
 /**
- * A composable UI component to set up and run a [trace](https://developers.arcgis.com/kotlin/api-reference/arcgis-maps-kotlin/com.arcgismaps.utilitynetworks/-utility-network/trace.html?)
+ * A composable UI component to set up and run a [trace](https://developers.arcgis.com/kotlin/api-reference/arcgis-maps-kotlin/com.arcgismaps.utilitynetworks/-utility-network/trace.html)
  * workflow on a [com.arcgismaps.toolkit.geoviewcompose.MapView].
  *
  * @since 200.6.0

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/Trace.kt
@@ -124,6 +124,7 @@ private fun TraceContainer(
                 is InitializationStatus.FailedToInitialize -> {
                     val errorMessage = initializationStatus.error.getErrorMessage(localContext)
                     NonRecoveredErrorIndicator(errorMessage)
+                    content()
                 }
 
                 else -> {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: kotlin#4867

<!-- link to design, if applicable -->

### Summary of changes:
- Refactors `Trace` to separate UI from Navigation 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/178/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  