### PR TITLE
`Forms` : Fix lint warnings

### DIFF
--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -18,6 +18,7 @@ public final class com/arcgismaps/toolkit/featureforms/ValidationErrorVisibility
 
 public final class com/arcgismaps/toolkit/featureforms/theme/AttachmentsElementColors {
 	public static final field $stable I
+	public synthetic fun <init> (JJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
 	public final fun component3-0d7_KjU ()J
@@ -41,6 +42,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/AttachmentsElementC
 
 public final class com/arcgismaps/toolkit/featureforms/theme/AttachmentsElementTypography {
 	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
 	public final fun component1 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun component2 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun component3 ()Landroidx/compose/ui/text/TextStyle;
@@ -56,6 +58,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/AttachmentsElementT
 
 public final class com/arcgismaps/toolkit/featureforms/theme/EditableTextFieldColors {
 	public static final field $stable I
+	public synthetic fun <init> (JJJJJJJJLandroidx/compose/foundation/text/selection/TextSelectionColors;JJJJJJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component10-0d7_KjU ()J
 	public final fun component11-0d7_KjU ()J
@@ -131,6 +134,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/EditableTextFieldCo
 
 public final class com/arcgismaps/toolkit/featureforms/theme/EditableTextFieldTypography {
 	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
 	public final fun component1 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun component2 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun component3 ()Landroidx/compose/ui/text/TextStyle;
@@ -146,6 +150,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/EditableTextFieldTy
 
 public final class com/arcgismaps/toolkit/featureforms/theme/FeatureFormColorScheme {
 	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/toolkit/featureforms/theme/EditableTextFieldColors;Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldColors;Lcom/arcgismaps/toolkit/featureforms/theme/GroupElementColors;Lcom/arcgismaps/toolkit/featureforms/theme/AttachmentsElementColors;)V
 	public final fun component1 ()Lcom/arcgismaps/toolkit/featureforms/theme/EditableTextFieldColors;
 	public final fun component2 ()Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors;
 	public final fun component3 ()Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldColors;
@@ -182,11 +187,22 @@ public final class com/arcgismaps/toolkit/featureforms/theme/FeatureFormDefaults
 
 public final class com/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography {
 	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/toolkit/featureforms/theme/EditableTextFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/GroupElementTypography;Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/AttachmentsElementTypography;)V
+	public final fun component1 ()Lcom/arcgismaps/toolkit/featureforms/theme/EditableTextFieldTypography;
+	public final fun component2 ()Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldTypography;
+	public final fun component3 ()Lcom/arcgismaps/toolkit/featureforms/theme/GroupElementTypography;
+	public final fun component4 ()Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldTypography;
+	public final fun component5 ()Lcom/arcgismaps/toolkit/featureforms/theme/AttachmentsElementTypography;
+	public final fun copy (Lcom/arcgismaps/toolkit/featureforms/theme/EditableTextFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/GroupElementTypography;Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/AttachmentsElementTypography;)Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;Lcom/arcgismaps/toolkit/featureforms/theme/EditableTextFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/GroupElementTypography;Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldTypography;Lcom/arcgismaps/toolkit/featureforms/theme/AttachmentsElementTypography;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachmentsElementTypography ()Lcom/arcgismaps/toolkit/featureforms/theme/AttachmentsElementTypography;
 	public final fun getEditableTextFieldTypography ()Lcom/arcgismaps/toolkit/featureforms/theme/EditableTextFieldTypography;
 	public final fun getGroupElementTypography ()Lcom/arcgismaps/toolkit/featureforms/theme/GroupElementTypography;
 	public final fun getRadioButtonFieldTypography ()Lcom/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldTypography;
 	public final fun getReadOnlyFieldTypography ()Lcom/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldTypography;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/arcgismaps/toolkit/featureforms/theme/GroupElementColors {
@@ -210,6 +226,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/GroupElementColors 
 
 public final class com/arcgismaps/toolkit/featureforms/theme/GroupElementTypography {
 	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
 	public final fun component1 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun component2 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun copy (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)Lcom/arcgismaps/toolkit/featureforms/theme/GroupElementTypography;
@@ -223,6 +240,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/GroupElementTypogra
 
 public final class com/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldColors {
 	public static final field $stable I
+	public synthetic fun <init> (JJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
 	public final fun component3-0d7_KjU ()J
@@ -248,6 +266,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldCol
 
 public final class com/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldTypography {
 	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
 	public final fun component1 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun component2 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun component3 ()Landroidx/compose/ui/text/TextStyle;
@@ -263,6 +282,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/RadioButtonFieldTyp
 
 public final class com/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors {
 	public static final field $stable I
+	public synthetic fun <init> (JJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
 	public final fun component3-0d7_KjU ()J
@@ -280,6 +300,7 @@ public final class com/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldColors
 
 public final class com/arcgismaps/toolkit/featureforms/theme/ReadOnlyFieldTypography {
 	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
 	public final fun component1 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun component2 ()Landroidx/compose/ui/text/TextStyle;
 	public final fun component3 ()Landroidx/compose/ui/text/TextStyle;

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -62,7 +62,9 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
 
@@ -97,6 +99,8 @@ apiValidation {
         "com.arcgismaps.toolkit.featureforms.internal.components.attachment.ComposableSingletons\$AttachmentTileKt",
         "com.arcgismaps.toolkit.featureforms.internal.components.formelement.ComposableSingletons\$GroupElementKt",
         "com.arcgismaps.toolkit.featureforms.internal.components.text.ComposableSingletons\$TextFormElementKt",
+        "com.arcgismaps.toolkit.featureforms.internal.components.barcode.ComposableSingletons\$BarcodeScannerKt",
+        "com.arcgismaps.toolkit.featureforms.internal.components.barcode.ComposableSingletons\$BarcodeTextFieldKt",
     )
     
     ignoredClasses.addAll(composableSingletons)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/theme/FeatureFormTheme.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/theme/FeatureFormTheme.kt
@@ -28,11 +28,11 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
 import com.arcgismaps.mapping.featureforms.ComboBoxFormInput
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.mapping.featureforms.GroupFormElement
-import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
 import com.arcgismaps.mapping.featureforms.RadioButtonsFormInput
 import com.arcgismaps.mapping.featureforms.SwitchFormInput
 import com.arcgismaps.mapping.featureforms.TextAreaFormInput
@@ -126,7 +126,7 @@ internal fun FeatureFormTheme(
  * @since 200.5.0
  */
 @Immutable
-public data class FeatureFormColorScheme internal constructor(
+public data class FeatureFormColorScheme(
     public val editableTextFieldColors: EditableTextFieldColors,
     public val readOnlyFieldColors: ReadOnlyFieldColors,
     public val radioButtonFieldColors: RadioButtonFieldColors,
@@ -179,7 +179,7 @@ public data class FeatureFormColorScheme internal constructor(
  * @since 200.5.0
  */
 @Immutable
-public data class EditableTextFieldColors internal constructor(
+public data class EditableTextFieldColors(
     public val focusedTextColor: Color,
     public val unfocusedTextColor: Color,
     public val errorTextColor: Color,
@@ -228,7 +228,7 @@ public data class EditableTextFieldColors internal constructor(
  * @since 200.5.0
  */
 @Immutable
-public data class ReadOnlyFieldColors internal constructor(
+public data class ReadOnlyFieldColors(
     public val labelColor: Color,
     public val textColor: Color,
     public val supportingTextColor: Color,
@@ -275,7 +275,7 @@ public data class GroupElementColors internal constructor(
  * @since 200.5.0
  */
 @Immutable
-public data class RadioButtonFieldColors internal constructor(
+public data class RadioButtonFieldColors(
     public val labelColor: Color,
     public val textColor: Color,
     public val supportingTextColor: Color,
@@ -301,7 +301,7 @@ public data class RadioButtonFieldColors internal constructor(
  * @property scrollBarColor the color used for the scroll bar of the attachment list.
  * @since 200.5.0
  */
-public data class AttachmentsElementColors internal constructor(
+public data class AttachmentsElementColors(
     public val labelColor: Color,
     public val supportingTextColor: Color,
     public val outlineColor: Color,
@@ -328,7 +328,7 @@ public data class AttachmentsElementColors internal constructor(
  * @since 200.5.0
  */
 @Immutable
-public class FeatureFormTypography internal constructor(
+public data class FeatureFormTypography(
     public val editableTextFieldTypography: EditableTextFieldTypography,
     public val readOnlyFieldTypography: ReadOnlyFieldTypography,
     public val groupElementTypography: GroupElementTypography,
@@ -348,7 +348,7 @@ public class FeatureFormTypography internal constructor(
  * @since 200.5.0
  */
 @Immutable
-public data class EditableTextFieldTypography internal constructor(
+public data class EditableTextFieldTypography(
     public val labelStyle: TextStyle,
     public val textStyle: TextStyle,
     public val supportingTextStyle: TextStyle
@@ -366,7 +366,7 @@ public data class EditableTextFieldTypography internal constructor(
  * @since 200.5.0
  */
 @Immutable
-public data class ReadOnlyFieldTypography internal constructor(
+public data class ReadOnlyFieldTypography(
     public val labelStyle: TextStyle,
     public val textStyle: TextStyle,
     public val supportingTextStyle: TextStyle
@@ -382,7 +382,7 @@ public data class ReadOnlyFieldTypography internal constructor(
  * @since 200.5.0
  */
 @Immutable
-public data class GroupElementTypography internal constructor(
+public data class GroupElementTypography(
     public val labelStyle: TextStyle,
     public val supportingTextStyle: TextStyle
 )
@@ -398,7 +398,7 @@ public data class GroupElementTypography internal constructor(
  * @since 200.5.0
  */
 @Immutable
-public data class RadioButtonFieldTypography internal constructor(
+public data class RadioButtonFieldTypography(
     public val labelStyle: TextStyle,
     public val optionStyle: TextStyle,
     public val supportingTextStyle: TextStyle
@@ -415,7 +415,7 @@ public data class RadioButtonFieldTypography internal constructor(
  * @property tileTextStyle The style for the text of an individual attachment tile.
  * @since 200.5.0
  */
-public data class AttachmentsElementTypography internal constructor(
+public data class AttachmentsElementTypography(
     public val labelStyle: TextStyle,
     public val supportingTextStyle: TextStyle,
     public val tileTextStyle: TextStyle,


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/951](https://devtopia.esri.com/runtime/apollo/issues/951)

<!-- link to design, if applicable -->

### Description:

Fixes lint warnings for :featureforms module.

### Summary of changes:

- Fixes the warning "**_Non-public primary constructor is exposed via the generated 'copy()' method of the 'data' class._**" for all the colors and typography classes. This will turn into an error in kotlin 2.1.
    - The constructor is now public which fixes the warning. There was no real need for the constructors of these classes to be internal. 
    - Google has also done the same for their themed classes [here](https://android-review.googlesource.com/c/platform/frameworks/support/+/2612175).
- Updated the `featureforms.api`.
- Updated the deprecated `kotlinOptions` to `compilerOptions`. See [kotlin doc](https://kotlinlang.org/docs/gradle-compiler-options.html#how-to-define-options).

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/182/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  