### PR TITLE
Depend on daily/dev builds of Maps SDK 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,9 +44,10 @@ artifactoryGroupId=com.esri
 artifactoryArtifactBaseId=arcgis-maps-kotlin-toolkit
 artifactoryUsername=""
 artifactoryPassword=""
-# these versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
-# and are generally not overridden at the command line unless a special build is requested.
-# A final build before release is such a special build, in which case these SDK version numbers
-# are overridden via command line, see sdkVersionNumber in settings.gradle.kts.
+
+# These versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
+# when building the toolkit locally, typically from Android Studio. When building the toolkit
+# with CI, these versions are obtained from command line provided properties, see sdkVersionNumber
+# in settings.gradle.kts.
 sdkVersionNumber=200.6.0
 sdkBuildNumber=4399

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ val finalBuild: Boolean = (providers.gradleProperty("finalBuild").orNull ?: "fal
 // The version of the ArcGIS Maps SDK for Kotlin dependency.
 // First look for the version number provided via command line (for CI builds), if not found,
 // take the one defined in gradle.properties.
+// CI builds pass -PversionNumber=${BUILDVER}
 val sdkVersionNumber: String =
     providers.gradleProperty("versionNumber").orNull
         ?: providers.gradleProperty("sdkVersionNumber").orNull
@@ -39,6 +40,7 @@ val sdkVersionNumber: String =
 // The build number of the ArcGIS Maps SDK for Kotlin dependency.
 // First look for the version number provided via command line (for CI builds), if not found,
 // take the one defined in gradle.properties.
+// CI builds pass -PbuildNumber=${BUILDNUM}
 val sdkBuildNumber: String =
     providers.gradleProperty("buildNumber").orNull
         ?: providers.gradleProperty("sdkBuildNumber").orNull

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,21 +32,17 @@ val finalBuild: Boolean = (providers.gradleProperty("finalBuild").orNull ?: "fal
 // First look for the version number provided via command line (for CI builds), if not found,
 // take the one defined in gradle.properties.
 val sdkVersionNumber: String =
-    providers.gradleProperty("versionNumber").orNull?.let { versionFromCommandLine ->
-        versionFromCommandLine
-    } ?: providers.gradleProperty("sdkVersionNumber").orNull?.let { versionFromFile ->
-        versionFromFile
-    } ?: throw IllegalStateException("sdkVersionNumber must be set either via command line or in gradle.properties")
+    providers.gradleProperty("versionNumber").orNull
+        ?: providers.gradleProperty("sdkVersionNumber").orNull
+        ?: throw IllegalStateException("sdkVersionNumber must be set either via command line or in gradle.properties")
 
 // The build number of the ArcGIS Maps SDK for Kotlin dependency.
 // First look for the version number provided via command line (for CI builds), if not found,
 // take the one defined in gradle.properties.
 val sdkBuildNumber: String =
-    providers.gradleProperty("buildNumber").orNull?.let { versionFromCommandLine ->
-        versionFromCommandLine
-    } ?: providers.gradleProperty("sdkBuildNumber").orNull?.let { versionFromFile ->
-        versionFromFile
-    } ?: throw IllegalStateException("sdkBuildNumber must be set either via command line or in gradle.properties")
+    providers.gradleProperty("buildNumber").orNull
+        ?: providers.gradleProperty("sdkBuildNumber").orNull
+        ?: throw IllegalStateException("sdkBuildNumber must be set either via command line or in gradle.properties")
 
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -73,7 +73,7 @@ dependencyResolutionManagement {
                 )
                 sdkVersionNumber
             } else {
-                logger.info("Maps SDK dependency: $sdkVersionNumber-$sdkBuildNumber")
+                logger.warn("Maps SDK dependency: $sdkVersionNumber-$sdkBuildNumber")
                 "$sdkVersionNumber-$sdkBuildNumber"
             }
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/4771

<!-- link to design, if applicable -->

### Description:

Changes to gradle scripts to depend on the latest MapsSDK version as part of every CI build. For local builds (from Android Studio), the Maps SDK version is still determined from `gradle.properties`.

### Summary of changes:
In `settings.gradle.kts` changed initialization of `sdkVersionNumber` and `sdkBuildNumber` to prioritise versions provided via command line. If these don't exist, fall back to versions in `gradle.properties`.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/187/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  