### PR TITLE
Tabletop - disable navigation

### DIFF
--- a/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/screens/MainScreen.kt
+++ b/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/screens/MainScreen.kt
@@ -66,15 +66,6 @@ fun MainScreen() {
             }
         }
     }
-    // disable pan/zoom/rotate interaction. These interactions can behave unexpectedly in TableTop scenarios
-    val interactionOptions = remember {
-        SceneViewInteractionOptions().apply {
-            this.isPanEnabled = false
-            this.isZoomEnabled = false
-            this.isRotateEnabled = false
-            this.isFlingEnabled = false
-        }
-    }
     val tableTopSceneViewProxy = remember { TableTopSceneViewProxy() }
     var tappedLocation by remember { mutableStateOf<Point?>(null) }
     var initializationStatus: TableTopSceneViewStatus by rememberTableTopSceneViewStatus()
@@ -89,7 +80,6 @@ fun MainScreen() {
             modifier = Modifier.fillMaxSize(),
             clippingDistance = 400.0,
             tableTopSceneViewProxy = tableTopSceneViewProxy,
-            sceneViewInteractionOptions = interactionOptions,
             onInitializationStatusChanged = {
                 initializationStatus = it
             },

--- a/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/screens/MainScreen.kt
+++ b/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/screens/MainScreen.kt
@@ -39,11 +39,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arcgismaps.LoadStatus
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.mapping.ArcGISScene
-import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.mapping.ElevationSource
 import com.arcgismaps.mapping.Surface
 import com.arcgismaps.mapping.layers.ArcGISSceneLayer
-import com.arcgismaps.mapping.view.SceneViewInteractionOptions
 import com.arcgismaps.toolkit.ar.TableTopSceneView
 import com.arcgismaps.toolkit.ar.TableTopSceneViewProxy
 import com.arcgismaps.toolkit.ar.TableTopSceneViewStatus

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneView.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneView.kt
@@ -105,7 +105,6 @@ import kotlin.coroutines.resume
  * type of [ViewpointType.BoundingGeometry]
  * @param graphicsOverlays graphics overlays used by this TableTopSceneView
  * @param tableTopSceneViewProxy the [TableTopSceneViewProxy] to associate with the TableTopSceneView
- * @param sceneViewInteractionOptions the [SceneViewInteractionOptions] used by this TableTopSceneView
  * @param viewLabelProperties the [ViewLabelProperties] used by the TableTopSceneView
  * @param selectionProperties the [SelectionProperties] used by the TableTopSceneView
  * @param isAttributionBarVisible true if attribution bar is visible in the TableTopSceneView, false otherwise
@@ -150,7 +149,6 @@ public fun TableTopSceneView(
     onViewpointChangedForBoundingGeometry: ((Viewpoint) -> Unit)? = null,
     graphicsOverlays: List<GraphicsOverlay> = remember { emptyList() },
     tableTopSceneViewProxy: TableTopSceneViewProxy = remember { TableTopSceneViewProxy() },
-    sceneViewInteractionOptions: SceneViewInteractionOptions = remember { SceneViewInteractionOptions() },
     viewLabelProperties: ViewLabelProperties = remember { ViewLabelProperties() },
     selectionProperties: SelectionProperties = remember { SelectionProperties() },
     isAttributionBarVisible: Boolean = true,
@@ -295,6 +293,12 @@ public fun TableTopSceneView(
             )
         }
         if (initializationStatus.value == TableTopSceneViewStatus.Initialized && arCoreAnchor != null) {
+            // Disable interaction, which is not supported in TableTop scenarios
+            val interactionOptions = remember {
+                SceneViewInteractionOptions().apply {
+                    this.isEnabled = false
+                }
+            }
             SceneView(
                 arcGISScene = arcGISScene,
                 modifier = Modifier.fillMaxSize(),
@@ -302,7 +306,7 @@ public fun TableTopSceneView(
                 onViewpointChangedForBoundingGeometry = onViewpointChangedForBoundingGeometry,
                 graphicsOverlays = graphicsOverlays,
                 sceneViewProxy = tableTopSceneViewProxy.sceneViewProxy,
-                sceneViewInteractionOptions = sceneViewInteractionOptions,
+                sceneViewInteractionOptions = interactionOptions,
                 viewLabelProperties = viewLabelProperties,
                 selectionProperties = selectionProperties,
                 isAttributionBarVisible = isAttributionBarVisible,

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneViewProxy.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneViewProxy.kt
@@ -224,39 +224,6 @@ public class TableTopSceneViewProxy internal constructor(internal val sceneViewP
         sceneViewProxy.identifyLayers(screenCoordinate, tolerance, returnPopupsOnly, maximumResults)
 
     /**
-     * Animate the TableTopSceneView's viewpoint to the viewpoint of the bookmark.
-     *
-     * @param bookmark bookmark to set
-     * @return a [Result] indicating whether the viewpoint was successfully set.
-     * A success result with a value of false may indicate the operation was cancelled.
-     * @since 200.6.0
-     */
-    public suspend fun setBookmark(bookmark: Bookmark): Result<Boolean> =
-        sceneViewProxy.setBookmark(bookmark)
-
-    /**
-     * Change the TableTopSceneView to the new viewpoint. The viewpoint is updated instantaneously.
-     *
-     * @param viewpoint the new viewpoint
-     * @since 200.6.0
-     */
-    public fun setViewpoint(viewpoint: Viewpoint): Unit = sceneViewProxy.setViewpoint(viewpoint)
-
-    /**
-     * Animate the TableTopSceneView to the new viewpoint, taking the given duration to complete the navigation.
-     *
-     * @param viewpoint the new viewpoint
-     * @param duration the duration of the animation
-     * @return a [Result] indicating whether the viewpoint was successfully set.
-     * A success result with a value of false may indicate the operation was cancelled.
-     * @since 200.6.0
-     */
-    public suspend fun setViewpointAnimated(
-        viewpoint: Viewpoint,
-        duration: Duration = 0.25.seconds
-    ): Result<Boolean> = sceneViewProxy.setViewpointAnimated(viewpoint, duration)
-
-    /**
      * Retrieve the layer's [LayerViewState].
      *
      * @param layer the layer to retrieve the view state from
@@ -342,27 +309,4 @@ public class TableTopSceneViewProxy internal constructor(internal val sceneViewP
      */
     public val fieldOfViewDistortionRatio: Double?
         get() = sceneViewProxy.fieldOfViewDistortionRatio
-
-    /**
-     * Change the TableTopSceneView to the viewpoint specified by the given camera.
-     * The viewpoint is updated instantaneously.
-     *
-     * @param camera the new camera
-     * @since 200.6.0
-     */
-    public fun setViewpointCamera(camera: Camera): Unit = sceneViewProxy.setViewpointCamera(camera)
-
-    /**
-     * Animate the TableTopSceneView to the viewpoint specified by the given camera using the specified duration.
-     *
-     * @param camera the new camera
-     * @param duration the duration of the animation
-     * @return a [Result] indicating whether the viewpoint was successfully set.
-     * A success result with a value of false may indicate the operation was cancelled.
-     * @since 200.6.0
-     */
-    public suspend fun setViewpointCameraAnimated(
-        camera: Camera,
-        duration: Duration = 0.25.seconds
-    ): Result<Boolean> = sceneViewProxy.setViewpointCameraAnimated(camera, duration)
 }

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneViewProxy.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneViewProxy.kt
@@ -22,10 +22,7 @@ import android.graphics.drawable.BitmapDrawable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.unit.Dp
 import com.arcgismaps.geometry.Point
-import com.arcgismaps.mapping.Bookmark
-import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.mapping.layers.Layer
-import com.arcgismaps.mapping.view.Camera
 import com.arcgismaps.mapping.view.DrawStatus
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.arcgismaps.mapping.view.IdentifyGraphicsOverlayResult
@@ -34,8 +31,6 @@ import com.arcgismaps.mapping.view.LayerViewState
 import com.arcgismaps.mapping.view.LocationToScreenResult
 import com.arcgismaps.mapping.view.ScreenCoordinate
 import com.arcgismaps.toolkit.geoviewcompose.SceneViewProxy
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Used to perform operations on a [TableTopSceneView].


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/4934

<!-- link to design, if applicable -->

### Description:

Disables interactive and programmatic SceneView navigation, since in a TableTop scenario the scene view camera is fully controlled by the position and orientation of the device.

### Summary of changes:
- removed `sceneViewInteractionOptions` parameter from TableTopSceneView
- disable interaction internally in TableTopSceneView
- remove all functions from TableTopSceneViewProxy that can change the camera:
   - setViewpoint
   - setViewpointAnimated
   - setBookmark
   - setViewpointCamera
   - setViewpointCameraAnimated

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/196/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  