### PR TITLE
`Forms`: Adjust FeatureForm parameters

### DIFF
--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -1,7 +1,7 @@
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormKt {
 	public static final synthetic fun FeatureForm (Lcom/arcgismaps/mapping/featureforms/FeatureForm;Landroidx/compose/ui/Modifier;Lcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility;Landroidx/compose/runtime/Composer;II)V
 	public static final synthetic fun FeatureForm (Lcom/arcgismaps/mapping/featureforms/FeatureForm;Landroidx/compose/ui/Modifier;Lcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormColorScheme;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;Landroidx/compose/runtime/Composer;II)V
-	public static final fun FeatureForm (Lcom/arcgismaps/mapping/featureforms/FeatureForm;Landroidx/compose/ui/Modifier;Lcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormColorScheme;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun FeatureForm (Lcom/arcgismaps/mapping/featureforms/FeatureForm;Landroidx/compose/ui/Modifier;Lcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormColorScheme;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;Landroidx/compose/runtime/Composer;II)V
 }
 
 public abstract class com/arcgismaps/toolkit/featureforms/ValidationErrorVisibility {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -197,11 +197,11 @@ public fun FeatureForm(
  * @param validationErrorVisibility The [ValidationErrorVisibility] that determines the behavior of
  * when the validation errors are visible. Default is [ValidationErrorVisibility.Automatic] which
  * indicates errors are only visible once the respective field gains focus.
- * @param colorScheme The [FeatureFormColorScheme] to use for the FeatureForm.
- * @param typography The [FeatureFormTypography] to use for the FeatureForm.
  * @param onBarcodeButtonClick A callback that is invoked when the barcode accessory is clicked.
  * The callback is invoked with the [FieldFormElement] that has the barcode accessory. If null, the
  * default barcode scanner is used.
+ * @param colorScheme The [FeatureFormColorScheme] to use for the FeatureForm.
+ * @param typography The [FeatureFormTypography] to use for the FeatureForm.
  *
  * @since 200.4.0
  */
@@ -210,9 +210,9 @@ public fun FeatureForm(
     featureForm: FeatureForm,
     modifier: Modifier = Modifier,
     validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.Automatic,
+    onBarcodeButtonClick: ((FieldFormElement) -> Unit)? = null,
     colorScheme: FeatureFormColorScheme = FeatureFormDefaults.colorScheme(),
     typography: FeatureFormTypography = FeatureFormDefaults.typography(),
-    onBarcodeButtonClick: ((FieldFormElement) -> Unit)? = null
 ) {
     val stateData = remember(featureForm) {
         StateData(featureForm)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -513,7 +513,7 @@ internal fun Modifier.horizontalScrollbar(
 ): Modifier = this
     .padding(bottom = offsetY)
     .then(
-        composed {
+        this.composed {
             // fade in fast when scrolling, fade out slow when not scrolling
             val duration = if (state.isScrollInProgress) 50 else 500
             // animate the scrollbar alpha based on the scroll state


### PR DESCRIPTION
### Summary of changes:

- Fixes the order of the parameters in the `FeatureForm` by moving the `onBarcodeButtonClicked` parameter to not be the last parameter. This change is necessary because it can be misleading as it is a user expectation to have a trailing lambda in a component to be `@Composable`.
- Updated api dump.
- Fixed a warning with the use of the `composed` modifier, where the reference `this` is required.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/201/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  