### PR TITLE
api files

### DIFF
--- a/toolkit/authentication/api/authentication.api
+++ b/toolkit/authentication/api/authentication.api
@@ -1,0 +1,81 @@
+public final class com/arcgismaps/toolkit/authentication/AuthenticatorKt {
+	public static final fun Authenticator (Lcom/arcgismaps/toolkit/authentication/AuthenticatorState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun DialogAuthenticator (Lcom/arcgismaps/toolkit/authentication/AuthenticatorState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+}
+
+public abstract interface class com/arcgismaps/toolkit/authentication/AuthenticatorState : com/arcgismaps/httpcore/authentication/ArcGISAuthenticationChallengeHandler, com/arcgismaps/httpcore/authentication/NetworkAuthenticationChallengeHandler {
+	public abstract fun dismissAll ()V
+	public abstract fun getOAuthUserConfiguration ()Lcom/arcgismaps/httpcore/authentication/OAuthUserConfiguration;
+	public abstract fun getPendingClientCertificateChallenge ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPendingOAuthUserSignIn ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPendingServerTrustChallenge ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPendingUsernamePasswordChallenge ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isDisplayed ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun setOAuthUserConfiguration (Lcom/arcgismaps/httpcore/authentication/OAuthUserConfiguration;)V
+}
+
+public final class com/arcgismaps/toolkit/authentication/AuthenticatorStateKt {
+	public static final fun AuthenticatorState (ZZ)Lcom/arcgismaps/toolkit/authentication/AuthenticatorState;
+	public static synthetic fun AuthenticatorState$default (ZZILjava/lang/Object;)Lcom/arcgismaps/toolkit/authentication/AuthenticatorState;
+	public static final fun completeOAuthSignIn (Lcom/arcgismaps/toolkit/authentication/AuthenticatorState;Landroid/content/Intent;)V
+}
+
+public final class com/arcgismaps/toolkit/authentication/ClientCertificateChallenge {
+	public static final field $stable I
+	public fun <init> (Landroid/security/KeyChainAliasCallback;Lkotlin/jvm/functions/Function0;)V
+	public final fun component1 ()Landroid/security/KeyChainAliasCallback;
+	public final fun component2 ()Lkotlin/jvm/functions/Function0;
+	public final fun copy (Landroid/security/KeyChainAliasCallback;Lkotlin/jvm/functions/Function0;)Lcom/arcgismaps/toolkit/authentication/ClientCertificateChallenge;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/authentication/ClientCertificateChallenge;Landroid/security/KeyChainAliasCallback;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/authentication/ClientCertificateChallenge;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyChainAliasCallback ()Landroid/security/KeyChainAliasCallback;
+	public final fun getOnCancel ()Lkotlin/jvm/functions/Function0;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/authentication/ExtensionsKt {
+	public static final fun launchCustomTabs (Landroid/app/Activity;Lcom/arcgismaps/httpcore/authentication/OAuthUserSignIn;)V
+	public static final fun signOut (Lcom/arcgismaps/httpcore/authentication/AuthenticationManager;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/arcgismaps/toolkit/authentication/OAuthUserSignInActivity : androidx/activity/ComponentActivity {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun handleRedirectIntent (Landroid/content/Intent;)V
+	public fun onCreate (Landroid/os/Bundle;)V
+	public fun onWindowFocusChanged (Z)V
+}
+
+public final class com/arcgismaps/toolkit/authentication/OAuthUserSignInActivity$Contract : androidx/activity/result/contract/ActivityResultContract {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun createIntent (Landroid/content/Context;Lcom/arcgismaps/httpcore/authentication/OAuthUserSignIn;)Landroid/content/Intent;
+	public synthetic fun createIntent (Landroid/content/Context;Ljava/lang/Object;)Landroid/content/Intent;
+	public synthetic fun parseResult (ILandroid/content/Intent;)Ljava/lang/Object;
+	public fun parseResult (ILandroid/content/Intent;)Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/authentication/ServerTrustChallenge {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/httpcore/authentication/NetworkAuthenticationChallenge;Lkotlin/jvm/functions/Function1;)V
+	public final fun distrust ()V
+	public final fun getChallenge ()Lcom/arcgismaps/httpcore/authentication/NetworkAuthenticationChallenge;
+	public final fun trust ()V
+}
+
+public final class com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticatorKt {
+	public static final fun UsernamePasswordAuthenticator (Lcom/arcgismaps/toolkit/authentication/UsernamePasswordChallenge;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;)V
+	public final fun cancel ()V
+	public final fun continueWithCredentials (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getAdditionalMessage ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun getHostname ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public final fun setAdditionalMessage (Ljava/lang/String;)V
+}
+

--- a/toolkit/authentication/build.gradle.kts
+++ b/toolkit/authentication/build.gradle.kts
@@ -78,6 +78,19 @@ android {
     }
 }
 
+apiValidation {
+    ignoredClasses.add("com.arcgismaps.toolkit.featureforms.BuildConfig")
+    // todo: remove when this is resolved https://github.com/Kotlin/binary-compatibility-validator/issues/74
+    // compose compiler generates public singletons for internal compose functions. this may be resolved in the compose
+    // compiler.
+    val composableSingletons = listOf(
+        "com.arcgismaps.toolkit.authentication.ComposableSingletons\$ServerTrustAuthenticatorKt",
+        "com.arcgismaps.toolkit.authentication.ComposableSingletons\$UsernamePasswordAuthenticatorKt"
+    )
+
+    ignoredClasses.addAll(composableSingletons)
+}
+
 dependencies {
     api(arcgis.mapsSdk)
     implementation(platform(libs.androidx.compose.bom))

--- a/toolkit/authentication/build.gradle.kts
+++ b/toolkit/authentication/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("artifact-deploy")
+    alias(libs.plugins.binary.compatibility.validator) apply true
 }
 
 android {

--- a/toolkit/compass/api/compass.api
+++ b/toolkit/compass/api/compass.api
@@ -1,0 +1,4 @@
+public final class com/arcgismaps/toolkit/compass/CompassKt {
+	public static final fun Compass-83Szm6w (DLandroidx/compose/ui/Modifier;ZFJJLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/toolkit/compass/build.gradle.kts
+++ b/toolkit/compass/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("artifact-deploy")
+    alias(libs.plugins.binary.compatibility.validator) apply true
 }
 
 android {

--- a/toolkit/geoview-compose/api/geoview-compose.api
+++ b/toolkit/geoview-compose/api/geoview-compose.api
@@ -1,0 +1,177 @@
+public abstract class com/arcgismaps/toolkit/geoviewcompose/GeoViewProxy {
+	public static final field $stable I
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun exportImage-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLayerViewState (Lcom/arcgismaps/mapping/layers/Layer;)Lcom/arcgismaps/mapping/view/LayerViewState;
+	protected final fun getNullGeoViewErrorMessage ()Ljava/lang/String;
+	public final fun identify-ZFpZYwg (Lcom/arcgismaps/mapping/layers/Layer;Lcom/arcgismaps/mapping/view/DoubleXY;FZLjava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun identify-ZFpZYwg (Lcom/arcgismaps/mapping/view/GraphicsOverlay;Lcom/arcgismaps/mapping/view/DoubleXY;FZLjava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun identify-ZFpZYwg$default (Lcom/arcgismaps/toolkit/geoviewcompose/GeoViewProxy;Lcom/arcgismaps/mapping/layers/Layer;Lcom/arcgismaps/mapping/view/DoubleXY;FZLjava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun identify-ZFpZYwg$default (Lcom/arcgismaps/toolkit/geoviewcompose/GeoViewProxy;Lcom/arcgismaps/mapping/view/GraphicsOverlay;Lcom/arcgismaps/mapping/view/DoubleXY;FZLjava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun identifyGraphicsOverlays-GOOf7xI (Lcom/arcgismaps/mapping/view/DoubleXY;FZLjava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun identifyGraphicsOverlays-GOOf7xI$default (Lcom/arcgismaps/toolkit/geoviewcompose/GeoViewProxy;Lcom/arcgismaps/mapping/view/DoubleXY;FZLjava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun identifyLayers-GOOf7xI (Lcom/arcgismaps/mapping/view/DoubleXY;FZLjava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun identifyLayers-GOOf7xI$default (Lcom/arcgismaps/toolkit/geoviewcompose/GeoViewProxy;Lcom/arcgismaps/mapping/view/DoubleXY;FZLjava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun isWrapAroundEnabled ()Ljava/lang/Boolean;
+	public final fun setBookmark-gIAlu-s (Lcom/arcgismaps/mapping/Bookmark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun setGeoView (Lcom/arcgismaps/mapping/view/GeoView;)V
+	public final fun setViewpoint (Lcom/arcgismaps/mapping/Viewpoint;)V
+	public final fun setViewpointAnimated-BlKvXls (Lcom/arcgismaps/mapping/Viewpoint;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun setViewpointAnimated-BlKvXls$default (Lcom/arcgismaps/toolkit/geoviewcompose/GeoViewProxy;Lcom/arcgismaps/mapping/Viewpoint;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class com/arcgismaps/toolkit/geoviewcompose/GeoViewScope {
+	public static final field $stable I
+	public synthetic fun <init> (Lcom/arcgismaps/mapping/view/GeoView;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun Callout (Lcom/arcgismaps/mapping/GeoElement;Landroidx/compose/ui/Modifier;Lcom/arcgismaps/geometry/Point;Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutColors;Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutShapes;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public final fun Callout-jHo2IpA (Lcom/arcgismaps/geometry/Point;Landroidx/compose/ui/Modifier;JZLcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutColors;Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutShapes;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/MapViewDefaults {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/geoviewcompose/MapViewDefaults;
+	public final fun getDefaultInsets ()Landroidx/compose/foundation/layout/PaddingValues;
+	public final fun getDefaultViewpointPersistence ()Lcom/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence;
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/MapViewKt {
+	public static final fun MapView (Lcom/arcgismaps/mapping/ArcGISMap;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence;Ljava/util/List;Lcom/arcgismaps/mapping/view/LocationDisplay;Lcom/arcgismaps/mapping/view/geometryeditor/GeometryEditor;Lcom/arcgismaps/toolkit/geoviewcompose/MapViewProxy;Lcom/arcgismaps/mapping/view/MapViewInteractionOptions;Lcom/arcgismaps/mapping/view/ViewLabelProperties;Lcom/arcgismaps/mapping/view/SelectionProperties;Landroidx/compose/foundation/layout/PaddingValues;Lcom/arcgismaps/mapping/view/Grid;Lcom/arcgismaps/mapping/view/BackgroundGrid;Lcom/arcgismaps/mapping/view/WrapAroundMode;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/mapping/TimeExtent;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;IIIIII)V
+	public static final fun rememberLocationDisplay (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/arcgismaps/mapping/view/LocationDisplay;
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/MapViewProxy : com/arcgismaps/toolkit/geoviewcompose/GeoViewProxy {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun locationToScreenOrNull (Lcom/arcgismaps/geometry/Point;)Lcom/arcgismaps/mapping/view/DoubleXY;
+	public final fun screenToLocationOrNull (Lcom/arcgismaps/mapping/view/DoubleXY;)Lcom/arcgismaps/geometry/Point;
+	public final fun setViewpointAnimated-JXpvp54 (Lcom/arcgismaps/mapping/Viewpoint;JLcom/arcgismaps/mapping/view/AnimationCurve;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setViewpointCenter-0E7RQCE (Lcom/arcgismaps/geometry/Point;Ljava/lang/Double;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun setViewpointCenter-0E7RQCE$default (Lcom/arcgismaps/toolkit/geoviewcompose/MapViewProxy;Lcom/arcgismaps/geometry/Point;Ljava/lang/Double;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun setViewpointGeometry-0E7RQCE (Lcom/arcgismaps/geometry/Geometry;Ljava/lang/Double;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun setViewpointGeometry-0E7RQCE$default (Lcom/arcgismaps/toolkit/geoviewcompose/MapViewProxy;Lcom/arcgismaps/geometry/Geometry;Ljava/lang/Double;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun setViewpointRotation-gIAlu-s (DLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setViewpointScale-gIAlu-s (DLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/MapViewScope : com/arcgismaps/toolkit/geoviewcompose/GeoViewScope {
+	public static final field $stable I
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/SceneViewDefaults {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/geoviewcompose/SceneViewDefaults;
+	public final fun getDefaultAmbientLightColor-0d7_KjU ()J
+	public final fun getDefaultSunTime ()Ljava/time/Instant;
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/SceneViewKt {
+	public static final fun SceneView-DjQMdAY (Lcom/arcgismaps/mapping/ArcGISScene;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/util/List;Lcom/arcgismaps/toolkit/geoviewcompose/SceneViewProxy;Lcom/arcgismaps/mapping/view/SceneViewInteractionOptions;Lcom/arcgismaps/mapping/view/ViewLabelProperties;Lcom/arcgismaps/mapping/view/SelectionProperties;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/mapping/view/CameraController;Ljava/util/List;Ljava/util/List;Lcom/arcgismaps/mapping/view/AtmosphereEffect;Lcom/arcgismaps/mapping/TimeExtent;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/mapping/view/SpaceEffect;Ljava/time/Instant;Lcom/arcgismaps/mapping/view/LightingMode;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;IIIIII)V
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/SceneViewProxy : com/arcgismaps/toolkit/geoviewcompose/GeoViewProxy {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun getFieldOfView ()Ljava/lang/Double;
+	public final fun getFieldOfViewDistortionRatio ()Ljava/lang/Double;
+	public final fun isManualRenderingEnabled ()Z
+	public final fun locationToScreen (Lcom/arcgismaps/geometry/Point;)Lcom/arcgismaps/mapping/view/LocationToScreenResult;
+	public final fun renderFrame ()V
+	public final fun screenToBaseSurface (Lcom/arcgismaps/mapping/view/DoubleXY;)Lcom/arcgismaps/geometry/Point;
+	public final fun screenToLocation-gIAlu-s (Lcom/arcgismaps/mapping/view/DoubleXY;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setFieldOfView (DD)V
+	public static synthetic fun setFieldOfView$default (Lcom/arcgismaps/toolkit/geoviewcompose/SceneViewProxy;DDILjava/lang/Object;)V
+	public final fun setFieldOfViewFromLensIntrinsics (FFFFFFLcom/arcgismaps/mapping/view/DeviceOrientation;)V
+	public final fun setManualRenderingEnabled (Z)V
+	public final fun setViewpointCamera (Lcom/arcgismaps/mapping/view/Camera;)V
+	public final fun setViewpointCameraAnimated-BlKvXls (Lcom/arcgismaps/mapping/view/Camera;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun setViewpointCameraAnimated-BlKvXls$default (Lcom/arcgismaps/toolkit/geoviewcompose/SceneViewProxy;Lcom/arcgismaps/mapping/view/Camera;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/SceneViewScope : com/arcgismaps/toolkit/geoviewcompose/GeoViewScope {
+	public static final field $stable I
+}
+
+public abstract class com/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence : android/os/Parcelable {
+	public static final field $stable I
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence$ByBoundingGeometry : com/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence$ByBoundingGeometry$Companion;
+	public fun <init> ()V
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence$ByBoundingGeometry$Companion {
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence$ByCenterAndScale : com/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence$ByCenterAndScale$Companion;
+	public fun <init> ()V
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence$ByCenterAndScale$Companion {
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence$None : com/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/geoviewcompose/ViewpointPersistence$None;
+	public fun describeContents ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/samples/GeoViewDocSamplesKt {
+	public static final fun MapViewSample (Landroidx/compose/runtime/Composer;I)V
+	public static final fun SceneViewSample (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/theme/CalloutColors {
+	public static final field $stable I
+	public final fun component1-0d7_KjU ()J
+	public final fun component2-0d7_KjU ()J
+	public final fun copy--OWjLjI (JJ)Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutColors;
+	public static synthetic fun copy--OWjLjI$default (Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutColors;JJILjava/lang/Object;)Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutColors;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundColor-0d7_KjU ()J
+	public final fun getBorderColor-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/theme/CalloutDefaults {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutDefaults;
+	public final fun colors-dgg9oW8 (JJLandroidx/compose/runtime/Composer;II)Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutColors;
+	public final fun shapes-ylViP9c (FFJLandroidx/compose/foundation/layout/PaddingValues;JLandroidx/compose/runtime/Composer;II)Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutShapes;
+}
+
+public final class com/arcgismaps/toolkit/geoviewcompose/theme/CalloutShapes {
+	public static final field $stable I
+	public final fun component1-D9Ej5fM ()F
+	public final fun component2-MYxV2XQ ()J
+	public final fun component3-D9Ej5fM ()F
+	public final fun component4 ()Landroidx/compose/foundation/layout/PaddingValues;
+	public final fun component5-MYxV2XQ ()J
+	public final fun copy-S84Tz1Y (FJFLandroidx/compose/foundation/layout/PaddingValues;J)Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutShapes;
+	public static synthetic fun copy-S84Tz1Y$default (Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutShapes;FJFLandroidx/compose/foundation/layout/PaddingValues;JILjava/lang/Object;)Lcom/arcgismaps/toolkit/geoviewcompose/theme/CalloutShapes;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBorderWidth-D9Ej5fM ()F
+	public final fun getCalloutContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public final fun getCornerRadius-D9Ej5fM ()F
+	public final fun getLeaderSize-MYxV2XQ ()J
+	public final fun getMinSize-MYxV2XQ ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/toolkit/geoview-compose/build.gradle.kts
+++ b/toolkit/geoview-compose/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("artifact-deploy")
+    alias(libs.plugins.binary.compatibility.validator) apply true
 }
 
 android {

--- a/toolkit/indoors/api/indoors.api
+++ b/toolkit/indoors/api/indoors.api
@@ -1,0 +1,130 @@
+public final class com/arcgismaps/toolkit/indoors/ButtonPosition : java/lang/Enum {
+	public static final field Bottom Lcom/arcgismaps/toolkit/indoors/ButtonPosition;
+	public static final field Top Lcom/arcgismaps/toolkit/indoors/ButtonPosition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/arcgismaps/toolkit/indoors/ButtonPosition;
+	public static fun values ()[Lcom/arcgismaps/toolkit/indoors/ButtonPosition;
+}
+
+public final class com/arcgismaps/toolkit/indoors/FloorFilterKt {
+	public static final fun FloorFilter (Lcom/arcgismaps/toolkit/indoors/FloorFilterState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/arcgismaps/toolkit/indoors/FloorFilterSelection {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type;)V
+	public final fun component1 ()Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type;
+	public final fun copy (Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type;)Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection;Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getType ()Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/arcgismaps/toolkit/indoors/FloorFilterSelection$Type {
+	public static final field $stable I
+}
+
+public final class com/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorFacility : com/arcgismaps/toolkit/indoors/FloorFilterSelection$Type {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/floor/FloorFacility;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/floor/FloorFacility;
+	public final fun copy (Lcom/arcgismaps/mapping/floor/FloorFacility;)Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorFacility;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorFacility;Lcom/arcgismaps/mapping/floor/FloorFacility;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorFacility;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFacility ()Lcom/arcgismaps/mapping/floor/FloorFacility;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorLevel : com/arcgismaps/toolkit/indoors/FloorFilterSelection$Type {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/floor/FloorLevel;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/floor/FloorLevel;
+	public final fun copy (Lcom/arcgismaps/mapping/floor/FloorLevel;)Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorLevel;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorLevel;Lcom/arcgismaps/mapping/floor/FloorLevel;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorLevel;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLevel ()Lcom/arcgismaps/mapping/floor/FloorLevel;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorSite : com/arcgismaps/toolkit/indoors/FloorFilterSelection$Type {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/floor/FloorSite;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/floor/FloorSite;
+	public final fun copy (Lcom/arcgismaps/mapping/floor/FloorSite;)Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorSite;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorSite;Lcom/arcgismaps/mapping/floor/FloorSite;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/indoors/FloorFilterSelection$Type$FloorSite;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSite ()Lcom/arcgismaps/mapping/floor/FloorSite;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/arcgismaps/toolkit/indoors/FloorFilterState {
+	public abstract fun getFacilities ()Ljava/util/List;
+	public abstract fun getFloorManager ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getOnFacilityChanged ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getOnLevelChanged ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getSelectedFacility ()Lcom/arcgismaps/mapping/floor/FloorFacility;
+	public abstract fun getSelectedFacilityId ()Ljava/lang/String;
+	public abstract fun getSelectedLevelId ()Ljava/lang/String;
+	public abstract fun getSelectedSite ()Lcom/arcgismaps/mapping/floor/FloorSite;
+	public abstract fun getSelectedSiteId ()Ljava/lang/String;
+	public abstract fun getSites ()Ljava/util/List;
+	public abstract fun getUiProperties ()Lcom/arcgismaps/toolkit/indoors/UIProperties;
+	public abstract fun setSelectedFacilityId (Ljava/lang/String;)V
+	public abstract fun setSelectedLevelId (Ljava/lang/String;)V
+	public abstract fun setSelectedSiteId (Ljava/lang/String;)V
+}
+
+public final class com/arcgismaps/toolkit/indoors/FloorFilterStateKt {
+	public static final fun FloorFilterState (Lcom/arcgismaps/mapping/GeoModel;Lkotlinx/coroutines/CoroutineScope;Lcom/arcgismaps/toolkit/indoors/UIProperties;Lkotlin/jvm/functions/Function1;)Lcom/arcgismaps/toolkit/indoors/FloorFilterState;
+	public static synthetic fun FloorFilterState$default (Lcom/arcgismaps/mapping/GeoModel;Lkotlinx/coroutines/CoroutineScope;Lcom/arcgismaps/toolkit/indoors/UIProperties;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/indoors/FloorFilterState;
+}
+
+public final class com/arcgismaps/toolkit/indoors/UIProperties {
+	public static final field $stable I
+	public synthetic fun <init> (JJJJJIIILcom/arcgismaps/toolkit/indoors/ButtonPosition;JLandroidx/compose/material3/Typography;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJIIILcom/arcgismaps/toolkit/indoors/ButtonPosition;JLandroidx/compose/material3/Typography;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-0d7_KjU ()J
+	public final fun component10-NH-jbRc ()J
+	public final fun component11 ()Landroidx/compose/material3/Typography;
+	public final fun component2-0d7_KjU ()J
+	public final fun component3-0d7_KjU ()J
+	public final fun component4-0d7_KjU ()J
+	public final fun component5-0d7_KjU ()J
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun component8 ()I
+	public final fun component9 ()Lcom/arcgismaps/toolkit/indoors/ButtonPosition;
+	public final fun copy-AxR95tw (JJJJJIIILcom/arcgismaps/toolkit/indoors/ButtonPosition;JLandroidx/compose/material3/Typography;)Lcom/arcgismaps/toolkit/indoors/UIProperties;
+	public static synthetic fun copy-AxR95tw$default (Lcom/arcgismaps/toolkit/indoors/UIProperties;JJJJJIIILcom/arcgismaps/toolkit/indoors/ButtonPosition;JLandroidx/compose/material3/Typography;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/indoors/UIProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundColor-0d7_KjU ()J
+	public final fun getButtonSize-NH-jbRc ()J
+	public final fun getCloseButtonPosition ()Lcom/arcgismaps/toolkit/indoors/ButtonPosition;
+	public final fun getCloseButtonVisibility ()I
+	public final fun getMaxDisplayLevels ()I
+	public final fun getSearchBackgroundColor-0d7_KjU ()J
+	public final fun getSelectedBackgroundColor-0d7_KjU ()J
+	public final fun getSelectedForegroundColor-0d7_KjU ()J
+	public final fun getSiteFacilityButtonVisibility ()I
+	public final fun getTextColor-0d7_KjU ()J
+	public final fun getTypography ()Landroidx/compose/material3/Typography;
+	public fun hashCode ()I
+	public final fun setBackgroundColor-8_81llA (J)V
+	public final fun setButtonSize-uvyYCjk (J)V
+	public final fun setCloseButtonPosition (Lcom/arcgismaps/toolkit/indoors/ButtonPosition;)V
+	public final fun setCloseButtonVisibility (I)V
+	public final fun setMaxDisplayLevels (I)V
+	public final fun setSearchBackgroundColor-8_81llA (J)V
+	public final fun setSelectedBackgroundColor-8_81llA (J)V
+	public final fun setSelectedForegroundColor-8_81llA (J)V
+	public final fun setSiteFacilityButtonVisibility (I)V
+	public final fun setTextColor-8_81llA (J)V
+	public final fun setTypography (Landroidx/compose/material3/Typography;)V
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/toolkit/indoors/build.gradle.kts
+++ b/toolkit/indoors/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("artifact-deploy")
+    alias(libs.plugins.binary.compatibility.validator) apply true
 }
 
 android {

--- a/toolkit/indoors/build.gradle.kts
+++ b/toolkit/indoors/build.gradle.kts
@@ -56,6 +56,19 @@ android {
     }
 }
 
+apiValidation {
+    ignoredClasses.add("com.arcgismaps.toolkit.featureforms.BuildConfig")
+    // todo: remove when this is resolved https://github.com/Kotlin/binary-compatibility-validator/issues/74
+    // compose compiler generates public singletons for internal compose functions. this may be resolved in the compose
+    // compiler.
+    val composableSingletons = listOf(
+        "com.arcgismaps.toolkit.indoors.ComposableSingletons\$SiteAndFacilitySelectorKt"
+    )
+
+    ignoredClasses.addAll(composableSingletons)
+}
+
+
 dependencies {
     api(arcgis.mapsSdk)
     implementation(platform(libs.androidx.compose.bom))

--- a/toolkit/template/api/template.api
+++ b/toolkit/template/api/template.api
@@ -1,0 +1,8 @@
+public abstract interface class com/arcgismaps/toolkit/template/TemplateInterface {
+	public abstract fun getSomeProperty ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class com/arcgismaps/toolkit/template/TemplateKt {
+	public static final fun Template (Lcom/arcgismaps/toolkit/template/TemplateInterface;Landroidx/compose/runtime/Composer;I)V
+}
+


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/3559

<!-- link to design, if applicable -->

### Description:

add api files and supporting plugins/logic to all published modules.

added exclusions for "composable singleton" classes in Authenticator, which are public classes generated when an internal composable function exists. It is possible to break binary compatibility by invoking these functions by way of a public function in a transitive dependency. The alternative is to track and deprecate old versions of internal composable functions when we change their signatures.

considered adding exclusions for geoview-composable sample functions, but did not. 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/215/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  