### PR TITLE
Ensure build is working when depending on final build in Android Studio

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,4 +50,4 @@ artifactoryPassword=""
 # with CI, these versions are obtained from command line provided properties, see sdkVersionNumber
 # in settings.gradle.kts.
 sdkVersionNumber=200.6.0
-sdkBuildNumber=4404
+sdkBuildNumber=

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -73,8 +73,13 @@ dependencyResolutionManagement {
                 )
                 sdkVersionNumber
             } else {
-                logger.warn("Maps SDK dependency: $sdkVersionNumber-$sdkBuildNumber")
-                "$sdkVersionNumber-$sdkBuildNumber"
+                if (sdkBuildNumber.isBlank()) {
+                    logger.warn("Maps SDK dependency: $sdkVersionNumber")
+                    sdkVersionNumber
+                } else {
+                    logger.warn("Maps SDK dependency: $sdkVersionNumber-$sdkBuildNumber")
+                    "$sdkVersionNumber-$sdkBuildNumber"
+                }
             }
 
             version("mapsSdk", versionAndBuild)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:



### Summary of changes:

- removes SDK build number from `gradle.properties`
- changes in `settings.gradle.kts` to ensure that when building from Android Studio, the toolkit can depend on the final build specified in `gradle.properties`, without `sdkBuildNumber`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  