### PR TITLE
`Forms`: Update Helper text behavior

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/BarcodeTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/BarcodeTests.kt
@@ -18,15 +18,21 @@ package com.arcgismaps.toolkit.featureforms
 
 import android.Manifest
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.requestFocus
 import androidx.test.rule.GrantPermissionRule
 import com.arcgismaps.mapping.featureforms.BarcodeScannerFormInput
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -48,12 +54,12 @@ class BarcodeTests : FeatureFormTestRunner(
      * Given a `FeatureForm` with a `BarcodeScannerFormInput`
      * When the `FeatureForm` is displayed
      * Then the barcode form element is displayed with the scan icon
-     * And receives length validation errors when the input length is out of range
+     * And displays the helper text when focused
      *
      * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-11-barcode-input-type
      */
     @Test
-    fun testBarcodeTextField() = runTest {
+    fun testBarcodeTextField(): Unit = runBlocking {
         composeTestRule.setContent {
             FeatureForm(featureForm = featureForm)
         }
@@ -64,11 +70,9 @@ class BarcodeTests : FeatureFormTestRunner(
         barcodeFormElement.onChildWithContentDescription("scan barcode").assertIsDisplayed()
         // Perform text input
         barcodeFormElement.performTextInput("https://esri.com")
-        // Check the scan icon is displayed
-        barcodeFormElement.onChildWithContentDescription("scan barcode").assertIsDisplayed()
-        // Perform text input
-        barcodeFormElement.performTextInput("https://runtimecoretest.maps.arcgis.com/apps/mapviewer/index.html?layers=a9155494098147b9be2fc52bcf825224")
-        // Check for validation error
+        barcodeFormElement.requestFocus()
+        barcodeFormElement.assertIsFocused()
+        // verify helper text is displayed
         barcodeFormElement.onChildWithText("Maximum 50 characters").assertIsDisplayed()
     }
 

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
@@ -128,10 +128,12 @@ class FormTextFieldTests : FeatureFormTestRunner(
         val label = composeTestRule.onNodeWithContentDescription(labelSemanticLabel)
         label.assertIsDisplayed()
 
-        composeTestRule.onNode(
+        val supportingText = composeTestRule.onNode(
             hasContentDescription(supportingTextSemanticLabel),
             useUnmergedTree = true
-        ).assertDoesNotExist()
+        )
+        supportingText.assertIsDisplayed()
+        assertEquals("Maximum 256 characters", supportingText.getTextString())
     }
 
     /**
@@ -151,10 +153,12 @@ class FormTextFieldTests : FeatureFormTestRunner(
         val label = composeTestRule.onNodeWithContentDescription(labelSemanticLabel)
         label.assertIsDisplayed()
 
-        composeTestRule.onNode(
+        val supportingText = composeTestRule.onNode(
             hasContentDescription(supportingTextSemanticLabel),
             useUnmergedTree = true
-        ).assertDoesNotExist()
+        )
+        supportingText.assertIsDisplayed()
+        assertEquals("Maximum 256 characters", supportingText.getTextString())
 
         val charCountNode =
             composeTestRule.onNode(
@@ -191,13 +195,14 @@ class FormTextFieldTests : FeatureFormTestRunner(
         val label = composeTestRule.onNodeWithContentDescription(labelSemanticLabel)
         label.assertIsDisplayed()
 
+        outlinedTextField.performImeAction()
+        outlinedTextField.assertIsNotFocused()
+
+        // The helper text is not displayed when the field is unfocused
         composeTestRule.onNode(
             hasContentDescription(supportingTextSemanticLabel),
             useUnmergedTree = true
         ).assertDoesNotExist()
-
-        outlinedTextField.performImeAction()
-        outlinedTextField.assertIsNotFocused()
 
         val charCountNode =
             composeTestRule.onNode(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextField.kt
@@ -68,11 +68,15 @@ internal fun BarcodeTextField(
     val isError = value.error !is ValidationErrorState.NoError
     // only show character count if there is a min or max length for this field
     val showCharacterCount = state.minLength > 0 || state.maxLength > 0
-    // if any errors are present, show the error as the supporting text
-    val supportingText = if (!isError) {
-        state.description.ifEmpty { state.helperText.getString() }
-    } else {
-        value.error.getString()
+    val isFocused by state.isFocused.collectAsState()
+    // show the supporting text based on the current state
+    val supportingText = when {
+        // show the error message if there is an error
+        isError -> value.error.getString()
+        // show the helper text if the description is empty and the field is focused
+        state.description.isEmpty() && isFocused -> state.helperText.getString()
+        // show the description if it is not empty
+        else -> state.description
     }
     val dialogRequester = LocalDialogRequester.current
     val stateId = remember(key1 = state) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextField.kt
@@ -70,7 +70,7 @@ internal fun BarcodeTextField(
     val showCharacterCount = state.minLength > 0 || state.maxLength > 0
     // if any errors are present, show the error as the supporting text
     val supportingText = if (!isError) {
-        state.description
+        state.description.ifEmpty { state.helperText.getString() }
     } else {
         value.error.getString()
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextField.kt
@@ -141,6 +141,7 @@ private fun BarcodeTextFieldPreview() {
                 visible = MutableStateFlow(true),
                 validationErrors = MutableStateFlow(emptyList()),
                 fieldType = FieldType.Text,
+                domain = null,
                 minLength = 0,
                 maxLength = 0
             ),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextFieldState.kt
@@ -30,6 +30,7 @@ import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseFieldSta
 import com.arcgismaps.toolkit.featureforms.internal.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.formattedValueAsStateFlow
+import com.arcgismaps.toolkit.featureforms.internal.components.base.handleCharConstraints
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -100,6 +101,17 @@ internal class BarcodeTextFieldState(
             FieldType.Text -> input
             else -> null
         } ?: input
+    }
+
+    override fun calculateHelperText(): ValidationErrorState {
+        // Call the base class implementation
+        val validationState = super.calculateHelperText()
+        // If no errors from base class, perform additional validation
+        return if (validationState is ValidationErrorState.NoError) {
+            handleCharConstraints(minLength, maxLength, hasValueExpression)
+        } else {
+            validationState
+        }
     }
 
     companion object {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextFieldState.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
+import com.arcgismaps.data.Domain
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.mapping.featureforms.BarcodeScannerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -42,7 +43,8 @@ internal class BarcodeFieldProperties(
     editable: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
     validationErrors: StateFlow<List<ValidationErrorState>>,
-    val fieldType: FieldType,
+    fieldType: FieldType,
+    domain: Domain?,
     val minLength: Int,
     val maxLength: Int,
 ) : FieldProperties<String>(
@@ -53,7 +55,9 @@ internal class BarcodeFieldProperties(
     validationErrors,
     required,
     editable,
-    visible
+    visible,
+    fieldType,
+    domain
 )
 
 internal class BarcodeTextFieldState(
@@ -73,11 +77,6 @@ internal class BarcodeTextFieldState(
     updateValue = updateValue,
     evaluateExpressions = evaluateExpressions
 ) {
-    /**
-     * The [FieldType] of the field.
-     */
-    val fieldType = properties.fieldType
-
     /**
      * The minimum length of the field.
      */
@@ -129,6 +128,7 @@ internal class BarcodeTextFieldState(
                         visible = field.isVisible,
                         validationErrors = field.mapValidationErrors(scope),
                         fieldType = field.fieldType,
+                        domain = field.domain,
                         minLength = input.minLength.toInt(),
                         maxLength = input.maxLength.toInt()
                     ),
@@ -166,6 +166,7 @@ internal fun rememberBarcodeTextFieldState(
             visible = field.isVisible,
             validationErrors = field.mapValidationErrors(scope),
             fieldType = field.fieldType,
+            domain = field.domain,
             minLength = (field.input as BarcodeScannerFormInput).minLength.toInt(),
             maxLength = (field.input as BarcodeScannerFormInput).maxLength.toInt()
         ),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/barcode/BarcodeTextFieldState.kt
@@ -32,6 +32,7 @@ import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationEr
 import com.arcgismaps.toolkit.featureforms.internal.components.base.formattedValueAsStateFlow
 import com.arcgismaps.toolkit.featureforms.internal.components.base.handleCharConstraints
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
+import com.arcgismaps.toolkit.featureforms.internal.utils.isNumeric
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
@@ -104,13 +105,12 @@ internal class BarcodeTextFieldState(
     }
 
     override fun calculateHelperText(): ValidationErrorState {
-        // Call the base class implementation
-        val validationState = super.calculateHelperText()
-        // If no errors from base class, perform additional validation
-        return if (validationState is ValidationErrorState.NoError) {
+        // If field type is text, handle character constraints
+        return if (fieldType == FieldType.Text) {
             handleCharConstraints(minLength, maxLength, hasValueExpression)
         } else {
-            validationState
+            // Otherwise, call the super class method which handles numeric constraints
+            super.calculateHelperText()
         }
     }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/BaseFieldState.kt
@@ -157,7 +157,10 @@ internal abstract class BaseFieldState<T>(
 
     /**
      * Text that indicates instructions or constraints for the field. This is derived from the
-     * properties of the input type of the field.
+     * properties of field and represented as a [ValidationErrorState]. See [calculateHelperText]
+     * on how to provide custom helper text.
+     *
+     * Use [ValidationErrorState.getString] to get the actual text from within a composition.
      */
     val helperText: ValidationErrorState by lazy {
         calculateHelperText()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
@@ -84,6 +84,84 @@ internal fun FieldFormElement.mapValidationErrors(scope: CoroutineScope): StateF
 }
 
 /**
+ * Creates a [ValidationErrorState] based on the character constraints of the given [formElement].
+ */
+internal fun handleCharConstraints(
+    formElement: FieldFormElement
+): ValidationErrorState {
+    val (min, max) = when (val input = formElement.input) {
+        is TextBoxFormInput -> Pair(input.minLength.toInt(), input.maxLength.toInt())
+        is TextAreaFormInput -> Pair(input.minLength.toInt(), input.maxLength.toInt())
+        is BarcodeScannerFormInput -> Pair(input.minLength.toInt(), input.maxLength.toInt())
+        // logical edge case, should never happen
+        else -> Pair(0, 256)
+    }
+    return handleCharConstraints(min, max, formElement.hasValueExpression)
+}
+
+/**
+ * Creates a [ValidationErrorState] based on the character constraints of the given [min], [max] and
+ * [hasValueExpression] values.
+ */
+internal fun handleCharConstraints(
+    min : Int,
+    max : Int,
+    hasValueExpression : Boolean
+) : ValidationErrorState {
+    return when {
+        min == max -> ValidationErrorState.ExactCharConstraint(min, hasValueExpression)
+        min > 0 && max > 0 -> ValidationErrorState.MinMaxCharConstraint(
+            min,
+            max,
+            hasValueExpression
+        )
+
+        max > 0 -> ValidationErrorState.MaxCharConstraint(max)
+        else -> ValidationErrorState.NoError
+    }
+}
+
+/**
+ * Creates a [ValidationErrorState] based on the numeric constraints of the given [formElement].
+ */
+internal fun handleNumericConstraints(
+    formElement: FieldFormElement
+): ValidationErrorState {
+    val rangeDomain = formElement.domain as RangeDomain
+    val (min: Number?, max: Number?) = if (formElement.fieldType.isIntegerType) {
+        val tuple = rangeDomain.asLongTuple
+        Pair(tuple.min, tuple.max)
+    } else if (formElement.fieldType.isFloatingPoint) {
+        val tuple = rangeDomain.asDoubleTuple
+        Pair(tuple.min, tuple.max)
+    } else {
+        Pair(null, null)
+    }
+    return handleNumericConstraints(min, max, formElement.hasValueExpression)
+}
+
+/**
+ * Creates a [ValidationErrorState] based on the numeric constraints of the given [min], [max] and
+ * [hasValueExpression] values.
+ */
+internal fun handleNumericConstraints(
+    min: Number?,
+    max: Number?,
+    hasValueExpression: Boolean
+): ValidationErrorState {
+    return when {
+        min != null && max != null -> ValidationErrorState.MinMaxNumericConstraint(
+            min.format(),
+            max.format(),
+            hasValueExpression
+        )
+        min != null -> ValidationErrorState.MinNumericConstraint(min.format())
+        max != null -> ValidationErrorState.MaxNumericConstraint(max.format())
+        else -> ValidationErrorState.NoError
+    }
+}
+
+/**
  * Creates a list of [ValidationErrorState] with appropriate messages with the given [errors] and
  * [formElement].
  */
@@ -115,9 +193,11 @@ private fun createValidationErrorStates(
                         formElement.fieldType.isFloatingPoint -> {
                             add(ValidationErrorState.NotANumber)
                         }
+
                         formElement.fieldType.isIntegerType -> {
                             add(ValidationErrorState.NotAWholeNumber)
                         }
+
                         formElement.fieldType is FieldType.Guid -> {
                             add(ValidationErrorState.NotAGuid)
                         }
@@ -142,7 +222,8 @@ private fun createValidationErrorStates(
 
                 is FeatureFormValidationException.LessThanMinimumDateTimeException -> {
                     val dateTimePickerInput = formElement.input as DateTimePickerFormInput
-                    val formatted = dateTimePickerInput.min?.formattedDateTime(dateTimePickerInput.includeTime)
+                    val formatted =
+                        dateTimePickerInput.min?.formattedDateTime(dateTimePickerInput.includeTime)
                     if (formatted != null) {
                         add(ValidationErrorState.MinDatetimeConstraint(formatted))
                     }
@@ -150,7 +231,8 @@ private fun createValidationErrorStates(
 
                 is FeatureFormValidationException.MaxDateTimeConstraintException -> {
                     val dateTimePickerInput = formElement.input as DateTimePickerFormInput
-                    val formatted = dateTimePickerInput.max?.formattedDateTime(dateTimePickerInput.includeTime)
+                    val formatted =
+                        dateTimePickerInput.max?.formattedDateTime(dateTimePickerInput.includeTime)
                     if (formatted != null) {
                         add(ValidationErrorState.MaxDatetimeConstraint(formatted))
                     }
@@ -158,58 +240,9 @@ private fun createValidationErrorStates(
             }
             if (formElement.input is TextBoxFormInput || formElement.input is TextAreaFormInput || formElement.input is BarcodeScannerFormInput) {
                 if (!formElement.fieldType.isNumeric && (hasMinCharError || hasMaxCharError)) {
-                    val (min, max) = when (val input = formElement.input) {
-                        is TextBoxFormInput -> Pair(input.minLength.toInt(), input.maxLength.toInt())
-                        is TextAreaFormInput -> Pair(input.minLength.toInt(), input.maxLength.toInt())
-                        is BarcodeScannerFormInput -> Pair(input.minLength.toInt(), input.maxLength.toInt())
-                        // logical edge case, should never happen
-                        else -> Pair(0, 256)
-                    }
-                    if (min > 0 && max > 0) {
-                        if (min == max) {
-                            add(
-                                ValidationErrorState.ExactCharConstraint(
-                                    min,
-                                    formElement.hasValueExpression
-                                )
-                            )
-                        } else {
-                            add(
-                                ValidationErrorState.MinMaxCharConstraint(
-                                    min,
-                                    max,
-                                    formElement.hasValueExpression
-                                )
-                            )
-                        }
-                    } else {
-                        add(ValidationErrorState.MaxCharConstraint(max))
-                    }
-
+                    add(handleCharConstraints(formElement))
                 } else if (hasMinRangeError || hasMaxRangeError) {
-                    val rangeDomain = formElement.domain as RangeDomain
-                    val (min: Number?, max: Number?) = if (formElement.fieldType.isIntegerType) {
-                        val tuple = rangeDomain.asLongTuple
-                        Pair(tuple.min, tuple.max)
-                    } else if (formElement.fieldType.isFloatingPoint) {
-                        val tuple = rangeDomain.asDoubleTuple
-                        Pair(tuple.min, tuple.max)
-                    } else {
-                        Pair(null, null)
-                    }
-                    if (min != null && max != null) {
-                        add(
-                            ValidationErrorState.MinMaxNumericConstraint(
-                                min.format(),
-                                max.format(),
-                                formElement.hasValueExpression
-                            )
-                        )
-                    } else if (min != null) {
-                        add(ValidationErrorState.MinNumericConstraint(min.format()))
-                    } else {
-                        add(ValidationErrorState.MaxNumericConstraint(max.format()))
-                    }
+                    add(handleNumericConstraints(formElement))
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/base/Flows.kt
@@ -173,6 +173,7 @@ private fun createValidationErrorStates(
     var (hasMinCharError, hasMaxCharError) = Pair(false, false)
     return buildList {
         errors.forEach { error ->
+            // add the appropriate error state based on the type of error
             when (error) {
                 is FeatureFormValidationException.RequiredException -> {
                     add(ValidationErrorState.Required)
@@ -238,12 +239,17 @@ private fun createValidationErrorStates(
                     }
                 }
             }
-            if (formElement.input is TextBoxFormInput || formElement.input is TextAreaFormInput || formElement.input is BarcodeScannerFormInput) {
-                if (!formElement.fieldType.isNumeric && (hasMinCharError || hasMaxCharError)) {
-                    add(handleCharConstraints(formElement))
-                } else if (hasMinRangeError || hasMaxRangeError) {
-                    add(handleNumericConstraints(formElement))
+            // check and add length/range constraints based validation rules
+            when (formElement.input) {
+                is TextBoxFormInput, is TextAreaFormInput, is BarcodeScannerFormInput -> {
+                    if (!formElement.fieldType.isNumeric && (hasMinCharError || hasMaxCharError)) {
+                        add(handleCharConstraints(formElement))
+                    } else if (hasMinRangeError || hasMaxRangeError) {
+                        add(handleNumericConstraints(formElement))
+                    }
                 }
+
+                else -> { /* no constraints to check */ }
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/codedvalue/CodedValueFieldState.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.codedvalue
 
-import com.arcgismaps.data.CodedValue
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.mapping.featureforms.FormExpressionEvaluationError
 import com.arcgismaps.mapping.featureforms.FormInputNoValueOption
@@ -33,15 +32,26 @@ internal open class CodedValueFieldProperties(
     placeholder: String,
     description: String,
     value: StateFlow<Any?>,
-    validationErrors : StateFlow<List<ValidationErrorState>>,
+    validationErrors: StateFlow<List<ValidationErrorState>>,
     required: StateFlow<Boolean>,
     editable: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
-    val fieldType: FieldType,
+    fieldType: FieldType,
     val codedValues: Map<Any?, String>,
     val showNoValueOption: FormInputNoValueOption,
     val noValueLabel: String
-) : FieldProperties<Any?>(label, placeholder, description, value, validationErrors, required, editable, visible)
+) : FieldProperties<Any?>(
+    label,
+    placeholder,
+    description,
+    value,
+    validationErrors,
+    required,
+    editable,
+    visible,
+    fieldType,
+    null
+)
 
 /**
  * A class to handle the state of any coded value type. Essential properties are inherited
@@ -93,11 +103,6 @@ internal abstract class CodedValueFieldState(
      * The custom label to use if [showNoValueOption] is enabled.
      */
     val noValueLabel: String = properties.noValueLabel
-
-    /**
-     * The FieldType of the element's Field.
-     */
-    val fieldType: FieldType = properties.fieldType
 
     /**
      * Returns the name of the [code] if it is present in [codedValues]. If not, it returns the

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeField.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.arcgismaps.data.FieldType
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseTextField
 import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
@@ -124,7 +125,8 @@ private fun DateTimeFieldPreview() {
                 visible = MutableStateFlow(true),
                 minEpochMillis = null,
                 maxEpochMillis = null,
-                shouldShowTime = true
+                shouldShowTime = true,
+                fieldType = FieldType.Date
             ),
             hasValueExpression = false,
             scope = scope,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateTimeFieldState.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
+import com.arcgismaps.data.FieldType
 import com.arcgismaps.mapping.featureforms.DateTimePickerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
@@ -41,14 +42,26 @@ internal class DateTimeFieldProperties(
     placeholder: String,
     description: String,
     value: StateFlow<Instant?>,
-    validationErrors : StateFlow<List<ValidationErrorState>>,
+    validationErrors: StateFlow<List<ValidationErrorState>>,
     required: StateFlow<Boolean>,
     editable: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
+    fieldType: FieldType,
     val minEpochMillis: Instant?,
     val maxEpochMillis: Instant?,
     val shouldShowTime: Boolean
-) : FieldProperties<Instant?>(label, placeholder, description, value, validationErrors, required, editable, visible)
+) : FieldProperties<Instant?>(
+    label,
+    placeholder,
+    description,
+    value,
+    validationErrors,
+    required,
+    editable,
+    visible,
+    fieldType,
+    null
+)
 
 /**
  * A class to handle the state of a [DateTimeField]. Essential properties are inherited from the
@@ -112,7 +125,8 @@ internal class DateTimeFieldState(
                         visible = field.isVisible,
                         minEpochMillis = input.min,
                         maxEpochMillis = input.max,
-                        shouldShowTime = input.includeTime
+                        shouldShowTime = input.includeTime,
+                        fieldType = field.fieldType
                     ),
                     initialValue = list[0] as Instant?,
                     hasValueExpression = field.hasValueExpression,
@@ -156,7 +170,8 @@ internal fun rememberDateTimeFieldState(
             visible = field.isVisible,
             minEpochMillis = minEpochMillis,
             maxEpochMillis = maxEpochMillis,
-            shouldShowTime = shouldShowTime
+            shouldShowTime = shouldShowTime,
+            fieldType = field.fieldType
         ),
         hasValueExpression = field.hasValueExpression,
         scope = scope,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextField.kt
@@ -39,7 +39,7 @@ internal fun FormTextField(
     val showCharacterCount = state.minLength > 0 || state.maxLength > 0
     // if any errors are present, show the error as the supporting text
     val supportingText = if (!isError) {
-        state.description
+        state.description.ifEmpty { state.helperText.getString() }
     } else {
        value.error.getString()
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextField.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextField.kt
@@ -37,11 +37,15 @@ internal fun FormTextField(
     val isError = value.error !is ValidationErrorState.NoError
     // only show character count if there is a min or max length for this field
     val showCharacterCount = state.minLength > 0 || state.maxLength > 0
-    // if any errors are present, show the error as the supporting text
-    val supportingText = if (!isError) {
-        state.description.ifEmpty { state.helperText.getString() }
-    } else {
-       value.error.getString()
+    val isFocused by state.isFocused.collectAsState()
+    // show the supporting text based on the current state
+    val supportingText = when {
+        // show the error message if there is an error
+        isError -> value.error.getString()
+        // show the helper text if the description is empty and the field is focused
+        state.description.isEmpty() && isFocused -> state.helperText.getString()
+        // show the description if it is not empty
+        else -> state.description
     }
 
     BaseTextField(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
@@ -122,13 +122,12 @@ internal class FormTextFieldState(
     }
 
     override fun calculateHelperText(): ValidationErrorState {
-        // Call the base class implementation
-        val validationState = super.calculateHelperText()
-        // If no errors from base class, perform additional validation
-        return if (validationState is ValidationErrorState.NoError) {
+        // If field type is text, handle character constraints
+        return if (fieldType == FieldType.Text) {
             handleCharConstraints(minLength, maxLength, hasValueExpression)
         } else {
-            validationState
+            // Otherwise, call the super class method which handles numeric constraints
+            super.calculateHelperText()
         }
     }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/text/FormTextFieldState.kt
@@ -33,6 +33,7 @@ import com.arcgismaps.toolkit.featureforms.internal.components.base.BaseFieldSta
 import com.arcgismaps.toolkit.featureforms.internal.components.base.FieldProperties
 import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.formattedValueAsStateFlow
+import com.arcgismaps.toolkit.featureforms.internal.components.base.handleCharConstraints
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -45,13 +46,24 @@ internal class TextFieldProperties(
     required: StateFlow<Boolean>,
     editable: StateFlow<Boolean>,
     visible: StateFlow<Boolean>,
-    validationErrors : StateFlow<List<ValidationErrorState>>,
-    val fieldType: FieldType,
-    val domain: Domain?,
+    validationErrors: StateFlow<List<ValidationErrorState>>,
+    fieldType: FieldType,
+    domain: Domain?,
     val singleLine: Boolean,
     val minLength: Int,
     val maxLength: Int,
-) : FieldProperties<String>(label, placeholder, description, value, validationErrors, required, editable, visible)
+) : FieldProperties<String>(
+    label,
+    placeholder,
+    description,
+    value,
+    validationErrors,
+    required,
+    editable,
+    visible,
+    fieldType,
+    domain
+)
 
 /**
  * A class to handle the state of a [FormTextField]. Essential properties are inherited from the
@@ -94,16 +106,6 @@ internal class FormTextFieldState(
     // fetch the maxLength based on the featureFormElement.inputType
     val maxLength = properties.maxLength
 
-    /**
-     * The domain of the element's field.
-     */
-    val domain: Domain? = properties.domain
-
-    /**
-     * The FieldType of the element's field.
-     */
-    val fieldType: FieldType = properties.fieldType
-
     override fun typeConverter(input: String): Any? {
         if (input.isEmpty()) {
             return null
@@ -117,6 +119,17 @@ internal class FormTextFieldState(
             FieldType.Text -> input
             else -> null
         } ?: input
+    }
+
+    override fun calculateHelperText(): ValidationErrorState {
+        // Call the base class implementation
+        val validationState = super.calculateHelperText()
+        // If no errors from base class, perform additional validation
+        return if (validationState is ValidationErrorState.NoError) {
+            handleCharConstraints(minLength, maxLength, hasValueExpression)
+        } else {
+            validationState
+        }
     }
 
     companion object {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/974](https://devtopia.esri.com/runtime/apollo/issues/974)

<!-- link to design, if applicable -->

### Description:

This PR updates the supporting text of Barcode and Text fields to show a "helper text" when they are in focus and no description is present. This matches the specified UI design spec.

### Summary of changes:

- Moved the properties `fieldType` and `domain` up to the `BaseFieldState` from its derived classes. These properties should have been in the `BaseFieldState` since they are part of the `FieldFormElement` class and not the `FormInput`.
- Introduced a new property 'helperText`.
- Introduced a new open fun `calculateHelperText` which provides a value for the `helperText` property. The base impl populates any range domain specific messages but derived classes can provide their own custom text.
- Updated 'FormTextField` and `BarcodeField` to show this helper text when the field is in focus and no description is available.
- Updated tests to their spec which includes testing for helper text messages.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/222/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  