### PR TITLE
`Forms` : Set viewpoint to created feature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,4 +50,4 @@ artifactoryPassword=""
 # with CI, these versions are obtained from command line provided properties, see sdkVersionNumber
 # in settings.gradle.kts.
 sdkVersionNumber=200.7.0
-sdkBuildNumber=4437
+sdkBuildNumber=4446

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -186,6 +186,8 @@ class MapViewModel @Inject constructor(
     val uiState: State<UIState>
         get() = _uiState
 
+    private val viewpointScale = 1_000.0
+
     init {
         scope.launch {
             // load the map and set the UI state to not editing
@@ -421,6 +423,11 @@ class MapViewModel @Inject constructor(
         table.addFeature(feature).onSuccess {
             // select the feature and open a FeatureForm for editing the feature
             val featureForm = FeatureForm(feature)
+            if (location != null) {
+                // set the viewpoint to the feature location
+                proxy.setViewpointCenter(location)
+                proxy.setViewpointScale(viewpointScale)
+            }
             layer.selectFeature(feature)
             _uiState.value = UIState.Editing(featureForm)
         }.onFailure {

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -186,8 +186,6 @@ class MapViewModel @Inject constructor(
     val uiState: State<UIState>
         get() = _uiState
 
-    private val viewpointScale = 1_000.0
-
     init {
         scope.launch {
             // load the map and set the UI state to not editing
@@ -426,7 +424,10 @@ class MapViewModel @Inject constructor(
             if (location != null) {
                 // set the viewpoint to the feature location
                 proxy.setViewpointCenter(location)
-                proxy.setViewpointScale(viewpointScale)
+                // set the viewpoint scale if the layer has a min scale
+                layer.minScale?.let { scale ->
+                    proxy.setViewpointScale(scale)
+                }
             }
             layer.selectFeature(feature)
             _uiState.value = UIState.Editing(featureForm)


### PR DESCRIPTION
### Description:

In some maps, when a feature is created it might not be visible at the default map scale if the FeatureLayer has a minimum scale value. This PR sets the viewpoint to a created feature and sets the scale to the `FeatureLayer.minScale` so that created features are visible.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  