### PR TITLE
Update deprecation

### DIFF
--- a/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
+++ b/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
@@ -82,8 +82,8 @@ class ArtifactPublisher : Plugin<Project> {
                     }
                 }
             }
-            
-            tasks.findByName("publish${project.name.capitalized()}PublicationToMavenRepository")
+
+            tasks.findByName("publish${project.name.replaceFirstChar { it.uppercase() }}PublicationToMavenRepository")
                 ?.dependsOn("assembleRelease")
             tasks.findByName("publishToMavenLocal")?.dependsOn("assembleRelease")
         }

--- a/microapps/AuthenticationApp/app/build.gradle.kts
+++ b/microapps/AuthenticationApp/app/build.gradle.kts
@@ -59,7 +59,6 @@ android {
         // context receivers are used by the MapInterface for gesture events
         freeCompilerArgs = freeCompilerArgs + "-Xcontext-receivers"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
         buildConfig = true

--- a/microapps/CompassApp/app/build.gradle.kts
+++ b/microapps/CompassApp/app/build.gradle.kts
@@ -57,7 +57,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
         buildConfig = true
@@ -78,7 +77,9 @@ android {
 
 //https://youtrack.jetbrains.com/issue/KTIJ-21063
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-receivers")
+    }
 }
 
 dependencies {

--- a/microapps/CompassApp/app/build.gradle.kts
+++ b/microapps/CompassApp/app/build.gradle.kts
@@ -75,13 +75,6 @@ android {
     }
 }
 
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-receivers")
-    }
-}
-
 dependencies {
     implementation(project(":compass"))
     implementation(project(":geoview-compose"))

--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -78,7 +78,9 @@ android {
 
 //https://youtrack.jetbrains.com/issue/KTIJ-21063
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-receivers")
+    }
 }
 
 dependencies {

--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -76,13 +76,6 @@ android {
     }
 }
 
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-receivers")
-    }
-}
-
 dependencies {
     implementation(project(":authentication"))
     implementation(project(":featureforms"))

--- a/microapps/FloorFilterApp/app/build.gradle.kts
+++ b/microapps/FloorFilterApp/app/build.gradle.kts
@@ -40,7 +40,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
         buildConfig = true
@@ -66,7 +65,9 @@ android {
 // context receivers are not experimental anymore, but AS thinks they are.
 //https://youtrack.jetbrains.com/issue/KTIJ-21063
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-receivers")
+    }
 }
 
 dependencies {

--- a/microapps/FloorFilterApp/app/build.gradle.kts
+++ b/microapps/FloorFilterApp/app/build.gradle.kts
@@ -62,14 +62,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-receivers")
-    }
-}
-
 dependencies {
     implementation(project(":indoors"))
     implementation(project(":geoview-compose"))

--- a/microapps/MapViewCalloutApp/app/build.gradle.kts
+++ b/microapps/MapViewCalloutApp/app/build.gradle.kts
@@ -58,7 +58,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
         buildConfig = true

--- a/microapps/MapViewGeometryEditorApp/app/build.gradle.kts
+++ b/microapps/MapViewGeometryEditorApp/app/build.gradle.kts
@@ -77,12 +77,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/microapps/MapViewIdentifyApp/app/build.gradle.kts
+++ b/microapps/MapViewIdentifyApp/app/build.gradle.kts
@@ -77,12 +77,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/microapps/MapViewInsetsApp/app/build.gradle.kts
+++ b/microapps/MapViewInsetsApp/app/build.gradle.kts
@@ -77,12 +77,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/microapps/MapViewLocationDisplayApp/app/build.gradle.kts
+++ b/microapps/MapViewLocationDisplayApp/app/build.gradle.kts
@@ -77,12 +77,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/microapps/MapViewSetViewpointApp/app/build.gradle.kts
+++ b/microapps/MapViewSetViewpointApp/app/build.gradle.kts
@@ -77,12 +77,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/microapps/MicroappsLib/build.gradle.kts
+++ b/microapps/MicroappsLib/build.gradle.kts
@@ -49,10 +49,10 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }
+    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
     }

--- a/microapps/SceneViewAnalysisOverlayApp/app/build.gradle.kts
+++ b/microapps/SceneViewAnalysisOverlayApp/app/build.gradle.kts
@@ -77,12 +77,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/microapps/SceneViewCalloutApp/app/build.gradle.kts
+++ b/microapps/SceneViewCalloutApp/app/build.gradle.kts
@@ -79,7 +79,9 @@ android {
 // context receivers are not experimental anymore, but AS thinks they are.
 //https://youtrack.jetbrains.com/issue/KTIJ-21063
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-receivers")
+    }
 }
 
 dependencies {

--- a/microapps/SceneViewCalloutApp/app/build.gradle.kts
+++ b/microapps/SceneViewCalloutApp/app/build.gradle.kts
@@ -76,14 +76,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-receivers")
-    }
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/microapps/SceneViewCameraControllerApp/app/build.gradle.kts
+++ b/microapps/SceneViewCameraControllerApp/app/build.gradle.kts
@@ -77,12 +77,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/microapps/SceneViewLightingOptionsApp/app/build.gradle.kts
+++ b/microapps/SceneViewLightingOptionsApp/app/build.gradle.kts
@@ -77,12 +77,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/microapps/SceneViewSetViewpointApp/app/build.gradle.kts
+++ b/microapps/SceneViewSetViewpointApp/app/build.gradle.kts
@@ -77,12 +77,6 @@ android {
     }
 }
 
-// context receivers are not experimental anymore, but AS thinks they are.
-//https://youtrack.jetbrains.com/issue/KTIJ-21063
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-}
-
 dependencies {
     implementation(project(":geoview-compose"))
     implementation(project(":microapps-lib"))

--- a/toolkit/ar/build.gradle.kts
+++ b/toolkit/ar/build.gradle.kts
@@ -47,20 +47,25 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }
-    packagingOptions {
-        exclude("META-INF/LICENSE-notice.md")
-        exclude("META-INF/LICENSE.md")
+    packaging {
+        resources {
+            excludes += setOf(
+                "META-INF/LICENSE-notice.md",
+                "META-INF/LICENSE.md"
+            )
+        }
     }
     // If this were not an android project, we would just write `explicitApi()` in the Kotlin scope.
     // but as an android project could write `freeCompilerArgs = listOf("-Xexplicit-api=strict")`
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
 

--- a/toolkit/authentication/build.gradle.kts
+++ b/toolkit/authentication/build.gradle.kts
@@ -47,20 +47,26 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }
-    packagingOptions {
-        exclude("META-INF/LICENSE-notice.md")
-        exclude("META-INF/LICENSE.md")
+    packaging {
+        resources {
+            excludes += setOf(
+                "META-INF/LICENSE-notice.md",
+                "META-INF/LICENSE.md"
+            )
+        }
     }
+
     // If this were not an android project, we would just write `explicitApi()` in the Kotlin scope.
     // but as an android project could write `freeCompilerArgs = listOf("-Xexplicit-api=strict")`
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
 
@@ -68,6 +74,7 @@ android {
      * Configures the test report for connected (instrumented) tests to be copied to a central
      * folder in the project's root directory.
      */
+    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
         val connectedTestReportsPath: String by project

--- a/toolkit/compass/build.gradle.kts
+++ b/toolkit/compass/build.gradle.kts
@@ -47,7 +47,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }
@@ -56,7 +55,9 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
 
@@ -64,6 +65,7 @@ android {
      * Configures the test report for connected (instrumented) tests to be copied to a central
      * folder in the project's root directory.
      */
+    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
         val connectedTestReportsPath: String by project

--- a/toolkit/composable-map/build.gradle.kts
+++ b/toolkit/composable-map/build.gradle.kts
@@ -47,7 +47,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }
@@ -56,9 +55,12 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
+    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
     }
@@ -69,7 +71,9 @@ android {
 
 //https://youtrack.jetbrains.com/issue/KTIJ-21063
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-receivers")
+    }
 }
 
 dependencies {

--- a/toolkit/composable-map/build.gradle.kts
+++ b/toolkit/composable-map/build.gradle.kts
@@ -47,7 +47,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }
@@ -56,9 +55,12 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
+    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
     }
@@ -69,7 +71,11 @@ android {
 
 //https://youtrack.jetbrains.com/issue/KTIJ-21063
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.add("-Xcontext-receiverst")
+        }
+    }
 }
 
 dependencies {

--- a/toolkit/composable-map/build.gradle.kts
+++ b/toolkit/composable-map/build.gradle.kts
@@ -55,12 +55,9 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            compilerOptions {
-                freeCompilerArgs.add("-Xexplicit-api=strict")
-            }
+            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
         }
     }
-    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
     }
@@ -71,11 +68,7 @@ android {
 
 //https://youtrack.jetbrains.com/issue/KTIJ-21063
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {
-    kotlin {
-        compilerOptions {
-            freeCompilerArgs.add("-Xcontext-receiverst")
-        }
-    }
+    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
 }
 
 dependencies {

--- a/toolkit/composable-map/build.gradle.kts
+++ b/toolkit/composable-map/build.gradle.kts
@@ -47,6 +47,7 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -52,7 +52,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
         buildConfig = true
@@ -72,6 +71,7 @@ android {
      * Configures the test report for connected (instrumented) tests to be copied to a central
      * folder in the project's root directory.
      */
+    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
         val connectedTestReportsPath: String by project

--- a/toolkit/geoview-compose/build.gradle.kts
+++ b/toolkit/geoview-compose/build.gradle.kts
@@ -47,7 +47,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }
@@ -56,7 +55,9 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
 
@@ -64,6 +65,7 @@ android {
      * Configures the test report for connected (instrumented) tests to be copied to a central
      * folder in the project's root directory.
      */
+    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
         val connectedTestReportsPath: String by project

--- a/toolkit/indoors/build.gradle.kts
+++ b/toolkit/indoors/build.gradle.kts
@@ -29,7 +29,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }
@@ -38,7 +37,9 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
 
@@ -46,6 +47,7 @@ android {
      * Configures the test report for connected (instrumented) tests to be copied to a central
      * folder in the project's root directory.
      */
+    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
         val connectedTestReportsPath: String by project

--- a/toolkit/popup/build.gradle.kts
+++ b/toolkit/popup/build.gradle.kts
@@ -56,7 +56,9 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
 

--- a/toolkit/template/build.gradle.kts
+++ b/toolkit/template/build.gradle.kts
@@ -46,7 +46,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
     }
@@ -55,7 +54,9 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
 
@@ -63,6 +64,7 @@ android {
      * Configures the test report for connected (instrumented) tests to be copied to a central
      * folder in the project's root directory.
      */
+    @Suppress("UnstableApiUsage")
     testOptions {
         targetSdk = libs.versions.compileSdk.get().toInt()
         val connectedTestReportsPath: String by project

--- a/toolkit/utilitynetworks/build.gradle.kts
+++ b/toolkit/utilitynetworks/build.gradle.kts
@@ -63,7 +63,9 @@ android {
     // in the kotlinOptions above, but that would enforce api rules on the test code, which we don't want.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         if ("Test" !in name) {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+            compilerOptions {
+                freeCompilerArgs.add("-Xexplicit-api=strict")
+            }
         }
     }
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5099

<!-- link to design, if applicable -->

### Description:

Fixes the deprecated calls in `build.gradle`

### Summary of changes:

- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/248/
  - [ ] https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/256/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  