### PR TITLE
Change the close button to expand/collapse

### DIFF
--- a/toolkit/indoors/api/indoors.api
+++ b/toolkit/indoors/api/indoors.api
@@ -68,6 +68,7 @@ public abstract interface class com/arcgismaps/toolkit/indoors/FloorFilterState 
 	public abstract fun getInitializationStatus ()Landroidx/compose/runtime/State;
 	public abstract fun getOnFacilityChanged ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getOnLevelChanged ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getOnSiteChanged ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getSelectedFacility ()Lcom/arcgismaps/mapping/floor/FloorFacility;
 	public abstract fun getSelectedFacilityId ()Ljava/lang/String;
 	public abstract fun getSelectedLevelId ()Ljava/lang/String;

--- a/toolkit/indoors/src/androidTest/java/com/arcgismaps/toolkit/indoors/FloorFilterTests.kt
+++ b/toolkit/indoors/src/androidTest/java/com/arcgismaps/toolkit/indoors/FloorFilterTests.kt
@@ -20,6 +20,7 @@
 package com.arcgismaps.toolkit.indoors
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -117,24 +118,35 @@ class FloorFilterTests {
         // verify if the facility has 12 floor levels
         assert(floorLevelButtons.fetchSemanticsNodes().size == 12)
 
-        // verify the floor level selector is not collapsed
-        val floorListCloseButton = composeTestRule.onAllNodesWithContentDescription(
-            label = "Close"
+        // verify that the collapse button is being displayed
+        val floorListCollapseButton = composeTestRule.onAllNodesWithContentDescription(
+            label = "Collapse"
         )[0]
 
         // get semantic node of the 8th floor level select button
         val eighthFloorLevelButton = floorLevelButtons[7]
+
+        // get semantic node of the 1st floor level select button
+        val firstFloorLevelButton = floorLevelButtons[0]
+
+        // verify if the 8th floor level select button is being displayed
+        eighthFloorLevelButton.assertIsDisplayed()
+
+        // verify if the 1st floor level select button is being displayed
+        firstFloorLevelButton.assertIsDisplayed()
 
         // select the 8th floor of the facility
         eighthFloorLevelButton.performClick()
         composeTestRule.waitForIdle()
 
         // collapse the floor level list
-        floorListCloseButton.performClick()
+        floorListCollapseButton.performClick()
         composeTestRule.waitForIdle()
 
         // verify the floor level selector is now collapsed
-        floorListCloseButton.assertDoesNotExist()
+        floorListCollapseButton.assertExists()
+        eighthFloorLevelButton.assertIsNotDisplayed()
+        firstFloorLevelButton.assertIsDisplayed()
     }
 }
 

--- a/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilter.kt
+++ b/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilter.kt
@@ -37,6 +37,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -199,6 +201,14 @@ internal fun FloorFilterContent(floorFilterState: FloorFilterState, uiProperties
         // display sites selector by default when set to false, and sites selector when set to true.
         var isFacilitiesSelectorVisible by rememberSaveable { mutableStateOf(false) }
 
+        // get the current selected site
+        val selectedSite = floorFilterState.onSiteChanged.collectAsStateWithLifecycle().value
+
+        // Reset isFloorsCollapsed to false whenever a new site is selected
+        LaunchedEffect(selectedSite) {
+            isFloorsCollapsed = false
+        }
+
         // get the current selected facility
         val selectedFacility =
             floorFilterState.onFacilityChanged.collectAsStateWithLifecycle().value
@@ -229,13 +239,15 @@ internal fun FloorFilterContent(floorFilterState: FloorFilterState, uiProperties
         if (uiProperties.closeButtonPosition == ButtonPosition.Top) {
             // check if close button is set to visible and not collapsed
             if (uiProperties.closeButtonVisibility == View.VISIBLE &&
-                !isFloorsCollapsed &&
                 selectedFacility.levels.isNotEmpty()
             ) {
                 FloorListCloseButton(
                     modifier,
                     uiProperties.buttonSize,
-                    onClick = { isFloorsCollapsed = true })
+                    uiProperties.closeButtonPosition,
+                    isFloorsCollapsed,
+                    selectedFacility.levels.size == 1,
+                    onClick = { isFloorsCollapsed = !isFloorsCollapsed })
             }
         } else {
             if (uiProperties.siteFacilityButtonVisibility == View.VISIBLE) {
@@ -291,10 +303,16 @@ internal fun FloorFilterContent(floorFilterState: FloorFilterState, uiProperties
         // display close button if set to bottom, if not display facilities button
         if (uiProperties.closeButtonPosition == ButtonPosition.Bottom) {
             // check if close button is set to visible and not collapsed
-            if (uiProperties.closeButtonVisibility == View.VISIBLE && !isFloorsCollapsed) {
-                FloorListCloseButton(modifier, uiProperties.buttonSize, onClick = {
-                    isFloorsCollapsed = true
-                })
+            if (uiProperties.closeButtonVisibility == View.VISIBLE) {
+                FloorListCloseButton(
+                    modifier,
+                    uiProperties.buttonSize,
+                    uiProperties.closeButtonPosition,
+                    isFloorsCollapsed,
+                    selectedFacility.levels.size == 1,
+                    onClick = {
+                        isFloorsCollapsed = !isFloorsCollapsed
+                    })
             }
         } else {
             if (uiProperties.siteFacilityButtonVisibility == View.VISIBLE) {
@@ -407,7 +425,8 @@ internal fun SiteFacilityButton(
 }
 
 /**
- * Button to collapse the list of floor levels and only display the selected floor level.
+ * Button to collapse/expand the list of floor levels and only display the selected floor level
+ * when collapsed.
  *
  * @since 200.2.0
  */
@@ -415,17 +434,34 @@ internal fun SiteFacilityButton(
 internal fun FloorListCloseButton(
     modifier: Modifier,
     buttonSize: Size,
+    closeButtonPosition: ButtonPosition,
+    isFloorListCollapsed: Boolean,
+    isDisabled: Boolean,
     onClick: (Unit) -> Unit
 ) {
+    val iconImage = if (closeButtonPosition == ButtonPosition.Top) {
+        if (isFloorListCollapsed) {
+            Icons.Outlined.ExpandLess
+        } else {
+            Icons.Outlined.ExpandMore
+        }
+    } else {
+        if (isFloorListCollapsed) {
+            Icons.Outlined.ExpandMore
+        } else {
+            Icons.Outlined.ExpandLess
+        }
+    }
     Box(
         modifier
             .fillMaxWidth()
             .height(buttonSize.height.dp)
-            .clickable { onClick(Unit) }) {
+            .clickable(enabled = !isDisabled) { onClick(Unit) }) {
         Icon(
             modifier = modifier.align(Center),
-            painter = painterResource(id = R.drawable.ic_x_24),
-            contentDescription = stringResource(R.string.close)
+            imageVector = iconImage,
+            contentDescription = stringResource(R.string.collapse),
+            tint = if (isDisabled) MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38F) else MaterialTheme.colorScheme.primary
         )
     }
 }

--- a/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilter.kt
+++ b/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilter.kt
@@ -191,9 +191,6 @@ internal fun FloorFilterContent(floorFilterState: FloorFilterState, uiProperties
         modifier = modifier,
         verticalArrangement = Arrangement.Center
     ) {
-        // displays only the selected floor when enabled
-        var isFloorsCollapsed by rememberSaveable { mutableStateOf(false) }
-
         // boolean toggle to display the site facility selector dialog
         var isSiteAndFacilitySelectorVisible by rememberSaveable { mutableStateOf(false) }
 
@@ -208,10 +205,9 @@ internal fun FloorFilterContent(floorFilterState: FloorFilterState, uiProperties
         val selectedFacility =
             floorFilterState.onFacilityChanged.collectAsStateWithLifecycle().value
 
+        // displays only the selected floor when enabled
         // Reset isFloorsCollapsed to false whenever a new site or facility is selected
-        LaunchedEffect(selectedSite, selectedFacility) {
-            isFloorsCollapsed = false
-        }
+        var isFloorsCollapsed by rememberSaveable(selectedSite, selectedFacility) { mutableStateOf(false) }
 
         // get the selected level ID
         val selectedLevelID =

--- a/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilter.kt
+++ b/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilter.kt
@@ -204,14 +204,14 @@ internal fun FloorFilterContent(floorFilterState: FloorFilterState, uiProperties
         // get the current selected site
         val selectedSite = floorFilterState.onSiteChanged.collectAsStateWithLifecycle().value
 
-        // Reset isFloorsCollapsed to false whenever a new site is selected
-        LaunchedEffect(selectedSite) {
-            isFloorsCollapsed = false
-        }
-
         // get the current selected facility
         val selectedFacility =
             floorFilterState.onFacilityChanged.collectAsStateWithLifecycle().value
+
+        // Reset isFloorsCollapsed to false whenever a new site or facility is selected
+        LaunchedEffect(selectedSite, selectedFacility) {
+            isFloorsCollapsed = false
+        }
 
         // get the selected level ID
         val selectedLevelID =

--- a/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilterState.kt
+++ b/toolkit/indoors/src/main/java/com/arcgismaps/toolkit/indoors/FloorFilterState.kt
@@ -71,6 +71,7 @@ public sealed interface FloorFilterState {
     public var selectedFacilityId: String?
     public var selectedLevelId: String?
 
+    public val onSiteChanged: StateFlow<FloorSite?>
     public val onFacilityChanged: StateFlow<FloorFacility?>
     public val onLevelChanged: StateFlow<FloorLevel?>
 
@@ -94,6 +95,9 @@ private class FloorFilterStateImpl(
 
     private val _floorManager: MutableStateFlow<FloorManager?> = MutableStateFlow(null)
     override val floorManager: StateFlow<FloorManager?> = _floorManager.asStateFlow()
+
+    private val _onSiteChanged: MutableStateFlow<FloorSite?> = MutableStateFlow(null)
+    override val onSiteChanged: StateFlow<FloorSite?> = _onSiteChanged.asStateFlow()
 
     private val _onFacilityChanged: MutableStateFlow<FloorFacility?> = MutableStateFlow(null)
     override val onFacilityChanged: StateFlow<FloorFacility?> = _onFacilityChanged.asStateFlow()
@@ -154,6 +158,7 @@ private class FloorFilterStateImpl(
         set(value) {
             _selectedSiteId = value
             selectedFacilityId = null
+            _onSiteChanged.value = getSelectedSite()
             getSelectedSite()?.let {
                 onSelectionChangedListener(
                     FloorFilterSelection(

--- a/toolkit/indoors/src/main/res/values/strings.xml
+++ b/toolkit/indoors/src/main/res/values/strings.xml
@@ -27,5 +27,7 @@
     <!-- This text is used to describe the UI element to support accessibility services -->
     <string name="close">Close</string>
     <!-- This text is used to describe the UI element to support accessibility services -->
+    <string name="collapse">Collapse</string>
+    <!-- This text is used to describe the UI element to support accessibility services -->
     <string name="go_back_to_site_selector">Go back to site selector</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/3853

<!-- link to design, if applicable -->

### Description:

Change the close button to expand/collapse button. Reset the collapsed status of the floor list to expanded again when the user changes the site/facility

### Summary of changes:

- Modify the Close button to be expandable/collapsable in both top and bottom position
- Disable the expand/collapse button when only one floor present
- Add onSiteChanged event to reset the collapse status of the button
- modify automated test to accommodate the change in behavior
- update .api file to include the new event

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/254/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  