### PR TITLE
Authenticator: Dismiss UsernamePassword after credential is provided

### DIFF
--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
@@ -316,17 +316,13 @@ class UsernamePasswordTests {
                 setupFailingArcGISTokenRequestInterceptor()
             }
 
-            // simulate incorrect username/password 4 times
-            repeat(4) {
+            // simulate incorrect username/password 5 times
+            repeat(5) {
                 composeTestRule.enterUsernamePasswordAndLogin()
                 advanceUntilIdle()
-                composeTestRule.onNodeWithText("Invalid username or password.").assertIsDisplayed()
             }
-            // the 5th time is should dismiss the dialog.
-            composeTestRule.enterUsernamePasswordAndLogin()
-            advanceUntilIdle()
 
-            // ensure the dialog has disappeared
+            // ensure the dialog has disappeared after last attempt
             assert(authenticatorState.pendingUsernamePasswordChallenge.value == null)
             composeTestRule.onNodeWithText(usernamePasswordMessage).assertDoesNotExist()
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/3811

<!-- link to design, if applicable -->

### Summary of changes:
- Dismisses UsernamePassword authenticator after credential is provided
- removes `additionalMessage`, see following issue: https://devtopia.esri.com/runtime/kotlin/issues/5108
### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link:https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/274/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  