### PR TITLE
Pull vnext into WorldScaleSceneView feature branch

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ mockkAndroid = "1.13.12"
 room = "2.6.1"
 truth = "1.4.4"
 uiautomator = "2.3.0"
-arcore = "1.46.0"
+arcore = "1.47.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose"}

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneView.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneView.kt
@@ -71,7 +71,12 @@ import com.arcgismaps.mapping.view.TwoPointerTapEvent
 import com.arcgismaps.mapping.view.UpEvent
 import com.arcgismaps.mapping.view.ViewLabelProperties
 import com.arcgismaps.toolkit.ar.internal.ArCameraFeed
+import com.arcgismaps.toolkit.ar.internal.checkArCoreAvailability
 import com.arcgismaps.toolkit.ar.internal.rememberArSessionWrapper
+import com.arcgismaps.toolkit.ar.internal.rememberCameraPermission
+import com.arcgismaps.toolkit.ar.internal.setFieldOfViewFromLensIntrinsics
+import com.arcgismaps.toolkit.ar.internal.transformationMatrix
+import com.arcgismaps.toolkit.ar.internal.update
 import com.arcgismaps.toolkit.geoviewcompose.SceneView
 import com.arcgismaps.toolkit.geoviewcompose.SceneViewDefaults
 import com.google.ar.core.Anchor
@@ -241,25 +246,23 @@ public fun TableTopSceneView(
                     session = arSession,
                     onFrame = { frame, displayRotation ->
                         arCoreAnchor?.let { anchor ->
-                            val anchorPosition = identityMatrix - anchor.pose.transformationMatrix
+                            val anchorPosition = identityMatrix - anchor.pose.translation.let {
+                                TransformationMatrix.createWithQuaternionAndTranslation(
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0,
+                                    it[0].toDouble(),
+                                    it[1].toDouble(),
+                                    it[2].toDouble()
+                                )
+                            }
                             val cameraPosition =
                                 anchorPosition + frame.camera.displayOrientedPose.transformationMatrix
                             cameraController.transformationMatrix = cameraPosition
-                            val imageIntrinsics = frame.camera.imageIntrinsics
                             tableTopSceneViewProxy.sceneViewProxy.setFieldOfViewFromLensIntrinsics(
-                                imageIntrinsics.focalLength[0],
-                                imageIntrinsics.focalLength[1],
-                                imageIntrinsics.principalPoint[0],
-                                imageIntrinsics.principalPoint[1],
-                                imageIntrinsics.imageDimensions[0].toFloat(),
-                                imageIntrinsics.imageDimensions[1].toFloat(),
-                                deviceOrientation = when (displayRotation) {
-                                    0 -> DeviceOrientation.LandscapeLeft
-                                    90 -> DeviceOrientation.Portrait
-                                    180 -> DeviceOrientation.LandscapeRight
-                                    270 -> DeviceOrientation.ReversePortrait
-                                    else -> DeviceOrientation.Portrait
-                                }
+                                frame.camera,
+                                displayRotation
                             )
                             tableTopSceneViewProxy.sceneViewProxy.renderFrame()
                         }
@@ -267,8 +270,7 @@ public fun TableTopSceneView(
                     onTapWithHitResult = { hit ->
                         hit?.let { hitResult ->
                             if (arCoreAnchor == null) {
-                                // use `extractTranslation` to ignore any rotation
-                                arCoreAnchor = hitResult.trackable.createAnchor(hitResult.hitPose.extractTranslation())
+                                arCoreAnchor = hitResult.createAnchor()
                                 // stop rendering planes
                                 visualizePlanes = false
                             }
@@ -335,77 +337,3 @@ public fun TableTopSceneView(
         }
     }
 }
-
-/**
- * Checks if the camera permission is granted and requests it if required.
- *
- * @since 200.6.0
- */
-@Composable
-private fun rememberCameraPermission(
-    requestCameraPermissionAutomatically: Boolean,
-    onNotGranted: () -> Unit
-): MutableState<Boolean> {
-    val cameraPermission = Manifest.permission.CAMERA
-    val context = LocalContext.current
-    val isGrantedState = remember {
-        mutableStateOf(
-            ContextCompat.checkSelfPermission(
-                context,
-                cameraPermission
-            ) == PackageManager.PERMISSION_GRANTED
-        )
-    }
-    if (!isGrantedState.value) {
-        if (requestCameraPermissionAutomatically) {
-            val requestPermissionLauncher =
-                rememberLauncherForActivityResult(contract = ActivityResultContracts.RequestPermission()) { granted ->
-                    isGrantedState.value = granted
-                    if (!granted) {
-                        onNotGranted()
-                    }
-                }
-            SideEffect {
-                requestPermissionLauncher.launch(Manifest.permission.CAMERA)
-            }
-        } else {
-            // We should use a SideEffect here to ensure that code executed in onNotGranted is run
-            // after the composition completes, for example, invoking the onInitializationStatusChanged
-            // callback
-            SideEffect {
-                onNotGranted()
-            }
-        }
-    }
-    return isGrantedState
-}
-
-private suspend fun checkArCoreAvailability(context: Context): ArCoreApk.Availability =
-    suspendCancellableCoroutine { continuation ->
-        ArCoreApk.getInstance().checkAvailabilityAsync(context) {
-            continuation.resume(it)
-        }
-    }
-
-private fun MutableState<TableTopSceneViewStatus>.update(
-    newStatus: TableTopSceneViewStatus,
-    callback: ((TableTopSceneViewStatus) -> Unit)?
-) {
-    this.value = newStatus
-    callback?.invoke(newStatus)
-}
-
-/**
- * Returns a [TransformationMatrix] based on the [Pose]'s rotation and translation.
- *
- * @since 200.6.0
- */
-private val Pose.transformationMatrix: TransformationMatrix
-    get() = TransformationMatrix.createWithQuaternionAndTranslation(
-        qx().toDouble(),
-        qy().toDouble(),
-        qz().toDouble(),
-        qw().toDouble(),
-        tx().toDouble(),
-        ty().toDouble(),
-        tz().toDouble())

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArCameraFeed.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArCameraFeed.kt
@@ -20,13 +20,14 @@ package com.arcgismaps.toolkit.ar.internal
 
 import android.content.Context
 import android.opengl.GLSurfaceView
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
@@ -88,9 +89,10 @@ internal fun ArCameraFeed(
 
     AndroidView(factory = { surfaceViewWrapper.glSurfaceView }, modifier = Modifier
         .fillMaxSize()
-        .pointerInteropFilter {
-            cameraFeedRenderer.onClick(it)
-            true
+        .pointerInput(Unit) {
+            detectTapGestures { offset ->
+                cameraFeedRenderer.onClick(offset)
+            }
         })
 }
 

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/Joyslider.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/Joyslider.kt
@@ -104,6 +104,6 @@ internal fun JoysliderPreview(){
                 style = TextStyle.Default.copy(),
                 text="Value: " + DecimalFormat("#.##").format(value))
         }
-        Joyslider (onValueChange = { newValue -> value += newValue})
+        Joyslider (onValueChange = { newValue -> value += newValue}, contentDescription = "Joyslider")
     }
 }

--- a/toolkit/authentication/build.gradle.kts
+++ b/toolkit/authentication/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.browser)
+    implementation(libs.androidx.material.icons)
     testImplementation(libs.bundles.unitTest)
     androidTestImplementation(libs.bundles.composeTest)
     debugImplementation(libs.bundles.debug)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

<!-- link to design, if applicable -->

### Description:

Pulls v.next into the WSSV feature branch, which is necessary because it includes the changes to the `ArCameraFeed` which fixed positioning issues for the `TableTopSceneView`

### Summary of changes:

- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/306/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  