### PR TITLE
changes to use the font specified in the theme

### DIFF
--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
@@ -60,7 +60,7 @@ class ScalebarTests {
                     maxWidth = 300f,
                     label = "1000 km",
                     colorScheme = ScalebarDefaults.colors(),
-
+                    labelTypography = ScalebarDefaults.typography()
                 )
             }
         composeTestRule.onNodeWithTag(lineScalebarTag).assertIsDisplayed()
@@ -88,7 +88,8 @@ class ScalebarTests {
                 GraduatedLineScalebar(
                     maxWidth = maxWidth,
                     colorScheme = ScalebarDefaults.colors(),
-                    tickMarks = tickMarks
+                    tickMarks = tickMarks,
+                    labelTypography = ScalebarDefaults.typography()
                 )
         }
         composeTestRule.onNodeWithTag(graduatedLineScalebarTag).assertIsDisplayed()
@@ -112,6 +113,7 @@ class ScalebarTests {
                     maxWidth = 300f,
                     label = "1000 km",
                     colorScheme = ScalebarDefaults.colors(lineColor = Color.Red),
+                    labelTypography = ScalebarDefaults.typography()
                 )
             }
         }

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -117,6 +117,7 @@ public fun Scalebar(
             style,
             colorScheme,
             shapes,
+            labelTypography,
             modifier
         )
     }
@@ -129,6 +130,7 @@ private fun ShowScalebar(
     scalebarStyle: ScalebarStyle,
     colorScheme: ScalebarColors,
     shapes: ScalebarShapes,
+    labelTypography: LabelTypography,
     modifier: Modifier = Modifier
 ) {
     when (scalebarStyle) {
@@ -141,6 +143,7 @@ private fun ShowScalebar(
             maxWidth = maxWidth.toFloat(),
             label = labels[0].label,
             colorScheme = colorScheme,
+            labelTypography = labelTypography
         )
     }
 }

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/ScalebarUnits.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/ScalebarUnits.kt
@@ -19,9 +19,6 @@ package com.arcgismaps.toolkit.scalebar
 
 import com.arcgismaps.geometry.LinearUnit
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils
-import kotlin.math.floor
-import kotlin.math.log10
-import kotlin.math.pow
 
 /**
  * A Scalebar unit.

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.arcgismaps.toolkit.scalebar.theme.LabelTypography
 import com.arcgismaps.toolkit.scalebar.theme.ScalebarColors
 import com.arcgismaps.toolkit.scalebar.theme.ScalebarDefaults
 
@@ -46,7 +46,6 @@ private const val pixelAlignment = 2.5f // Aligns the horizontal line edges
 internal const val lineWidth = 5f
 private const val shadowOffset = 3f
 private const val scalebarHeight = 20f // Height of the scalebar in pixels
-private val textSize = 14.sp
 private const val textOffset = 5f
 internal const val labelXPadding = 4f // padding between scalebar labels.
 
@@ -66,10 +65,11 @@ internal fun LineScalebar(
     maxWidth: Float,
     label: String,
     colorScheme: ScalebarColors,
+    labelTypography: LabelTypography
 ) {
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
-    val textSizeInPx = with(density) { textSize.toPx() }
+    val textSizeInPx = with(density) { labelTypography.labelStyle.fontSize.toPx() }
 
     val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInPx
     val totalWidth = maxWidth + shadowOffset + pixelAlignment
@@ -109,6 +109,7 @@ internal fun LineScalebar(
         drawText(
             text = label,
             textMeasurer = textMeasurer,
+            labelTypography = labelTypography,
             xPos = maxWidth / 2,
             color = colorScheme.textColor,
             shadowColor = colorScheme.textShadowColor,
@@ -132,10 +133,11 @@ internal fun GraduatedLineScalebar(
     maxWidth: Float,
     tickMarks: List<ScalebarDivision>,
     colorScheme: ScalebarColors,
+    labelTypography: LabelTypography
 ) {
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
-    val textSizeInPx = with(density) { textSize.toPx() }
+    val textSizeInPx = with(density) { labelTypography.labelStyle.fontSize.toPx() }
 
     val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInPx
     val totalWidth = maxWidth + shadowOffset + pixelAlignment
@@ -151,6 +153,7 @@ internal fun GraduatedLineScalebar(
             color = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor,
             textMeasurer = textMeasurer,
+            labelTypography = labelTypography,
             textColor = colorScheme.textColor,
             textShadowColor = colorScheme.textShadowColor
         )
@@ -177,6 +180,7 @@ internal fun GraduatedLineScalebar(
         drawText(
             text = tickMarks.last().label,
             textMeasurer = textMeasurer,
+            labelTypography = labelTypography,
             xPos = tickMarks.last().xOffset.toFloat(),
             color = colorScheme.textColor,
             shadowColor = colorScheme.textShadowColor,
@@ -198,6 +202,7 @@ internal fun LineScaleBarPreview() {
             maxWidth = 300f,
             label = "1,000 km",
             colorScheme = ScalebarDefaults.colors(lineColor = Color.Red),
+            labelTypography = ScalebarDefaults.typography()
         )
     }
 }
@@ -222,7 +227,8 @@ internal fun GraduatedLineScaleBarPreview() {
             modifier = Modifier,
             maxWidth = maxWidth,
             colorScheme = ScalebarDefaults.colors(),
-            tickMarks = tickMarks
+            tickMarks = tickMarks,
+            labelTypography = ScalebarDefaults.typography()
         )
     }
 }
@@ -322,6 +328,7 @@ private fun DrawScope.drawHorizontalLineAndShadow(
  *
  * @param text The text to be drawn.
  * @param textMeasurer The [TextMeasurer] to measure the text.
+ * @param labelTypography The typography to use for the text.
  * @param xPos The location where the text should be drawn.
  * @param color The color of the text.
  * @param shadowColor The color of the text shadow.
@@ -331,6 +338,7 @@ private fun DrawScope.drawHorizontalLineAndShadow(
 private fun DrawScope.drawText(
     text: String,
     textMeasurer: TextMeasurer,
+    labelTypography: LabelTypography,
     xPos: Float,
     color: Color = Color.Black,
     shadowColor: Color = Color.White,
@@ -338,7 +346,7 @@ private fun DrawScope.drawText(
 ) {
     val measuredText = textMeasurer.measure(
         text = text,
-        style = TextStyle(fontSize = textSize)
+        style = labelTypography.labelStyle
     )
     val alignedXPos = when (alignment) {
         TextAlignment.LEFT -> xPos - measuredText.size.width + pixelAlignment
@@ -365,6 +373,7 @@ private fun DrawScope.drawTickMarksWithLabels(
     color: Color,
     shadowColor: Color,
     textMeasurer: TextMeasurer,
+    labelTypography: LabelTypography,
     textColor: Color,
     textShadowColor: Color
 ) {
@@ -380,6 +389,7 @@ private fun DrawScope.drawTickMarksWithLabels(
         drawText(
             text = tickMarks[i].label,
             textMeasurer = textMeasurer,
+            labelTypography = labelTypography,
             xPos = tickMarks[i].xOffset.toFloat(),
             color = textColor,
             shadowColor = textShadowColor,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextMeasurer
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/theme/ScalebarTheme.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/theme/ScalebarTheme.kt
@@ -140,7 +140,7 @@ public object ScalebarDefaults {
      */
     @Composable
     public fun typography(
-        labelStyle: TextStyle = MaterialTheme.typography.labelSmall
+        labelStyle: TextStyle = MaterialTheme.typography.titleSmall
     ): LabelTypography {
         return LabelTypography(
             labelStyle = labelStyle


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5234

<!-- link to design, if applicable -->

### Description:

Remove the use of textSize constant and use the text size of the text style mentioned in the theme

### Summary of changes:

- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/313/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  