### PR TITLE
Scalebar: Update renderers to use maxWidth

### DIFF
--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
@@ -60,7 +60,7 @@ class ScalebarTests {
         composeTestRule.setContent {
                 LineScalebar(
                     maxWidth = 300f,
-                    displayLength = 290f,
+                    displayLength = 290.0,
                     label = "1000 km",
                     colorScheme = ScalebarDefaults.colors(),
                     labelTypography = ScalebarDefaults.typography(),
@@ -80,7 +80,7 @@ class ScalebarTests {
     @Test
     fun testGraduatedLineScalebarIsDisplayed() {
         val maxWidth = 510f
-        val displayLength = 500f
+        val displayLength = 500.0
         val tickMarks = listOf(
             ScalebarDivision(0, 0.0, 0.0, "0"),
             ScalebarDivision(1, (displayLength / 4.0), 0.0, "25"),
@@ -115,7 +115,7 @@ class ScalebarTests {
         composeTestRule.setContent {
             BarScalebar(
                 maxWidth = 300f,
-                displayLength = 290f,
+                displayLength = 290.0,
                 label = "1000 km",
                 colorScheme = ScalebarDefaults.colors(),
                 shapes = ScalebarDefaults.shapes(),
@@ -141,7 +141,7 @@ class ScalebarTests {
             ) {
                 LineScalebar(
                     maxWidth = 300f,
-                    displayLength = 290f,
+                    displayLength = 290.0,
                     label = "1000 km",
                     colorScheme = ScalebarDefaults.colors(lineColor = Color.Red),
                     labelTypography = ScalebarDefaults.typography(),

--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
@@ -60,6 +60,7 @@ class ScalebarTests {
         composeTestRule.setContent {
                 LineScalebar(
                     maxWidth = 300f,
+                    displayLength = 290f,
                     label = "1000 km",
                     colorScheme = ScalebarDefaults.colors(),
                     labelTypography = ScalebarDefaults.typography(),
@@ -78,18 +79,20 @@ class ScalebarTests {
      */
     @Test
     fun testGraduatedLineScalebarIsDisplayed() {
-        val maxWidth = 500f
+        val maxWidth = 510f
+        val displayLength = 500f
         val tickMarks = listOf(
             ScalebarDivision(0, 0.0, 0.0, "0"),
-            ScalebarDivision(1, (maxWidth / 4.0), 0.0, "25"),
-            ScalebarDivision(2, maxWidth / 2.0, 0.0, "50"),
-            ScalebarDivision(3, (maxWidth / 4.0)* 3, 0.0, "75"),
-            ScalebarDivision(4, maxWidth.toDouble(), 0.0, "100")
+            ScalebarDivision(1, (displayLength / 4.0), 0.0, "25"),
+            ScalebarDivision(2, displayLength / 2.0, 0.0, "50"),
+            ScalebarDivision(3, (displayLength / 4.0)* 3, 0.0, "75"),
+            ScalebarDivision(4, displayLength.toDouble(), 0.0, "100")
         )
         // Test the scalebar
         composeTestRule.setContent {
                 GraduatedLineScalebar(
                     maxWidth = maxWidth,
+                    displayLength = displayLength,
                     colorScheme = ScalebarDefaults.colors(),
                     tickMarks = tickMarks,
                     labelTypography = ScalebarDefaults.typography(),
@@ -112,6 +115,7 @@ class ScalebarTests {
         composeTestRule.setContent {
             BarScalebar(
                 maxWidth = 300f,
+                displayLength = 290f,
                 label = "1000 km",
                 colorScheme = ScalebarDefaults.colors(),
                 shapes = ScalebarDefaults.shapes(),
@@ -137,6 +141,7 @@ class ScalebarTests {
             ) {
                 LineScalebar(
                     maxWidth = 300f,
+                    displayLength = 290f,
                     label = "1000 km",
                     colorScheme = ScalebarDefaults.colors(lineColor = Color.Red),
                     labelTypography = ScalebarDefaults.typography(),

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -34,7 +34,6 @@ import com.arcgismaps.toolkit.scalebar.internal.GraduatedLineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.BarScalebar
 import com.arcgismaps.toolkit.scalebar.internal.LineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarDivision
-import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils.toPx
 import com.arcgismaps.toolkit.scalebar.internal.computeScalebarProperties
 import com.arcgismaps.toolkit.scalebar.internal.computeDivisions
 import com.arcgismaps.toolkit.scalebar.internal.labelXPadding
@@ -106,7 +105,7 @@ public fun Scalebar(
     val density = LocalDensity.current
     Scalebar(
         maxWidth = maxWidth,
-        displayLength = scalebarProperties.displayLength.toPx(density),
+        displayLength = scalebarProperties.displayLength,
         labels = scalebarDivisions,
         scalebarStyle = style,
         colorScheme = colorScheme,
@@ -132,7 +131,7 @@ private fun Scalebar(
         ScalebarStyle.Bar -> BarScalebar(
             modifier = modifier,
             maxWidth = maxWidth.toFloat(),
-            displayLength = displayLength.toFloat(),
+            displayLength = displayLength,
             label = labels[0].label,
             colorScheme = colorScheme,
             labelTypography = labelTypography,
@@ -143,7 +142,7 @@ private fun Scalebar(
         ScalebarStyle.GraduatedLine -> GraduatedLineScalebar(
             modifier = modifier,
             maxWidth = maxWidth.toFloat(),
-            displayLength = displayLength.toFloat(),
+            displayLength = displayLength,
             tickMarks = labels,
             colorScheme = colorScheme,
             labelTypography = labelTypography,
@@ -153,7 +152,7 @@ private fun Scalebar(
         ScalebarStyle.Line -> LineScalebar(
             modifier = modifier,
             maxWidth = maxWidth.toFloat(),
-            displayLength = displayLength.toFloat(),
+            displayLength = displayLength,
             label = labels[0].label,
             colorScheme = colorScheme,
             labelTypography = labelTypography,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -105,7 +105,8 @@ public fun Scalebar(
     // and the labels are updated
     val density = LocalDensity.current
     Scalebar(
-        maxWidth = scalebarProperties.displayLength.toPx(density),
+        maxWidth = maxWidth,
+        displayLength = scalebarProperties.displayLength.toPx(density),
         labels = scalebarDivisions,
         scalebarStyle = style,
         colorScheme = colorScheme,
@@ -118,6 +119,7 @@ public fun Scalebar(
 @Composable
 private fun Scalebar(
     maxWidth: Double,
+    displayLength: Double,
     labels: List<ScalebarDivision>,
     scalebarStyle: ScalebarStyle,
     colorScheme: ScalebarColors,
@@ -130,6 +132,7 @@ private fun Scalebar(
         ScalebarStyle.Bar -> BarScalebar(
             modifier = modifier,
             maxWidth = maxWidth.toFloat(),
+            displayLength = displayLength.toFloat(),
             label = labels[0].label,
             colorScheme = colorScheme,
             labelTypography = labelTypography,
@@ -140,6 +143,7 @@ private fun Scalebar(
         ScalebarStyle.GraduatedLine -> GraduatedLineScalebar(
             modifier = modifier,
             maxWidth = maxWidth.toFloat(),
+            displayLength = displayLength.toFloat(),
             tickMarks = labels,
             colorScheme = colorScheme,
             labelTypography = labelTypography,
@@ -149,6 +153,7 @@ private fun Scalebar(
         ScalebarStyle.Line -> LineScalebar(
             modifier = modifier,
             maxWidth = maxWidth.toFloat(),
+            displayLength = displayLength.toFloat(),
             label = labels[0].label,
             colorScheme = colorScheme,
             labelTypography = labelTypography,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -69,7 +69,7 @@ internal const val labelXPadding = 4f // padding between scalebar labels.
 internal fun LineScalebar(
     modifier: Modifier = Modifier.testTag("LineScalebar"),
     maxWidth: Float,
-    displayLength: Float,
+    displayLength: Double,
     label: String,
     colorScheme: ScalebarColors,
     labelTypography: LabelTypography,
@@ -100,14 +100,14 @@ internal fun LineScalebar(
         drawHorizontalLineAndShadow(
             yPos = scalebarHeight,
             left = 0f,
-            right = displayLength,
+            right = displayLength.toPx(density).toFloat(),
             lineColor = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor
         )
 
         // right line
         drawVerticalLineAndShadow(
-            xPos = displayLength,
+            xPos = displayLength.toPx(density).toFloat(),
             top = 0f,
             bottom = scalebarHeight,
             lineColor = colorScheme.lineColor,
@@ -118,7 +118,7 @@ internal fun LineScalebar(
             text = label,
             textMeasurer = textMeasurer,
             labelTypography = labelTypography,
-            xPos = displayLength / 2,
+            xPos = displayLength.toPx(density).toFloat() / 2,
             color = colorScheme.textColor,
             shadowColor = colorScheme.textShadowColor,
             shadowBlurRadius = shapes.textShadowBlurRadius,
@@ -143,7 +143,7 @@ internal fun LineScalebar(
 internal fun BarScalebar(
     modifier: Modifier = Modifier.testTag("BarScalebar"),
     maxWidth: Float,
-    displayLength: Float,
+    displayLength: Double,
     label: String,
     colorScheme: ScalebarColors,
     shapes: ScalebarShapes,
@@ -166,7 +166,7 @@ internal fun BarScalebar(
         drawRoundRect(
             color = colorScheme.shadowColor,
             topLeft = Offset(topLeftPoint.x + shadowOffset, topLeftPoint.y + shadowOffset),
-            size = Size(displayLength, scalebarHeight),
+            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -176,14 +176,14 @@ internal fun BarScalebar(
             color = colorScheme.fillColor,
             topLeft = topLeftPoint,
             cornerRadius = CornerRadius(shapes.barCornerRadius),
-            size = Size(displayLength, scalebarHeight),
+            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight),
 
         )
         // draws the rectangle's border
         drawRoundRect(
             color = colorScheme.lineColor,
             topLeft = topLeftPoint,
-            size = Size(displayLength, scalebarHeight),
+            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -192,7 +192,7 @@ internal fun BarScalebar(
             text = label,
             textMeasurer = textMeasurer,
             labelTypography = labelTypography,
-            xPos = displayLength / 2.0f,
+            xPos = displayLength.toPx(density).toFloat() / 2.0f,
             color = colorScheme.textColor,
             shadowColor = colorScheme.textShadowColor,
             shadowBlurRadius = shapes.textShadowBlurRadius,
@@ -217,7 +217,7 @@ internal fun BarScalebar(
 internal fun GraduatedLineScalebar(
     modifier: Modifier = Modifier.testTag("GraduatedLineScalebar"),
     maxWidth: Float,
-    displayLength: Float,
+    displayLength: Double,
     tickMarks: List<ScalebarDivision>,
     colorScheme: ScalebarColors,
     labelTypography: LabelTypography,
@@ -254,14 +254,14 @@ internal fun GraduatedLineScalebar(
         drawHorizontalLineAndShadow(
             yPos = scalebarHeight,
             left = 0f,
-            right = displayLength,
+            right = displayLength.toPx(density).toFloat(),
             lineColor = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor
         )
 
         // right line
         drawVerticalLineAndShadow(
-            xPos = displayLength,
+            xPos = displayLength.toPx(density).toFloat(),
             top = 0f,
             bottom = scalebarHeight,
             lineColor = colorScheme.lineColor,
@@ -286,7 +286,7 @@ internal fun GraduatedLineScalebar(
 @Composable
 internal fun LineScaleBarPreview() {
     val maxWidth = 500f
-    val displayLength = 490f
+    val displayLength = 490.0
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -308,7 +308,7 @@ internal fun LineScaleBarPreview() {
 @Composable
 internal fun BarScaleBarPreview() {
     val maxWidth = 500f
-    val displayLength = 490f
+    val displayLength = 490.0
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -330,7 +330,7 @@ internal fun BarScaleBarPreview() {
 @Composable
 internal fun GraduatedLineScaleBarPreview() {
     val maxWidth = 550f
-    val displayLength = 500f
+    val displayLength = 500.0
     val density = LocalDensity.current.density
     val tickMarks = listOf(
         ScalebarDivision(0, 0.0, 0.0, "0"),

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -57,7 +57,8 @@ internal const val labelXPadding = 4f // padding between scalebar labels.
  * Displays a scalebar with single label and endpoint lines.
  *
  * @param modifier The modifier to apply to the layout.
- * @param maxWidth The width of the scalebar in pixels.
+ * @param maxWidth The width of the scalebar container displaying line and text in pixels.
+ * @param displayLength The width of the scalebar in pixels.
  * @param label The scale value to display.
  * @param colorScheme The color scheme to use.
  * @param labelTypography The typography to use for the label.
@@ -68,6 +69,7 @@ internal const val labelXPadding = 4f // padding between scalebar labels.
 internal fun LineScalebar(
     modifier: Modifier = Modifier.testTag("LineScalebar"),
     maxWidth: Float,
+    displayLength: Float,
     label: String,
     colorScheme: ScalebarColors,
     labelTypography: LabelTypography,
@@ -98,14 +100,14 @@ internal fun LineScalebar(
         drawHorizontalLineAndShadow(
             yPos = scalebarHeight,
             left = 0f,
-            right = maxWidth,
+            right = displayLength,
             lineColor = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor
         )
 
         // right line
         drawVerticalLineAndShadow(
-            xPos = maxWidth,
+            xPos = displayLength,
             top = 0f,
             bottom = scalebarHeight,
             lineColor = colorScheme.lineColor,
@@ -116,7 +118,7 @@ internal fun LineScalebar(
             text = label,
             textMeasurer = textMeasurer,
             labelTypography = labelTypography,
-            xPos = maxWidth / 2,
+            xPos = displayLength / 2,
             color = colorScheme.textColor,
             shadowColor = colorScheme.textShadowColor,
             shadowBlurRadius = shapes.textShadowBlurRadius,
@@ -129,7 +131,8 @@ internal fun LineScalebar(
  * Displays bar scalebar with a single label.
  *
  * @param modifier The modifier to apply to the layout.
- * @param maxWidth The width of the scale bar.
+ * @param maxWidth The width of the scalebar container displaying line and text in pixels.
+ * @param displayLength The width of the scale bar.
  * @param label The scale value to display.
  * @param colorScheme The color scheme to use.
  * @param shapes The shape properties to use.
@@ -140,6 +143,7 @@ internal fun LineScalebar(
 internal fun BarScalebar(
     modifier: Modifier = Modifier.testTag("BarScalebar"),
     maxWidth: Float,
+    displayLength: Float,
     label: String,
     colorScheme: ScalebarColors,
     shapes: ScalebarShapes,
@@ -162,7 +166,7 @@ internal fun BarScalebar(
         drawRoundRect(
             color = colorScheme.shadowColor,
             topLeft = Offset(topLeftPoint.x + shadowOffset, topLeftPoint.y + shadowOffset),
-            size = Size(maxWidth, scalebarHeight),
+            size = Size(displayLength, scalebarHeight),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -172,14 +176,14 @@ internal fun BarScalebar(
             color = colorScheme.fillColor,
             topLeft = topLeftPoint,
             cornerRadius = CornerRadius(shapes.barCornerRadius),
-            size = Size(maxWidth, scalebarHeight),
+            size = Size(displayLength, scalebarHeight),
 
         )
         // draws the rectangle's border
         drawRoundRect(
             color = colorScheme.lineColor,
             topLeft = topLeftPoint,
-            size = Size(maxWidth, scalebarHeight),
+            size = Size(displayLength, scalebarHeight),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -188,7 +192,7 @@ internal fun BarScalebar(
             text = label,
             textMeasurer = textMeasurer,
             labelTypography = labelTypography,
-            xPos = maxWidth / 2.0f,
+            xPos = displayLength / 2.0f,
             color = colorScheme.textColor,
             shadowColor = colorScheme.textShadowColor,
             shadowBlurRadius = shapes.textShadowBlurRadius,
@@ -201,7 +205,8 @@ internal fun BarScalebar(
  * Displays a graduated line scalebar with multiple labels and tick marks.
  *
  * @param modifier The modifier to apply to the layout.
- * @param maxWidth The width of the scale bar.
+ * @param maxWidth The width of the scalebar container displaying line and text in pixels.
+ * @param displayLength The width of the scale bar.
  * @param tickMarks The list of tick marks to display.
  * @param colorScheme The color scheme to use.
  * @param labelTypography The typography to use for the label.
@@ -212,6 +217,7 @@ internal fun BarScalebar(
 internal fun GraduatedLineScalebar(
     modifier: Modifier = Modifier.testTag("GraduatedLineScalebar"),
     maxWidth: Float,
+    displayLength: Float,
     tickMarks: List<ScalebarDivision>,
     colorScheme: ScalebarColors,
     labelTypography: LabelTypography,
@@ -248,14 +254,14 @@ internal fun GraduatedLineScalebar(
         drawHorizontalLineAndShadow(
             yPos = scalebarHeight,
             left = 0f,
-            right = maxWidth,
+            right = displayLength,
             lineColor = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor
         )
 
         // right line
         drawVerticalLineAndShadow(
-            xPos = maxWidth,
+            xPos = displayLength,
             top = 0f,
             bottom = scalebarHeight,
             lineColor = colorScheme.lineColor,
@@ -279,6 +285,8 @@ internal fun GraduatedLineScalebar(
 @Preview(showBackground = true, backgroundColor = 0xff91d2ff)
 @Composable
 internal fun LineScaleBarPreview() {
+    val maxWidth = 500f
+    val displayLength = 490f
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -286,7 +294,8 @@ internal fun LineScaleBarPreview() {
     ) {
         LineScalebar(
             modifier = Modifier,
-            maxWidth = 500f / LocalDensity.current.density,
+            maxWidth = maxWidth / LocalDensity.current.density,
+            displayLength = displayLength / LocalDensity.current.density,
             label = "1,000 km",
             colorScheme = ScalebarDefaults.colors(),
             labelTypography = ScalebarDefaults.typography(),
@@ -298,6 +307,8 @@ internal fun LineScaleBarPreview() {
 @Preview(showBackground = true, backgroundColor = 0xff91d2ff)
 @Composable
 internal fun BarScaleBarPreview() {
+    val maxWidth = 500f
+    val displayLength = 490f
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -305,7 +316,8 @@ internal fun BarScaleBarPreview() {
     ) {
         BarScalebar(
             modifier = Modifier,
-            maxWidth = 300f,
+            maxWidth = maxWidth / LocalDensity.current.density,
+            displayLength = displayLength / LocalDensity.current.density,
             label = "1000 km",
             colorScheme = ScalebarDefaults.colors(shadowColor = Color.Red, textShadowColor = Color.Red),
             shapes = ScalebarDefaults.shapes(barCornerRadius = 4f, textShadowBlurRadius = 2f),
@@ -317,14 +329,14 @@ internal fun BarScaleBarPreview() {
 @Preview(showBackground = true, backgroundColor = 0xff91d2ff)
 @Composable
 internal fun GraduatedLineScaleBarPreview() {
-    val maxWidth = 500f
+    val maxWidth = 550f
+    val displayLength = 500f
     val density = LocalDensity.current.density
     val tickMarks = listOf(
         ScalebarDivision(0, 0.0, 0.0, "0"),
-        ScalebarDivision(1, (maxWidth / (4.0 * density)), 0.0, "25"),
-        ScalebarDivision(2, maxWidth / (2.0 * density), 0.0, "50"),
-        ScalebarDivision(3, (maxWidth / (4.0 * density))* 3, 0.0, "75"),
-        ScalebarDivision(4, maxWidth.toDouble()/ density, 0.0, "100 km")
+        ScalebarDivision(1, (displayLength / (3.0 * density)), 0.0, "100"),
+        ScalebarDivision(2, 2.0 * displayLength / (3.0 * density), 0.0, "200"),
+        ScalebarDivision(4, displayLength.toDouble()/ density, 0.0, "300 km")
     )
     Box(
         modifier = Modifier
@@ -334,6 +346,7 @@ internal fun GraduatedLineScaleBarPreview() {
         GraduatedLineScalebar(
             modifier = Modifier,
             maxWidth = maxWidth,
+            displayLength = displayLength,
             colorScheme = ScalebarDefaults.colors(),
             tickMarks = tickMarks,
             labelTypography = ScalebarDefaults.typography(),


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Determine the size of the canvas based on maxWidth and not displayLength of the scalebar

### Summary of changes:

- Updates line, bar and graduatedLine scalebar composables to use maxWidth to determine the size of canvas to draw the scalebar

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/331/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  