### PR TITLE
Scalebar: Refactor `ScalebarProperties.computeDivisions` method

### DIFF
--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarComputationsTest.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarComputationsTest.kt
@@ -158,7 +158,6 @@ class ScalebarComputationsTest {
                 val minimumSegmentWidth = measureMinSegmentWidth(scalebarProperties.scalebarLengthInMapUnits, defaultLabelTypography)
                 val scalebarLabels = scalebarProperties.computeDivisions(
                     minSegmentWidth = minimumSegmentWidth,
-                    labelTypography = defaultLabelTypography,
                     scalebarStyle = style
                 )
                 assertThat(scalebarProperties.displayLength.roundToInt()).isEqualTo(displayLength)

--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
@@ -82,11 +82,11 @@ class ScalebarTests {
         val maxWidth = 510f
         val displayLength = 500.0
         val tickMarks = listOf(
-            ScalebarDivision(0, 0.0, 0.0, "0"),
-            ScalebarDivision(1, (displayLength / 4.0), 0.0, "25"),
-            ScalebarDivision(2, displayLength / 2.0, 0.0, "50"),
-            ScalebarDivision(3, (displayLength / 4.0)* 3, 0.0, "75"),
-            ScalebarDivision(4, displayLength.toDouble(), 0.0, "100")
+            ScalebarDivision(0.0, "0"),
+            ScalebarDivision((displayLength / 4.0), "25"),
+            ScalebarDivision(displayLength / 2.0, "50"),
+            ScalebarDivision((displayLength / 4.0)* 3, "75"),
+            ScalebarDivision(displayLength.toDouble(), "100")
         )
         // Test the scalebar
         composeTestRule.setContent {

--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
@@ -140,10 +140,10 @@ class ScalebarTests {
         val maxWidth = 550f
         val displayLength = 500.0
         val scalebarDivisions = listOf(
-            ScalebarDivision(0, 0.0, 0.0, "0"),
-            ScalebarDivision(1, (displayLength / 3.0), 0.0, "100"),
-            ScalebarDivision(2, 2.0 * displayLength / 3.0, 0.0, "200"),
-            ScalebarDivision(3, displayLength, 0.0, "300 km")
+            ScalebarDivision(0.0, "0"),
+            ScalebarDivision((displayLength / 3.0), "100"),
+            ScalebarDivision(2.0 * displayLength / 3.0, "200"),
+            ScalebarDivision(displayLength, "300 km")
         )
         // Test the scalebar
         composeTestRule.setContent {

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -96,7 +96,6 @@ public fun Scalebar(
     // update the label text and offsets
     val scalebarDivisions = scalebarProperties.computeDivisions(
         minSegmentWidth = minSegmentWidth,
-        labelTypography = labelTypography,
         scalebarStyle = style
     )
     // invoked after the scalebar properties displayLength, displayUnit are computed

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarDivision.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarDivision.kt
@@ -11,8 +11,6 @@ package com.arcgismaps.toolkit.scalebar.internal
  * @since 200.7.0
  */
 internal data class ScalebarDivision(
-    val index: Int,
     val xOffset: Double,
-    val labelYOffset: Double,
     val label: String
 )

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarDivision.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarDivision.kt
@@ -3,9 +3,7 @@ package com.arcgismaps.toolkit.scalebar.internal
 /**
  * Represents a Scalebar division.
  *
- * @param index The index of the division.
  * @param xOffset The x offset of the division.
- * @param labelYOffset The y offset of the division's label from the scalebar.
  * @param label The text of the division's label.
  *
  * @since 200.7.0

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
@@ -66,7 +66,7 @@ internal fun ScalebarProperties.computeDivisions(
 ): List<ScalebarDivision> {
     return if (scalebarStyle == ScalebarStyle.Bar || scalebarStyle == ScalebarStyle.Line) {
         listOf(
-            genratePrimaryDivision(
+            createPrimaryDivision(
                 displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
                 scalebarLengthInMapUnits = scalebarLengthInMapUnits,
                 xOffset = displayLength
@@ -106,7 +106,7 @@ internal fun ScalebarProperties.computeDivisions(
         }
 
         localLabels.add(
-            genratePrimaryDivision(
+            createPrimaryDivision(
                 displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
                 scalebarLengthInMapUnits = scalebarLengthInMapUnits,
                 xOffset = displayLength
@@ -118,11 +118,12 @@ internal fun ScalebarProperties.computeDivisions(
 }
 
 /**
- * Generates the last label for the scalebar.
+ * Creates the primary scalebar division.
  *
+ * It contains the length and [displayUnitAbbreviation].
  * @since 200.7.0
  */
-private fun genratePrimaryDivision(
+private fun createPrimaryDivision(
     displayUnitAbbreviation: String,
     scalebarLengthInMapUnits: Double,
     xOffset: Double,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
@@ -66,7 +66,7 @@ internal fun ScalebarProperties.computeDivisions(
 ): List<ScalebarDivision> {
     return if (scalebarStyle == ScalebarStyle.Bar || scalebarStyle == ScalebarStyle.Line) {
         listOf(
-            generateLastLabel(
+            genratePrimaryDivision(
                 displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
                 scalebarLengthInMapUnits = scalebarLengthInMapUnits,
                 xOffset = displayLength
@@ -106,7 +106,7 @@ internal fun ScalebarProperties.computeDivisions(
         }
 
         localLabels.add(
-            generateLastLabel(
+            genratePrimaryDivision(
                 displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
                 scalebarLengthInMapUnits = scalebarLengthInMapUnits,
                 xOffset = displayLength
@@ -122,7 +122,7 @@ internal fun ScalebarProperties.computeDivisions(
  *
  * @since 200.7.0
  */
-private fun generateLastLabel(
+private fun genratePrimaryDivision(
     displayUnitAbbreviation: String,
     scalebarLengthInMapUnits: Double,
     xOffset: Double,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
@@ -30,7 +30,6 @@ import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils.baseLinearUnit
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils.closestDistanceWithoutGoingOver
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils.format
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils.linearUnitsForDistance
-import com.arcgismaps.toolkit.scalebar.theme.LabelTypography
 
 
 /**
@@ -52,67 +51,87 @@ internal data class ScalebarProperties(
     }
 }
 
+private const val MAX_NUM_OF_SEGMENTS = 4
+
 /**
  * Computes the scalebar divisions based on the given parameters.
  *
  * @param minSegmentWidth The minimum width of a segment.
- * @param labelTypography The typography for the labels.
  * @param scalebarStyle The style of the scalebar.
  * @since 200.7.0
  */
 internal fun ScalebarProperties.computeDivisions(
     minSegmentWidth: Double,
-    labelTypography: LabelTypography,
     scalebarStyle: ScalebarStyle
 ): List<ScalebarDivision> {
-    val suggestedNumSegments = (displayLength / minSegmentWidth).toInt()
-
-    // Cap segments at 4
-    val maxNumSegments = minOf(suggestedNumSegments, 4)
-
-    val numSegments = ScalebarUtils.numSegments(
-        scalebarLengthInMapUnits,
-        maxNumSegments
-    )
-
-    val segmentScreenLength = displayLength / numSegments
-    var currSegmentX = 0.0
-    val localLabels = mutableListOf<ScalebarDivision>()
-
-    localLabels.add(
-        ScalebarDivision(
-            index = -1,
-            xOffset = 0.0 ,
-            labelYOffset = labelTypography.labelStyle.fontSize.value / 2.0,
-            label = "0"
+    return if (scalebarStyle == ScalebarStyle.Bar || scalebarStyle == ScalebarStyle.Line) {
+        listOf(
+            generateLastLabel(
+                displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
+                scalebarLengthInMapUnits = scalebarLengthInMapUnits,
+                xOffset = displayLength
+            )
         )
-    )
+    } else {
+        val suggestedNumSegments = (displayLength / minSegmentWidth).toInt()
+        val maxNumSegments = minOf(suggestedNumSegments, MAX_NUM_OF_SEGMENTS)
 
-    for (index in 0 until numSegments) {
-        currSegmentX += segmentScreenLength
-        val segmentMapLength: Double = (segmentScreenLength * (index + 1) / displayLength) * scalebarLengthInMapUnits
+        val numSegments = ScalebarUtils.numSegments(
+            scalebarLengthInMapUnits,
+            maxNumSegments
+        )
 
-        val segmentText: String = if (index == numSegments - 1) {
-            val displayUnitAbbr = mapUnitsToDisplay.getAbbreviation()
-            "${segmentMapLength.format()} $displayUnitAbbr"
-        } else {
-            segmentMapLength.format()
+        val segmentScreenLength = displayLength / numSegments
+        var currSegmentX = 0.0
+        val localLabels = mutableListOf<ScalebarDivision>()
+
+        // Add the first label at 0
+        localLabels.add(
+            ScalebarDivision(
+                xOffset = 0.0,
+                label = "0"
+            )
+        )
+
+        for (index in 1 until numSegments) {
+            currSegmentX += segmentScreenLength
+            val segmentLengthInMapUnits: Double =
+                (segmentScreenLength * index / displayLength) * scalebarLengthInMapUnits
+
+            val label = ScalebarDivision(
+                xOffset = currSegmentX,
+                label = segmentLengthInMapUnits.format()
+            )
+            localLabels.add(label)
         }
 
-        val label = ScalebarDivision(
-            index = index,
-            xOffset = currSegmentX,
-            labelYOffset = labelTypography.labelStyle.fontSize.value / 2.0,
-            label = segmentText
+        localLabels.add(
+            generateLastLabel(
+                displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
+                scalebarLengthInMapUnits = scalebarLengthInMapUnits,
+                xOffset = displayLength
+            )
         )
-        localLabels.add(label)
-    }
 
-    return if (scalebarStyle == ScalebarStyle.Bar || scalebarStyle == ScalebarStyle.Line) {
-        localLabels.takeLast(1)
-    } else {
         localLabels
     }
+}
+
+/**
+ * Generates the last label for the scalebar.
+ *
+ * @since 200.7.0
+ */
+private fun generateLastLabel(
+    displayUnitAbbreviation: String,
+    scalebarLengthInMapUnits: Double,
+    xOffset: Double,
+): ScalebarDivision {
+    val label = ScalebarDivision(
+        xOffset = xOffset,
+        label = "${scalebarLengthInMapUnits.format()} $displayUnitAbbreviation"
+    )
+    return label
 }
 
 /**

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -451,10 +451,10 @@ internal fun AlternatingBarScaleBarPreview() {
     val displayLength = 500.0
     val density = LocalDensity.current.density
     val scalebarDivisions = listOf(
-        ScalebarDivision(0, 0.0, 0.0, "0"),
-        ScalebarDivision(1, 0.33 * (displayLength / density), 0.0, "100"),
-        ScalebarDivision(2, 0.66 * (displayLength / density), 0.0, "200"),
-        ScalebarDivision(4, displayLength / density, 0.0, "300 km")
+        ScalebarDivision(0.0, "0"),
+        ScalebarDivision(0.33 * (displayLength / density),"100"),
+        ScalebarDivision(0.66 * (displayLength / density), "200"),
+        ScalebarDivision(displayLength / density,"300 km")
     )
     Box(
         modifier = Modifier

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -333,10 +333,10 @@ internal fun GraduatedLineScaleBarPreview() {
     val displayLength = 500.0
     val density = LocalDensity.current.density
     val tickMarks = listOf(
-        ScalebarDivision(0, 0.0, 0.0, "0"),
-        ScalebarDivision(1, (displayLength / (3.0 * density)), 0.0, "100"),
-        ScalebarDivision(2, 2.0 * displayLength / (3.0 * density), 0.0, "200"),
-        ScalebarDivision(4, displayLength.toDouble()/ density, 0.0, "300 km")
+        ScalebarDivision(0.0,  "0"),
+        ScalebarDivision((displayLength / (3.0 * density)),  "100"),
+        ScalebarDivision(2.0 * displayLength / (3.0 * density), "200"),
+        ScalebarDivision(displayLength.toDouble()/ density,  "300 km")
     )
     Box(
         modifier = Modifier


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

### Summary of changes:
- Refactors method `computeDivisions` to exit early when the scalebar type is Line or Bar 

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/355/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  