### PR TITLE
Scalebar: Adds test for Scalebar property `minScale`

### DIFF
--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
@@ -19,14 +19,20 @@ package com.arcgismaps.toolkit.scalebar
 import android.graphics.Bitmap
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import com.arcgismaps.geometry.Point
+import com.arcgismaps.geometry.SpatialReference
+import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.toolkit.scalebar.internal.AlternatingBarScalebar
 import com.arcgismaps.toolkit.scalebar.internal.BarScalebar
 import com.arcgismaps.toolkit.scalebar.internal.GraduatedLineScalebar
@@ -46,6 +52,9 @@ class ScalebarTests {
     private val graduatedLineScalebarTag = "GraduatedLineScalebar"
     private val barScalebarTag = "BarScalebar"
     private val alternatingBarScalebarTag = "AlternatingBarScalebar"
+    private val scalebarTag = "Scalebar"
+    private val esriRedlands = Point(-13046081.04434825, 4036489.208008117, SpatialReference.webMercator())
+
     @get:Rule
     val composeTestRule = createComposeRule()
 
@@ -102,6 +111,37 @@ class ScalebarTests {
                 )
         }
         composeTestRule.onNodeWithTag(graduatedLineScalebarTag).assertIsDisplayed()
+    }
+
+    /**
+     * Given a scalebar with a given minScale value
+     * When the initial viewpoint is at the same minScale
+     * Then the scalebar should not be drawn
+     * When the viewpoint is changed to a lower scale
+     * Then the scalebar should be shown
+     *
+     * @since 200.7.0
+     */
+    @Test
+    fun testScalebarMinScale() {
+        val minScale = 3125000.0
+        val viewPoint = mutableStateOf(Viewpoint(esriRedlands, minScale))
+        composeTestRule.setContent {
+            Scalebar(
+                minScale = minScale,
+                modifier = Modifier.testTag(scalebarTag),
+                maxWidth = 175.0,
+                unitsPerDip = 2645.833333330476,
+                viewpoint = viewPoint.value,
+                spatialReference = SpatialReference.webMercator(),
+                style = ScalebarStyle.Line,
+            )
+        }
+        composeTestRule.onNodeWithTag(scalebarTag).assertIsNotDisplayed()
+        composeTestRule.runOnUiThread {
+            viewPoint.value = Viewpoint(esriRedlands, minScale - 1000)
+        }
+        composeTestRule.onNodeWithTag(scalebarTag).assertIsDisplayed()
     }
 
     /**


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #https://devtopia.esri.com/runtime/kotlin/issues/5278

<!-- link to design, if applicable -->

### Summary of changes:
- adds automated test to verify that `Scalebar` is not displayed when the a viewpoint's `minScale` is lower than the one set on `Scalebar`
- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/352/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  