### PR TITLE
Change maxWidth from Double to Dp

### DIFF
--- a/microapps/ScalebarApp/app/src/main/java/com/arcgismaps/toolkit/scalebarapp/screens/MainScreen.kt
+++ b/microapps/ScalebarApp/app/src/main/java/com/arcgismaps/toolkit/scalebarapp/screens/MainScreen.kt
@@ -77,7 +77,7 @@ fun MainScreen(modifier: Modifier) {
                 .align(Alignment.BottomStart)
         ) {
             Scalebar(
-                maxWidth = 175.0,
+                maxWidth = 175.dp,
                 unitsPerDip = unitsPerDip,
                 viewpoint = viewpoint,
                 spatialReference = spatialReference,

--- a/toolkit/scalebar/api/scalebar.api
+++ b/toolkit/scalebar/api/scalebar.api
@@ -1,5 +1,5 @@
 public final class com/arcgismaps/toolkit/scalebar/ScalebarKt {
-	public static final fun Scalebar-MPUtEvE (DDLcom/arcgismaps/mapping/Viewpoint;Lcom/arcgismaps/geometry/SpatialReference;Landroidx/compose/ui/Modifier;JDZLcom/arcgismaps/toolkit/scalebar/ScalebarStyle;Lcom/arcgismaps/UnitSystem;Lcom/arcgismaps/toolkit/scalebar/theme/ScalebarColors;Lcom/arcgismaps/toolkit/scalebar/theme/ScalebarShapes;Lcom/arcgismaps/toolkit/scalebar/theme/LabelTypography;Landroidx/compose/runtime/Composer;III)V
+	public static final fun Scalebar-TCCHP28 (FDLcom/arcgismaps/mapping/Viewpoint;Lcom/arcgismaps/geometry/SpatialReference;Landroidx/compose/ui/Modifier;JDZLcom/arcgismaps/toolkit/scalebar/ScalebarStyle;Lcom/arcgismaps/UnitSystem;Lcom/arcgismaps/toolkit/scalebar/theme/ScalebarColors;Lcom/arcgismaps/toolkit/scalebar/theme/ScalebarShapes;Lcom/arcgismaps/toolkit/scalebar/theme/LabelTypography;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/arcgismaps/toolkit/scalebar/ScalebarStyle : java/lang/Enum {

--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarComputationsTest.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarComputationsTest.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.arcgismaps.UnitSystem
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.geometry.SpatialReference
@@ -58,7 +60,7 @@ class ScalebarComputationsTest {
             x = esriRedlands.x,
             y = esriRedlands.y,
             style = ScalebarStyle.Line,
-            maxWidth = 175.0,
+            maxWidth = 175.dp,
             units = UnitSystem.Metric,
             scale = 10000000.0,
             unitsPerDip = 2645.833333330476,
@@ -80,7 +82,7 @@ class ScalebarComputationsTest {
             x = esriRedlands.x,
             y = esriRedlands.y,
             style = ScalebarStyle.Bar,
-            maxWidth = 175.0,
+            maxWidth = 175.dp,
             units = UnitSystem.Metric,
             scale = 10000000.0,
             unitsPerDip = 2645.833333330476,
@@ -102,7 +104,7 @@ class ScalebarComputationsTest {
             x = esriRedlands.x,
             y = esriRedlands.y,
             style = ScalebarStyle.GraduatedLine,
-            maxWidth = 175.0,
+            maxWidth = 175.dp,
             units = UnitSystem.Metric,
             scale = 10000000.0,
             unitsPerDip = 2645.833333330476,
@@ -124,7 +126,7 @@ class ScalebarComputationsTest {
             x = esriRedlands.x,
             y = esriRedlands.y,
             style = ScalebarStyle.AlternatingBar,
-            maxWidth = 175.0,
+            maxWidth = 175.dp,
             units = UnitSystem.Metric,
             scale = 10000000.0,
             unitsPerDip = 2645.833333330476,
@@ -143,7 +145,7 @@ class ScalebarComputationsTest {
         y: Double,
         spatialReference: SpatialReference = SpatialReference.webMercator(),
         style: ScalebarStyle,
-        maxWidth: Double,
+        maxWidth: Dp,
         units: UnitSystem,
         scale: Double,
         unitsPerDip: Double,
@@ -167,7 +169,7 @@ class ScalebarComputationsTest {
             ) {
                 val defaultLabelTypography = ScalebarDefaults.typography()
 
-                val availableLineDisplayLength = measureAvailableLineDisplayLength(maxWidth, defaultLabelTypography, style)
+                val availableLineDisplayLength = measureAvailableLineDisplayLength(maxWidth.value.toDouble(), defaultLabelTypography, style)
                 val scalebarProperties = computeScalebarProperties(
                     0.0,
                     spatialReference,

--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarComputationsTest.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarComputationsTest.kt
@@ -27,8 +27,8 @@ import com.arcgismaps.UnitSystem
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.Viewpoint
-import com.arcgismaps.toolkit.scalebar.internal.computeScalebarProperties
 import com.arcgismaps.toolkit.scalebar.internal.computeDivisions
+import com.arcgismaps.toolkit.scalebar.internal.computeScalebarProperties
 import com.arcgismaps.toolkit.scalebar.theme.ScalebarDefaults
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest

--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
@@ -132,7 +132,7 @@ class ScalebarTests {
             Scalebar(
                 minScale = minScale,
                 modifier = Modifier.testTag(scalebarTag),
-                maxWidth = 175.0,
+                maxWidth = 175.dp,
                 unitsPerDip = 2645.833333330476,
                 viewpoint = viewPoint.value,
                 spatialReference = SpatialReference.webMercator(),

--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.scalebar.internal.AlternatingBarScalebar
 import com.arcgismaps.toolkit.scalebar.internal.BarScalebar
 import com.arcgismaps.toolkit.scalebar.internal.GraduatedLineScalebar
@@ -61,8 +62,8 @@ class ScalebarTests {
         // Test the scalebar
         composeTestRule.setContent {
                 LineScalebar(
-                    maxWidth = 300f,
-                    displayLength = 290.0,
+                    maxWidth = 175.dp,
+                    displayLength = 160.0,
                     label = "1000 km",
                     colorScheme = ScalebarDefaults.colors(),
                     labelTypography = ScalebarDefaults.typography(),
@@ -81,8 +82,8 @@ class ScalebarTests {
      */
     @Test
     fun testGraduatedLineScalebarIsDisplayed() {
-        val maxWidth = 510f
-        val displayLength = 500.0
+        val maxWidth = 175.dp
+        val displayLength = 139.3
         val tickMarks = listOf(
             ScalebarDivision(0, 0.0, 0.0, "0"),
             ScalebarDivision(1, (displayLength / 4.0), 0.0, "25"),
@@ -116,8 +117,8 @@ class ScalebarTests {
         // Test the scalebar
         composeTestRule.setContent {
             BarScalebar(
-                maxWidth = 300f,
-                displayLength = 290.0,
+                maxWidth = 175.dp,
+                displayLength = 160.0,
                 label = "1000 km",
                 colorScheme = ScalebarDefaults.colors(),
                 shapes = ScalebarDefaults.shapes(),
@@ -137,8 +138,8 @@ class ScalebarTests {
     @Test
     fun testAlternatingBarScaleBarIsDisplayed(){
         // Test the scalebar
-        val maxWidth = 550f
-        val displayLength = 500.0
+        val maxWidth = 175.dp
+        val displayLength = 139.3
         val scalebarDivisions = listOf(
             ScalebarDivision(0, 0.0, 0.0, "0"),
             ScalebarDivision(1, (displayLength / 3.0), 0.0, "100"),
@@ -174,8 +175,8 @@ class ScalebarTests {
                 contentAlignment = Alignment.BottomCenter
             ) {
                 LineScalebar(
-                    maxWidth = 300f,
-                    displayLength = 290.0,
+                    maxWidth = 175.dp,
+                    displayLength = 160.0,
                     label = "1000 km",
                     colorScheme = ScalebarDefaults.colors(lineColor = Color.Red),
                     labelTypography = ScalebarDefaults.typography(),

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -244,7 +244,7 @@ private fun rememberDefaultUnitSystem(): UnitSystem {
 }
 
 /**
- * Returns the display length in pixels of the Scalebar line.
+ * Returns the display length in device independent pixels of the Scalebar line.
  *
  * @return maxWidth the maximum width of the Scalebar taking into account the text units
  * @since 200.7.0

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.arcgismaps.UnitSystem
 import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.Viewpoint
@@ -37,8 +38,8 @@ import com.arcgismaps.toolkit.scalebar.internal.GraduatedLineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.LineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarDivision
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarProperties
-import com.arcgismaps.toolkit.scalebar.internal.computeScalebarProperties
 import com.arcgismaps.toolkit.scalebar.internal.computeDivisions
+import com.arcgismaps.toolkit.scalebar.internal.computeScalebarProperties
 import com.arcgismaps.toolkit.scalebar.internal.labelXPadding
 import com.arcgismaps.toolkit.scalebar.internal.lineWidth
 import com.arcgismaps.toolkit.scalebar.theme.LabelTypography
@@ -47,7 +48,6 @@ import com.arcgismaps.toolkit.scalebar.theme.ScalebarDefaults
 import com.arcgismaps.toolkit.scalebar.theme.ScalebarShapes
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import androidx.compose.ui.unit.dp
 
 /**
  * A composable UI component to display a Scalebar.

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import com.arcgismaps.UnitSystem
 import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.Viewpoint
@@ -46,6 +47,7 @@ import com.arcgismaps.toolkit.scalebar.theme.ScalebarDefaults
 import com.arcgismaps.toolkit.scalebar.theme.ScalebarShapes
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import androidx.compose.ui.unit.dp
 
 /**
  * A composable UI component to display a Scalebar.
@@ -58,7 +60,7 @@ import kotlin.time.Duration.Companion.seconds
  */
 @Composable
 public fun Scalebar(
-    maxWidth: Double, //  maximum screen width allotted to the scalebar
+    maxWidth: Dp, //  maximum screen width allotted to the scalebar
     unitsPerDip: Double,
     viewpoint: Viewpoint?,
     spatialReference: SpatialReference?,
@@ -73,7 +75,7 @@ public fun Scalebar(
     labelTypography: LabelTypography = ScalebarDefaults.typography()
 ) {
     val availableLineDisplayLength =
-        measureAvailableLineDisplayLength(maxWidth, labelTypography, style)
+        measureAvailableLineDisplayLength(maxWidth.value.toDouble(), labelTypography, style)
 
     val scalebarProperties by remember(spatialReference, viewpoint, unitsPerDip, availableLineDisplayLength) {
         mutableStateOf(
@@ -116,7 +118,7 @@ public fun Scalebar(
 
 @Composable
 private fun Scalebar(
-    maxWidth: Double,
+    maxWidth: Dp,
     displayLength: Double,
     labels: List<ScalebarDivision>,
     scalebarStyle: ScalebarStyle,
@@ -131,7 +133,7 @@ private fun Scalebar(
     when (scalebarStyle) {
         ScalebarStyle.AlternatingBar -> AlternatingBarScalebar(
             modifier = modifier,
-            maxWidth = maxWidth.toFloat(),
+            maxWidth = maxWidth,
             displayLength = displayLength,
             scalebarDivisions = labels,
             colorScheme = colorScheme,
@@ -140,7 +142,7 @@ private fun Scalebar(
         )
         ScalebarStyle.Bar -> BarScalebar(
             modifier = modifier,
-            maxWidth = maxWidth.toFloat(),
+            maxWidth = maxWidth,
             displayLength = displayLength,
             label = labels[0].label,
             colorScheme = colorScheme,
@@ -151,7 +153,7 @@ private fun Scalebar(
         ScalebarStyle.DualUnitLine -> TODO()
         ScalebarStyle.GraduatedLine -> GraduatedLineScalebar(
             modifier = modifier,
-            maxWidth = maxWidth.toFloat(),
+            maxWidth = maxWidth,
             displayLength = displayLength,
             tickMarks = labels,
             colorScheme = colorScheme,
@@ -161,7 +163,7 @@ private fun Scalebar(
 
         ScalebarStyle.Line -> LineScalebar(
             modifier = modifier,
-            maxWidth = maxWidth.toFloat(),
+            maxWidth = maxWidth,
             displayLength = displayLength,
             label = labels[0].label,
             colorScheme = colorScheme,
@@ -175,7 +177,7 @@ private fun Scalebar(
 @Composable
 internal fun ScalebarPreview() {
     Scalebar(
-        maxWidth = 200.0,
+        maxWidth = 200.dp,
         spatialReference = null,
         unitsPerDip = 1.0,
         viewpoint = Viewpoint(0.0, 0.0, 0.0),

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -82,7 +82,7 @@ import kotlin.time.Duration.Companion.seconds
  */
 @Composable
 public fun Scalebar(
-    maxWidth: Dp, //  maximum screen width allotted to the scalebar
+    maxWidth: Dp,
     unitsPerDip: Double,
     viewpoint: Viewpoint?,
     spatialReference: SpatialReference?,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -278,7 +278,8 @@ internal fun measureAvailableLineDisplayLength(
 }
 
 /**
- * Returns the minimum segment width in pixels required to display the labels without overlapping.
+ * Returns the minimum segment width in device independent pixels required to display the labels
+ * without overlapping.
  *
  * @return minimum segment width
  * @since 200.7.0

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
@@ -32,7 +32,6 @@ import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils.format
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils.linearUnitsForDistance
 import com.arcgismaps.toolkit.scalebar.theme.LabelTypography
 
-
 /**
  * A data class to hold the properties of the Scalebar.
  *

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils.toPx
 import com.arcgismaps.toolkit.scalebar.theme.LabelTypography
@@ -46,12 +47,12 @@ import com.arcgismaps.toolkit.scalebar.theme.ScalebarColors
 import com.arcgismaps.toolkit.scalebar.theme.ScalebarDefaults
 import com.arcgismaps.toolkit.scalebar.theme.ScalebarShapes
 
-private const val pixelAlignment = 2.5f // Aligns the horizontal line edges
+private val pixelAlignment = 1.dp // Aligns the horizontal line edges
 internal val lineWidth = 2.dp
-private const val shadowOffset = 3f
-private const val scalebarHeight = 20f // Height of the scalebar in pixels
-private const val textOffset = 5f
-internal const val labelXPadding = 4f // padding between scalebar labels.
+private val shadowOffset = 1.dp
+private val scalebarHeight = 7.dp // Height of the scalebar in pixels
+private val textOffset = 7.dp
+internal const val labelXPadding = 4f // padding between scalebar labels
 
 /**
  * Displays a scalebar with single label and endpoint lines.
@@ -68,7 +69,7 @@ internal const val labelXPadding = 4f // padding between scalebar labels.
 @Composable
 internal fun LineScalebar(
     modifier: Modifier = Modifier.testTag("LineScalebar"),
-    maxWidth: Float,
+    maxWidth: Dp,
     displayLength: Double,
     label: String,
     colorScheme: ScalebarColors,
@@ -77,28 +78,28 @@ internal fun LineScalebar(
 ) {
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
-    val textSizeInPx = with(density) { labelTypography.labelStyle.fontSize.toPx() }
+    val textSizeInDp = with(density) { labelTypography.labelStyle.fontSize.toDp() }
 
-    val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInPx
+    val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInDp
     val totalWidth = maxWidth + shadowOffset + pixelAlignment
 
     Canvas(
         modifier = modifier
-            .width(calculateSizeInDp(density, totalWidth))
-            .height(calculateSizeInDp(density, totalHeight))
+            .width(totalWidth)
+            .height(totalHeight)
     ) {
         // left line
         drawVerticalLineAndShadow(
             xPos = 0f,
             top = 0f,
-            bottom = scalebarHeight,
+            bottom = scalebarHeight.toPx(),
             lineColor = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor
         )
 
         // bottom line
         drawHorizontalLineAndShadow(
-            yPos = scalebarHeight,
+            yPos = scalebarHeight.toPx(),
             left = 0f,
             right = displayLength.toPx(density).toFloat(),
             lineColor = colorScheme.lineColor,
@@ -109,7 +110,7 @@ internal fun LineScalebar(
         drawVerticalLineAndShadow(
             xPos = displayLength.toPx(density).toFloat(),
             top = 0f,
-            bottom = scalebarHeight,
+            bottom = scalebarHeight.toPx(),
             lineColor = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor
         )
@@ -142,7 +143,7 @@ internal fun LineScalebar(
 @Composable
 internal fun BarScalebar(
     modifier: Modifier = Modifier.testTag("BarScalebar"),
-    maxWidth: Float,
+    maxWidth: Dp,
     displayLength: Double,
     label: String,
     colorScheme: ScalebarColors,
@@ -151,22 +152,22 @@ internal fun BarScalebar(
 ) {
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
-    val textSizeInPx = with(density) { labelTypography.labelStyle.fontSize.toPx() }
+    val textSizeInDp = with(density) { labelTypography.labelStyle.fontSize.toDp() }
 
-    val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInPx
+    val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInDp
     val totalWidth = maxWidth + shadowOffset + pixelAlignment
     val topLeftPoint = Offset(0f, 0f)
 
     Canvas(
         modifier = modifier
-            .width(calculateSizeInDp(density, totalWidth))
-            .height(calculateSizeInDp(density, totalHeight))
+            .width(totalWidth)
+            .height(totalHeight)
     ) {
         // draws the rectangle's shadow
         drawRoundRect(
             color = colorScheme.shadowColor,
-            topLeft = Offset(topLeftPoint.x + shadowOffset, topLeftPoint.y + shadowOffset),
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight),
+            topLeft = Offset(topLeftPoint.x + shadowOffset.toPx(), topLeftPoint.y + shadowOffset.toPx()),
+            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -176,14 +177,14 @@ internal fun BarScalebar(
             color = colorScheme.fillColor,
             topLeft = topLeftPoint,
             cornerRadius = CornerRadius(shapes.barCornerRadius),
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight),
+            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
 
         )
         // draws the rectangle's border
         drawRoundRect(
             color = colorScheme.lineColor,
             topLeft = topLeftPoint,
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight),
+            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -216,7 +217,7 @@ internal fun BarScalebar(
 @Composable
 internal fun AlternatingBarScalebar(
     modifier: Modifier = Modifier.testTag("AlternatingBarScalebar"),
-    maxWidth: Float,
+    maxWidth: Dp,
     displayLength: Double,
     scalebarDivisions: List<ScalebarDivision>,
     colorScheme: ScalebarColors,
@@ -225,22 +226,22 @@ internal fun AlternatingBarScalebar(
 ) {
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
-    val textSizeInPx = with(density) { labelTypography.labelStyle.fontSize.toPx() }
+    val textSizeInDp = with(density) { labelTypography.labelStyle.fontSize.toDp() }
 
-    val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInPx
+    val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInDp
     val totalWidth = maxWidth + shadowOffset + pixelAlignment
     val topLeftPoint = Offset(0f, 0f)
 
     Canvas(
         modifier = modifier
-            .width(calculateSizeInDp(density, totalWidth))
-            .height(calculateSizeInDp(density, totalHeight))
+            .width(totalWidth)
+            .height(totalHeight)
     ) {
         // draws the rectangle's shadow
         drawRoundRect(
             color = colorScheme.shadowColor,
-            topLeft = Offset(topLeftPoint.x + shadowOffset, topLeftPoint.y + shadowOffset),
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight),
+            topLeft = Offset(topLeftPoint.x + shadowOffset.toPx(), topLeftPoint.y + shadowOffset.toPx()),
+            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -255,14 +256,14 @@ internal fun AlternatingBarScalebar(
                 color = if (index % 2 == 0) colorScheme.fillColor else colorScheme.alternateFillColor,
                 topLeft = Offset(startX + lineWidth.toPx() / 2, 0f),
                 cornerRadius = CornerRadius(shapes.barCornerRadius),
-                size = Size(width - lineWidth.toPx(), scalebarHeight)
+                size = Size(width - lineWidth.toPx(), scalebarHeight.toPx())
             )
 
             // Draw the segment line
             drawLine(
                 color = colorScheme.lineColor,
                 start = Offset(endX, 0f),
-                end = Offset(endX, scalebarHeight),
+                end = Offset(endX, scalebarHeight.toPx()),
                 strokeWidth = lineWidth.toPx(),
             )
 
@@ -283,7 +284,7 @@ internal fun AlternatingBarScalebar(
         drawRoundRect(
             color = colorScheme.lineColor,
             topLeft = topLeftPoint,
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight),
+            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -305,7 +306,7 @@ internal fun AlternatingBarScalebar(
 @Composable
 internal fun GraduatedLineScalebar(
     modifier: Modifier = Modifier.testTag("GraduatedLineScalebar"),
-    maxWidth: Float,
+    maxWidth: Dp,
     displayLength: Double,
     tickMarks: List<ScalebarDivision>,
     colorScheme: ScalebarColors,
@@ -314,15 +315,15 @@ internal fun GraduatedLineScalebar(
 ) {
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
-    val textSizeInPx = with(density) { labelTypography.labelStyle.fontSize.toPx() }
+    val textSizeInDp = with(density) { labelTypography.labelStyle.fontSize.toDp() }
 
-    val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInPx
+    val totalHeight = scalebarHeight + shadowOffset + textOffset + textSizeInDp
     val totalWidth = maxWidth + shadowOffset + pixelAlignment
 
     Canvas(
         modifier = modifier
-            .width(calculateSizeInDp(density, totalWidth))
-            .height(calculateSizeInDp(density, totalHeight))
+            .width(totalWidth)
+            .height(totalHeight)
     ) {
         val tickMarksWithDensityOffsets = tickMarks.map { tickMark ->
             tickMark.copy(xOffset = tickMark.xOffset.toPx(density))
@@ -341,7 +342,7 @@ internal fun GraduatedLineScalebar(
 
         // bottom line
         drawHorizontalLineAndShadow(
-            yPos = scalebarHeight,
+            yPos = scalebarHeight.toPx(),
             left = 0f,
             right = displayLength.toPx(density).toFloat(),
             lineColor = colorScheme.lineColor,
@@ -352,7 +353,7 @@ internal fun GraduatedLineScalebar(
         drawVerticalLineAndShadow(
             xPos = displayLength.toPx(density).toFloat(),
             top = 0f,
-            bottom = scalebarHeight,
+            bottom = scalebarHeight.toPx(),
             lineColor = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor
         )
@@ -374,8 +375,8 @@ internal fun GraduatedLineScalebar(
 @Preview(showBackground = true, backgroundColor = 0xff91d2ff)
 @Composable
 internal fun LineScaleBarPreview() {
-    val maxWidth = 500f
-    val displayLength = 490.0
+    val maxWidth = 175.dp
+    val displayLength = 160.0
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -383,8 +384,8 @@ internal fun LineScaleBarPreview() {
     ) {
         LineScalebar(
             modifier = Modifier,
-            maxWidth = maxWidth / LocalDensity.current.density,
-            displayLength = displayLength / LocalDensity.current.density,
+            maxWidth = maxWidth,
+            displayLength = displayLength,
             label = "1,000 km",
             colorScheme = ScalebarDefaults.colors(),
             labelTypography = ScalebarDefaults.typography(),
@@ -396,8 +397,8 @@ internal fun LineScaleBarPreview() {
 @Preview(showBackground = true, backgroundColor = 0xff91d2ff)
 @Composable
 internal fun BarScaleBarPreview() {
-    val maxWidth = 500f
-    val displayLength = 490.0
+    val maxWidth = 175.dp
+    val displayLength = 160.0
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -405,8 +406,8 @@ internal fun BarScaleBarPreview() {
     ) {
         BarScalebar(
             modifier = Modifier,
-            maxWidth = maxWidth / LocalDensity.current.density,
-            displayLength = displayLength / LocalDensity.current.density,
+            maxWidth = maxWidth,
+            displayLength = displayLength,
             label = "1000 km",
             colorScheme = ScalebarDefaults.colors(shadowColor = Color.Red, textShadowColor = Color.Red),
             shapes = ScalebarDefaults.shapes(barCornerRadius = 4f, textShadowBlurRadius = 2f),
@@ -418,14 +419,13 @@ internal fun BarScaleBarPreview() {
 @Preview(showBackground = true, backgroundColor = 0xff91d2ff)
 @Composable
 internal fun GraduatedLineScaleBarPreview() {
-    val maxWidth = 550f
-    val displayLength = 500.0
-    val density = LocalDensity.current.density
+    val maxWidth = 175.dp
+    val displayLength = 139.3
     val tickMarks = listOf(
         ScalebarDivision(0, 0.0, 0.0, "0"),
-        ScalebarDivision(1, 0.33 * (displayLength / density), 0.0, "100"),
-        ScalebarDivision(2, 0.66 * (displayLength / density), 0.0, "200"),
-        ScalebarDivision(4, displayLength / density, 0.0, "300 km")
+        ScalebarDivision(1, 0.33 * displayLength, 0.0, "100"),
+        ScalebarDivision(2, 0.66 * displayLength, 0.0, "200"),
+        ScalebarDivision(4, displayLength, 0.0, "300 km")
     )
     Box(
         modifier = Modifier
@@ -435,7 +435,7 @@ internal fun GraduatedLineScaleBarPreview() {
         GraduatedLineScalebar(
             modifier = Modifier,
             maxWidth = maxWidth,
-            displayLength = displayLength / density,
+            displayLength = displayLength,
             colorScheme = ScalebarDefaults.colors(),
             tickMarks = tickMarks,
             labelTypography = ScalebarDefaults.typography(),
@@ -447,14 +447,13 @@ internal fun GraduatedLineScaleBarPreview() {
 @Preview(showBackground = true, backgroundColor = 0xff91d2ff)
 @Composable
 internal fun AlternatingBarScaleBarPreview() {
-    val maxWidth = 550f
-    val displayLength = 500.0
-    val density = LocalDensity.current.density
+    val maxWidth = 175.dp
+    val displayLength = 139.3
     val scalebarDivisions = listOf(
         ScalebarDivision(0, 0.0, 0.0, "0"),
-        ScalebarDivision(1, 0.33 * (displayLength / density), 0.0, "100"),
-        ScalebarDivision(2, 0.66 * (displayLength / density), 0.0, "200"),
-        ScalebarDivision(4, displayLength / density, 0.0, "300 km")
+        ScalebarDivision(1, 0.33 * displayLength, 0.0, "100"),
+        ScalebarDivision(2, 0.66 * displayLength, 0.0, "200"),
+        ScalebarDivision(4, displayLength, 0.0, "300 km")
     )
     Box(
         modifier = Modifier
@@ -464,7 +463,7 @@ internal fun AlternatingBarScaleBarPreview() {
         AlternatingBarScalebar(
             modifier = Modifier,
             maxWidth = maxWidth,
-            displayLength = displayLength / density,
+            displayLength = displayLength,
             colorScheme = ScalebarDefaults.colors(),
             scalebarDivisions = scalebarDivisions,
             labelTypography = ScalebarDefaults.typography(),
@@ -523,8 +522,8 @@ private fun DrawScope.drawVerticalLineAndShadow(
         // draw shadow
         drawLine(
             color = shadowColor,
-            start = Offset(xPos + shadowOffset, top),
-            end = Offset(xPos + shadowOffset, bottom),
+            start = Offset(xPos + shadowOffset.toPx(), top),
+            end = Offset(xPos + shadowOffset.toPx(), bottom),
             strokeWidth = lineWidth.toPx(),
         )
         drawLine(
@@ -550,14 +549,14 @@ private fun DrawScope.drawHorizontalLineAndShadow(
     // draw shadow
     drawLine(
         color = shadowColor,
-        start = Offset((left - pixelAlignment) + shadowOffset, yPos + shadowOffset),
-        end = Offset((right + pixelAlignment) + shadowOffset, yPos + shadowOffset),
+        start = Offset((left - pixelAlignment.toPx()) + shadowOffset.toPx(), yPos + shadowOffset.toPx()),
+        end = Offset((right + pixelAlignment.toPx()) + shadowOffset.toPx(), yPos + shadowOffset.toPx()),
         strokeWidth = lineWidth.toPx(),
     )
     drawLine(
         color = lineColor,
-        start = Offset(left - pixelAlignment, yPos),
-        end = Offset(right + pixelAlignment, yPos),
+        start = Offset(left - pixelAlignment.toPx(), yPos),
+        end = Offset(right + pixelAlignment.toPx(), yPos),
         strokeWidth = lineWidth.toPx(),
     )
 }
@@ -590,11 +589,11 @@ private fun DrawScope.drawText(
         style = labelTypography.labelStyle
     )
     val alignedXPos = when (alignment) {
-        TextAlignment.LEFT -> xPos - measuredText.size.width + pixelAlignment
+        TextAlignment.LEFT -> xPos - measuredText.size.width + pixelAlignment.toPx()
         TextAlignment.CENTER -> xPos - (measuredText.size.width / 2)
-        TextAlignment.RIGHT -> xPos - pixelAlignment
+        TextAlignment.RIGHT -> xPos - pixelAlignment.toPx()
     }
-    val yPos = scalebarHeight + textOffset
+    val yPos = scalebarHeight.toPx() + textOffset.value
     drawText(
         measuredText,
         color = color,
@@ -628,7 +627,7 @@ private fun DrawScope.drawTickMarksWithLabels(
         drawVerticalLineAndShadow(
             xPos = tickMarks[i].xOffset.toFloat(),
             top = 0f,
-            bottom = scalebarHeight,
+            bottom = scalebarHeight.toPx() + shadowOffset.toPx(),
             lineColor = color,
             shadowColor = shadowColor
         )

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -57,7 +57,7 @@ internal const val labelXPadding = 4f // padding between scalebar labels
  * Displays a scalebar with single label and endpoint lines.
  *
  * @param modifier The modifier to apply to the layout.
- * @param maxWidth The width of the scalebar container displaying line and text in pixels.
+ * @param maxWidth The width of the scalebar container displaying line and text in dp.
  * @param displayLength The width of the scalebar in pixels.
  * @param label The scale value to display.
  * @param colorScheme The color scheme to use.
@@ -131,7 +131,7 @@ internal fun LineScalebar(
  * Displays bar scalebar with a single label.
  *
  * @param modifier The modifier to apply to the layout.
- * @param maxWidth The width of the scale bar container displaying line and text in pixels.
+ * @param maxWidth The width of the scale bar container displaying line and text in dp.
  * @param displayLength The width of the scale bar.
  * @param label The scale value to display.
  * @param colorScheme The color scheme to use.
@@ -205,7 +205,7 @@ internal fun BarScalebar(
  * Displays AlternatingBar scalebar with segmented bars of alternating fill color.
  *
  * @param modifier The modifier to apply to the layout.
- * @param maxWidth The width of the scale bar container displaying line and text in pixels.
+ * @param maxWidth The width of the scale bar container displaying line and text in dp.
  * @param displayLength The width of the scale bar.
  * @param scalebarDivisions The scale value to display.
  * @param colorScheme The color scheme to use.
@@ -294,7 +294,7 @@ internal fun AlternatingBarScalebar(
  * Displays a graduated line scalebar with multiple labels and tick marks.
  *
  * @param modifier The modifier to apply to the layout.
- * @param maxWidth The width of the scale bar container displaying line and text in pixels.
+ * @param maxWidth The width of the scale bar container displaying line and text in dp.
  * @param displayLength The width of the scale bar.
  * @param tickMarks The list of tick marks to display.
  * @param colorScheme The color scheme to use.

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -100,14 +100,14 @@ internal fun LineScalebar(
         drawHorizontalLineAndShadow(
             yPos = scalebarHeight.toPx(),
             left = 0f,
-            right = displayLength.toPx(density).toFloat(),
+            right = displayLength.toPx(density),
             lineColor = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor
         )
 
         // right line
         drawVerticalLineAndShadow(
-            xPos = displayLength.toPx(density).toFloat(),
+            xPos = displayLength.toPx(density),
             top = 0f,
             bottom = scalebarHeight.toPx(),
             lineColor = colorScheme.lineColor,
@@ -118,7 +118,7 @@ internal fun LineScalebar(
             text = label,
             textMeasurer = textMeasurer,
             labelTypography = labelTypography,
-            xPos = displayLength.toPx(density).toFloat() / 2,
+            xPos = displayLength.toPx(density) / 2,
             color = colorScheme.textColor,
             shadowColor = colorScheme.textShadowColor,
             shadowBlurRadius = shapes.textShadowBlurRadius,
@@ -166,7 +166,7 @@ internal fun BarScalebar(
         drawRoundRect(
             color = colorScheme.shadowColor,
             topLeft = Offset(topLeftPoint.x + shadowOffset.toPx(), topLeftPoint.y + shadowOffset.toPx()),
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
+            size = Size(displayLength.toPx(density), scalebarHeight.toPx()),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -176,14 +176,14 @@ internal fun BarScalebar(
             color = colorScheme.fillColor,
             topLeft = topLeftPoint,
             cornerRadius = CornerRadius(shapes.barCornerRadius),
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
+            size = Size(displayLength.toPx(density), scalebarHeight.toPx()),
 
         )
         // draws the rectangle's border
         drawRoundRect(
             color = colorScheme.lineColor,
             topLeft = topLeftPoint,
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
+            size = Size(displayLength.toPx(density), scalebarHeight.toPx()),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -192,7 +192,7 @@ internal fun BarScalebar(
             text = label,
             textMeasurer = textMeasurer,
             labelTypography = labelTypography,
-            xPos = displayLength.toPx(density).toFloat() / 2.0f,
+            xPos = displayLength.toPx(density) / 2.0f,
             color = colorScheme.textColor,
             shadowColor = colorScheme.textShadowColor,
             shadowBlurRadius = shapes.textShadowBlurRadius,
@@ -240,14 +240,14 @@ internal fun AlternatingBarScalebar(
         drawRoundRect(
             color = colorScheme.shadowColor,
             topLeft = Offset(topLeftPoint.x + shadowOffset.toPx(), topLeftPoint.y + shadowOffset.toPx()),
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
+            size = Size(displayLength.toPx(density), scalebarHeight.toPx()),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
         // Draws the alternating fill colors, bars and text labels
         for (index in scalebarDivisions.indices) {
-            val startX = if (index == 0) 0f else scalebarDivisions[index - 1].xOffset.toPx(density).toFloat()
-            val endX = scalebarDivisions[index].xOffset.toPx(density).toFloat()
+            val startX = if (index == 0) 0f else scalebarDivisions[index - 1].xOffset.toPx(density)
+            val endX = scalebarDivisions[index].xOffset.toPx(density)
             val width = endX - startX
 
             // Draw the inner fill color
@@ -271,7 +271,7 @@ internal fun AlternatingBarScalebar(
                 text = scalebarDivisions[index].label,
                 textMeasurer = textMeasurer,
                 labelTypography = labelTypography,
-                xPos = scalebarDivisions[index].xOffset.toPx(density).toFloat(),
+                xPos = scalebarDivisions[index].xOffset.toPx(density),
                 color = colorScheme.textColor,
                 shadowColor = colorScheme.textShadowColor,
                 shadowBlurRadius = shapes.textShadowBlurRadius,
@@ -283,7 +283,7 @@ internal fun AlternatingBarScalebar(
         drawRoundRect(
             color = colorScheme.lineColor,
             topLeft = topLeftPoint,
-            size = Size(displayLength.toPx(density).toFloat(), scalebarHeight.toPx()),
+            size = Size(displayLength.toPx(density), scalebarHeight.toPx()),
             cornerRadius = CornerRadius(shapes.barCornerRadius),
             style = Stroke(width = lineWidth.toPx())
         )
@@ -325,7 +325,7 @@ internal fun GraduatedLineScalebar(
             .height(totalHeight)
     ) {
         val tickMarksWithPixelOffsets = tickMarks.map { tickMark ->
-            tickMark.copy(xOffset = tickMark.xOffset.toPx(density))
+            tickMark.copy(xOffset = tickMark.xOffset.toPx(density).toDouble())
         }
         // draw tick marks
         drawTickMarksWithLabels(
@@ -343,14 +343,14 @@ internal fun GraduatedLineScalebar(
         drawHorizontalLineAndShadow(
             yPos = scalebarHeight.toPx(),
             left = 0f,
-            right = displayLength.toPx(density).toFloat(),
+            right = displayLength.toPx(density),
             lineColor = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor
         )
 
         // right line
         drawVerticalLineAndShadow(
-            xPos = displayLength.toPx(density).toFloat(),
+            xPos = displayLength.toPx(density),
             top = 0f,
             bottom = scalebarHeight.toPx(),
             lineColor = colorScheme.lineColor,
@@ -362,7 +362,7 @@ internal fun GraduatedLineScalebar(
             text = tickMarks.last().label,
             textMeasurer = textMeasurer,
             labelTypography = labelTypography,
-            xPos = tickMarks.last().xOffset.toPx(density).toFloat(),
+            xPos = tickMarks.last().xOffset.toPx(density),
             color = colorScheme.textColor,
             shadowColor = colorScheme.textShadowColor,
             shadowBlurRadius = shapes.textShadowBlurRadius,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -473,15 +473,6 @@ internal fun AlternatingBarScaleBarPreview() {
 }
 
 /**
- * Calculates the size in dp based on the density of the device.
- *
- * @since 200.7.0
- */
-private fun calculateSizeInDp(density: Density, value: Float) = with(density) {
-    value.toDp()
-}
-
-/**
  * Used to align the text relative to an anchor point in the scalebar.
  *
  * @since 200.7.0

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarUtils.toPx
@@ -276,7 +275,7 @@ internal fun AlternatingBarScalebar(
                 color = colorScheme.textColor,
                 shadowColor = colorScheme.textShadowColor,
                 shadowBlurRadius = shapes.textShadowBlurRadius,
-                alignment = TextAlignment.CENTER
+                alignment = if (index == 0) TextAlignment.RIGHT else TextAlignment.CENTER
             )
         }
 
@@ -325,12 +324,12 @@ internal fun GraduatedLineScalebar(
             .width(totalWidth)
             .height(totalHeight)
     ) {
-        val tickMarksWithDensityOffsets = tickMarks.map { tickMark ->
+        val tickMarksWithPixelOffsets = tickMarks.map { tickMark ->
             tickMark.copy(xOffset = tickMark.xOffset.toPx(density))
         }
         // draw tick marks
         drawTickMarksWithLabels(
-            tickMarks = tickMarksWithDensityOffsets,
+            tickMarks = tickMarksWithPixelOffsets,
             color = colorScheme.lineColor,
             shadowColor = colorScheme.shadowColor,
             textMeasurer = textMeasurer,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarUtils.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarUtils.kt
@@ -138,7 +138,7 @@ internal object ScalebarUtils {
      *
      * @since 200.7.0
      */
-    fun Double.toPx(density: Density): Double = this * density.density
+    fun Double.toPx(density: Density): Float = (this * density.density).toFloat()
 
     /**
      * Determines an appropriate base linear unit for this [UnitSystem].


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5282

<!-- link to design, if applicable -->

### Description:

Changes `maxWidth` from Double to Dp

### Summary of changes:

- Change `maxWidth` type from Double to Dp
- Update Internal constants values from Double to Dp
- Update usage of constants by converting them to pixels
- Update usage of maxHeight and maxWidth to use directly as now they are calculated in Dp
- Remove unused calculateSizeInDp() fun

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/354/
  - [x] https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/358/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  