### PR TITLE
Add Changes for DualUnitLine

### DIFF
--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarComputationsTest.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarComputationsTest.kt
@@ -115,6 +115,28 @@ class ScalebarComputationsTest {
 
     /**
      * Given a Scalebar
+     * When the Scalebar of Dual unit line style is updated
+     * Then the display length and labels should be correct
+     *
+     * @since 200.7.0
+     */
+    @Test
+    fun testDualUnitLineStyle() = runTest {
+        testScalebar(
+            x = esriRedlands.x,
+            y = esriRedlands.y,
+            style = ScalebarStyle.DualUnitLine,
+            maxWidth = 175.dp,
+            units = UnitSystem.Metric,
+            scale = 10000000.0,
+            unitsPerDip = 2645.833333330476,
+            displayLength = 137,
+            labels = listOf("300 km", "175 mi")
+        )
+    }
+
+    /**
+     * Given a Scalebar
      * When the Scalebar of AlternatingBar style is updated
      * Then the display length and labels should be correct
      *
@@ -182,7 +204,8 @@ class ScalebarComputationsTest {
                 val minimumSegmentWidth = measureMinSegmentWidth(scalebarProperties.scalebarLengthInMapUnits, defaultLabelTypography)
                 val scalebarLabels = scalebarProperties.computeDivisions(
                     minSegmentWidth = minimumSegmentWidth,
-                    scalebarStyle = style
+                    scalebarStyle = style,
+                    units = units
                 )
                 assertThat(scalebarProperties.displayLength.roundToInt()).isEqualTo(displayLength)
                 assertThat(scalebarLabels.size).isEqualTo(labels.size)

--- a/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
+++ b/toolkit/scalebar/src/androidTest/java/com/arcgismaps/toolkit/scalebar/ScalebarTests.kt
@@ -36,6 +36,7 @@ import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.toolkit.scalebar.internal.AlternatingBarScalebar
 import com.arcgismaps.toolkit.scalebar.internal.BarScalebar
+import com.arcgismaps.toolkit.scalebar.internal.DualUnitLineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.GraduatedLineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.LineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarDivision
@@ -54,6 +55,7 @@ class ScalebarTests {
     private val graduatedLineScalebarTag = "GraduatedLineScalebar"
     private val barScalebarTag = "BarScalebar"
     private val alternatingBarScalebarTag = "AlternatingBarScalebar"
+    private val dualUnitLineScalebarTag = "DualUnitLineScalebar"
     private val scalebarTag = "Scalebar"
     private val esriRedlands = Point(-13046081.04434825, 4036489.208008117, SpatialReference.webMercator())
 
@@ -167,6 +169,33 @@ class ScalebarTests {
             )
         }
         composeTestRule.onNodeWithTag(barScalebarTag).assertIsDisplayed()
+    }
+
+    /**
+     * Given a dual unit line scalebar
+     * When it is displayed
+     * Then it should be visible
+     *
+     * @since 200.7.0
+     */
+    @Test
+    fun testDualUnitLineScalebarIsDisplayed() {
+        val maxWidth = 175.dp
+        val displayLength = 139.3
+        val endScalebarDivision = ScalebarDivision(displayLength, "3000 mi")
+        val alternateScalebarDivision = ScalebarDivision(0.75 * (displayLength),"3500 Km")
+        // Test the scalebar
+        composeTestRule.setContent {
+            DualUnitLineScalebar(
+                maxWidth = maxWidth,
+                primaryScalebarDivision = endScalebarDivision,
+                alternateScalebarDivision = alternateScalebarDivision,
+                colorScheme = ScalebarDefaults.colors(),
+                labelTypography = ScalebarDefaults.typography(),
+                shapes = ScalebarDefaults.shapes()
+            )
+        }
+        composeTestRule.onNodeWithTag(dualUnitLineScalebarTag).assertIsDisplayed()
     }
 
     /**

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -43,6 +43,7 @@ import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.toolkit.scalebar.internal.AlternatingBarScalebar
 import com.arcgismaps.toolkit.scalebar.internal.BarScalebar
+import com.arcgismaps.toolkit.scalebar.internal.DualUnitLineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.GraduatedLineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.LineScalebar
 import com.arcgismaps.toolkit.scalebar.internal.ScalebarDivision
@@ -129,7 +130,8 @@ public fun Scalebar(
     // update the label text and offsets
     val scalebarDivisions = scalebarProperties.computeDivisions(
         minSegmentWidth = minSegmentWidth,
-        scalebarStyle = style
+        scalebarStyle = style,
+        units = units
     )
 
     AnimatedVisibility(
@@ -186,7 +188,16 @@ private fun Scalebar(
             shapes = shapes
         )
 
-        ScalebarStyle.DualUnitLine -> TODO()
+        ScalebarStyle.DualUnitLine -> DualUnitLineScalebar(
+            modifier = modifier,
+            maxWidth = maxWidth,
+            primaryScalebarDivision = labels.first(),
+            alternateScalebarDivision = labels.last(),
+            colorScheme = colorScheme,
+            labelTypography = labelTypography,
+            shapes = shapes
+        )
+
         ScalebarStyle.GraduatedLine -> GraduatedLineScalebar(
             modifier = modifier,
             maxWidth = maxWidth,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarProperties.kt
@@ -64,59 +64,69 @@ internal fun ScalebarProperties.computeDivisions(
     scalebarStyle: ScalebarStyle,
     units: UnitSystem
 ): List<ScalebarDivision> {
-    return if (scalebarStyle == ScalebarStyle.Bar || scalebarStyle == ScalebarStyle.Line) {
-        listOf(
-            createPrimaryDivision(
-                displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
-                scalebarLengthInMapUnits = scalebarLengthInMapUnits,
-                xOffset = displayLength
+    return when (scalebarStyle) {
+        ScalebarStyle.Bar,ScalebarStyle.Line -> {
+            listOf(
+                createPrimaryDivision(
+                    displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
+                    scalebarLengthInMapUnits = scalebarLengthInMapUnits,
+                    xOffset = displayLength
+                )
             )
-        )
-    } else {
-        val suggestedNumSegments = (displayLength / minSegmentWidth).toInt()
-        val maxNumSegments = minOf(suggestedNumSegments, MAX_NUM_OF_SEGMENTS)
-
-        val numSegments = ScalebarUtils.numSegments(
-            scalebarLengthInMapUnits,
-            maxNumSegments
-        )
-
-        val segmentScreenLength = displayLength / numSegments
-        var currSegmentX = 0.0
-        var localLabels = mutableListOf<ScalebarDivision>()
-
-        // Add the first label at 0
-        localLabels.add(
-            ScalebarDivision(
-                xOffset = 0.0,
-                label = "0"
-            )
-        )
-
-        for (index in 1 until numSegments) {
-            currSegmentX += segmentScreenLength
-            val segmentLengthInMapUnits: Double =
-                (segmentScreenLength * index / displayLength) * scalebarLengthInMapUnits
-
-            val label = ScalebarDivision(
-                xOffset = currSegmentX,
-                label = segmentLengthInMapUnits.format()
-            )
-            localLabels.add(label)
         }
-
-        localLabels.add(
-            createPrimaryDivision(
-                displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
-                scalebarLengthInMapUnits = scalebarLengthInMapUnits,
-                xOffset = displayLength
+        ScalebarStyle.DualUnitLine -> {
+            listOf(
+                createPrimaryDivision(
+                    displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
+                    scalebarLengthInMapUnits = scalebarLengthInMapUnits,
+                    xOffset = displayLength
+                ),
+                computeAlternateUnitScalebarDivision(units)
             )
-        )
-        if (scalebarStyle == ScalebarStyle.DualUnitLine) {
-            localLabels = mutableListOf(localLabels.last(), computeAlternateUnitScalebarDivision(units))
         }
+        else -> {
+            val suggestedNumSegments = (displayLength / minSegmentWidth).toInt()
+            val maxNumSegments = minOf(suggestedNumSegments, MAX_NUM_OF_SEGMENTS)
 
-        localLabels
+            val numSegments = ScalebarUtils.numSegments(
+                scalebarLengthInMapUnits,
+                maxNumSegments
+            )
+
+            val segmentScreenLength = displayLength / numSegments
+            var currSegmentX = 0.0
+            val localLabels = mutableListOf<ScalebarDivision>()
+
+            // Add the first label at 0
+            localLabels.add(
+                ScalebarDivision(
+                    xOffset = 0.0,
+                    label = "0"
+                )
+            )
+
+            for (index in 1 until numSegments) {
+                currSegmentX += segmentScreenLength
+                val segmentLengthInMapUnits: Double =
+                    (segmentScreenLength * index / displayLength) * scalebarLengthInMapUnits
+
+                val label = ScalebarDivision(
+                    xOffset = currSegmentX,
+                    label = segmentLengthInMapUnits.format()
+                )
+                localLabels.add(label)
+            }
+
+            localLabels.add(
+                createPrimaryDivision(
+                    displayUnitAbbreviation = mapUnitsToDisplay.getAbbreviation(),
+                    scalebarLengthInMapUnits = scalebarLengthInMapUnits,
+                    xOffset = displayLength
+                )
+            )
+            
+            localLabels
+        }
     }
 }
 

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -398,10 +398,13 @@ internal fun DualUnitLineScalebar(
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
     val textSizeInPx = with(density) { labelTypography.labelStyle.fontSize.toDp() }
+
     val totalHeight: Dp = scalebarHeight + (textSizeInPx * 2) + shadowOffset + (textOffset * 2)
     val totalWidth = maxWidth + shadowOffset + pixelAlignment
+
     val totalHeightInPx = with(density) { totalHeight.toPx() }
     val scalebarHeightInPx = with(density) { scalebarHeight.toPx() }
+
     Canvas(
         modifier = modifier
             .width(totalWidth)

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -54,7 +54,7 @@ private val textOffset = 7.dp
 internal const val labelXPadding = 4f // padding between scalebar labels
 
 /**
- * Displays a scalebar with single label and endpoint lines.
+ * Displays a line scalebar with single label and endpoint lines.
  *
  * @param modifier The modifier to apply to the layout.
  * @param maxWidth The width of the scalebar container displaying line and text in dp.
@@ -371,6 +371,101 @@ internal fun GraduatedLineScalebar(
     }
 }
 
+/**
+ * Displays a dual unit line scalebar with scale length and measurements in primary and
+ * alternate unit.
+ *
+ * @param modifier The modifier to apply to the layout.
+ * @param maxWidth The width of the scale bar container displaying line and text in dp.
+ * @param primaryScalebarDivision The end segment for the primary unit.
+ * @param alternateScalebarDivision The end segment for the alternate unit.
+ * @param colorScheme The color scheme to use.
+ * @param labelTypography The typography to use for the labels.
+ * @param shapes The shape properties to use.
+ *
+ * @since 200.7.0
+ */
+@Composable
+internal fun DualUnitLineScalebar(
+    modifier: Modifier = Modifier.testTag("DualUnitLineScalebar"),
+    maxWidth: Dp,
+    primaryScalebarDivision: ScalebarDivision,
+    alternateScalebarDivision: ScalebarDivision,
+    colorScheme: ScalebarColors,
+    labelTypography: LabelTypography,
+    shapes: ScalebarShapes
+) {
+    val textMeasurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    val textSizeInPx = with(density) { labelTypography.labelStyle.fontSize.toDp() }
+    val totalHeight: Dp = scalebarHeight + (textSizeInPx * 2) + shadowOffset + (textOffset * 2)
+    val totalWidth = maxWidth + shadowOffset + pixelAlignment
+    val totalHeightInPx = with(density) { totalHeight.toPx() }
+    val scalebarHeightInPx = with(density) { scalebarHeight.toPx() }
+    Canvas(
+        modifier = modifier
+            .width(totalWidth)
+            .height(totalHeight)
+    ) {
+        // left end line
+        drawVerticalLineAndShadow(
+            xPos = 0f,
+            top = totalHeightInPx / 2 - scalebarHeightInPx,
+            bottom = (totalHeightInPx / 2) + scalebarHeightInPx + lineWidth.toPx(),
+            lineColor = colorScheme.lineColor,
+            shadowColor = colorScheme.shadowColor
+        )
+        // Scalebar line
+        drawHorizontalLineAndShadow(
+            yPos = totalHeightInPx / 2,
+            left = lineWidth.toPx(),
+            right = primaryScalebarDivision.xOffset.toPx(density).toFloat(),
+            lineColor = colorScheme.lineColor,
+            shadowColor = colorScheme.shadowColor
+        )
+        // right end line
+        drawVerticalLineAndShadow(
+            xPos = primaryScalebarDivision.xOffset.toPx(density).toFloat(),
+            top = totalHeightInPx / 2 - scalebarHeightInPx,
+            bottom = totalHeightInPx / 2,
+            lineColor = colorScheme.lineColor,
+            shadowColor = colorScheme.shadowColor
+        )
+        // draw last label
+        drawText(
+            text = primaryScalebarDivision.label,
+            textMeasurer = textMeasurer,
+            labelTypography = labelTypography,
+            xPos = primaryScalebarDivision.xOffset.toPx(density).toFloat(),
+            yPos = 0f,
+            color = colorScheme.textColor,
+            shadowColor = colorScheme.textShadowColor,
+            shadowBlurRadius = shapes.textShadowBlurRadius,
+            alignment = TextAlignment.CENTER
+        )
+        // draw end line for alternate scalebar
+        drawVerticalLineAndShadow(
+            xPos = alternateScalebarDivision.xOffset.toPx(density).toFloat(),
+            top = (totalHeightInPx / 2) + (lineWidth.toPx() / 2),
+            bottom = (totalHeightInPx / 2) + scalebarHeightInPx + lineWidth.toPx(),
+            lineColor = colorScheme.lineColor,
+            shadowColor = colorScheme.shadowColor
+        )
+        // draw alternate unit label
+        drawText(
+            text = alternateScalebarDivision.label,
+            textMeasurer = textMeasurer,
+            labelTypography = labelTypography,
+            xPos = alternateScalebarDivision.xOffset.toPx(density),
+            yPos = (totalHeightInPx / 2) + scalebarHeightInPx,
+            color = colorScheme.textColor,
+            shadowColor = colorScheme.textShadowColor,
+            shadowBlurRadius = shapes.textShadowBlurRadius,
+            alignment = TextAlignment.CENTER
+        )
+    }
+}
+
 @Preview(showBackground = true, backgroundColor = 0xff91d2ff)
 @Composable
 internal fun LineScaleBarPreview() {
@@ -411,6 +506,30 @@ internal fun BarScaleBarPreview() {
             colorScheme = ScalebarDefaults.colors(shadowColor = Color.Red, textShadowColor = Color.Red),
             shapes = ScalebarDefaults.shapes(barCornerRadius = 4f, textShadowBlurRadius = 2f),
             labelTypography = ScalebarDefaults.typography()
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xff91d2ff)
+@Composable
+internal fun DualUnitLineScalebarPreview() {
+    val maxWidth = 175.dp
+    val displayLength = 139.3
+    val endScalebarDivision = ScalebarDivision(displayLength,"3000 m")
+    val alternateScalebarDivision = ScalebarDivision(0.75 * displayLength,"3500 Km")
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(4.dp), contentAlignment = Alignment.BottomStart
+    ) {
+        DualUnitLineScalebar(
+            modifier = Modifier,
+            maxWidth = maxWidth,
+            primaryScalebarDivision = endScalebarDivision,
+            alternateScalebarDivision = alternateScalebarDivision,
+            colorScheme = ScalebarDefaults.colors(),
+            labelTypography = ScalebarDefaults.typography(),
+            shapes = ScalebarDefaults.shapes()
         )
     }
 }
@@ -569,6 +688,7 @@ private fun DrawScope.drawText(
     textMeasurer: TextMeasurer,
     labelTypography: LabelTypography,
     xPos: Float,
+    yPos: Float = scalebarHeight.toPx() + textOffset.value,
     color: Color = Color.Black,
     shadowColor: Color = Color.White,
     shadowBlurRadius: Float,
@@ -583,7 +703,6 @@ private fun DrawScope.drawText(
         TextAlignment.CENTER -> xPos - (measuredText.size.width / 2)
         TextAlignment.RIGHT -> xPos - pixelAlignment.toPx()
     }
-    val yPos = scalebarHeight.toPx() + textOffset.value
     drawText(
         measuredText,
         color = color,

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/internal/ScalebarRenderer.kt
@@ -518,8 +518,8 @@ internal fun BarScaleBarPreview() {
 internal fun DualUnitLineScalebarPreview() {
     val maxWidth = 175.dp
     val displayLength = 139.3
-    val endScalebarDivision = ScalebarDivision(displayLength,"3000 m")
-    val alternateScalebarDivision = ScalebarDivision(0.75 * displayLength,"3500 Km")
+    val primaryScalebarDivision = ScalebarDivision(displayLength,"1750 mi")
+    val alternateScalebarDivision = ScalebarDivision(0.75 * displayLength,"2500 Km")
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -528,7 +528,7 @@ internal fun DualUnitLineScalebarPreview() {
         DualUnitLineScalebar(
             modifier = Modifier,
             maxWidth = maxWidth,
-            primaryScalebarDivision = endScalebarDivision,
+            primaryScalebarDivision = primaryScalebarDivision,
             alternateScalebarDivision = alternateScalebarDivision,
             colorScheme = ScalebarDefaults.colors(),
             labelTypography = ScalebarDefaults.typography(),


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5194

<!-- link to design, if applicable -->

UI and logic to display `Dual unit line` scalebar

### Summary of changes:

- Add composable to draw Dual unit line scalebar
- Add preview 
- Add fun to determine the alternate unit display length and label text
- Add test

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/368/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  