### PR TITLE
Compute scalebar properties everytime the minScale, useGeodeticCalcul…

### DIFF
--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -148,7 +148,15 @@ public fun Scalebar(
     val availableLineDisplayLength =
         measureAvailableLineDisplayLength(maxWidth.value.toDouble(), labelTypography, style)
 
-    val scalebarProperties by remember(spatialReference, viewpoint, unitsPerDip, availableLineDisplayLength) {
+    val scalebarProperties by remember(
+        minScale,
+        spatialReference,
+        viewpoint,
+        unitsPerDip,
+        availableLineDisplayLength,
+        useGeodeticCalculations,
+        units
+    ) {
         mutableStateOf(
             computeScalebarProperties(
                 minScale = minScale,
@@ -157,7 +165,7 @@ public fun Scalebar(
                 unitsPerDip = unitsPerDip,
                 maxLength = availableLineDisplayLength,
                 useGeodeticCalculations = useGeodeticCalculations,
-                units = units,
+                units = units
             )
         )
     }


### PR DESCRIPTION
…ations and units also change

<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5361

<!-- link to design, if applicable -->

### Description:

Currently Scalebar does not update until spatialReference, viewpoint, unitsPerDip and availableLineDisplayLength change. We want the Scalebar to redraw when the minScale, useGeodeticCalculations and unit system change as well

### Summary of changes:

- Add minScale, useGeodeticCalculations and units keys to compute Scalebar properties

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/396/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  