### PR TITLE
WorldScaleCameraController rotation persistence

### DIFF
--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/WorldTrackingCameraController.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/WorldTrackingCameraController.kt
@@ -18,11 +18,16 @@
 
 package com.arcgismaps.toolkit.ar.internal
 
+import android.content.Context
+import android.os.Build
+import android.view.Surface
+import android.view.WindowManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.mapSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -45,6 +50,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.time.Instant
 
@@ -60,7 +66,9 @@ import java.time.Instant
  *
  * @since 200.7.0
  */
-internal class WorldTrackingCameraController(private val onLocationDataSourceFailedToStart: (Throwable) -> Unit) :
+internal class WorldTrackingCameraController(
+    context: Context,
+    private val onLocationDataSourceFailedToStart: (Throwable) -> Unit) :
     DefaultLifecycleObserver {
 
     // This coroutine scope is tied to the lifecycle of this [LocationDataSourceWrapper]
@@ -72,8 +80,18 @@ internal class WorldTrackingCameraController(private val onLocationDataSourceFai
     internal var hasSetOriginCamera by mutableStateOf(false)
         private set
 
-    private var totalHeadingOffset = 0.0
-    private var totalElevationOffset = 0.0
+    internal var totalHeadingOffset = 0.0
+    internal var totalElevationOffset = 0.0
+    private var deviceRotation = if (Build.VERSION.SDK_INT >= 30) {
+        context.display.rotation
+    } else {
+        (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.rotation
+    }
+
+
+    internal fun restoreCamera(){
+        hasSetOriginCamera = true
+    }
 
     /**
      * Sets the current position of the camera using the orientation of the [Frame.getCamera].
@@ -109,17 +127,18 @@ internal class WorldTrackingCameraController(private val onLocationDataSourceFai
      *
      * @since 200.7.0
      */
-    private fun updateCamera(location: Location) =
+    private fun updateCamera(location: Location) {
         cameraController.setOriginCamera(
             Camera(
                 location.position.y,
                 location.position.x,
-                if (location.position.hasZ) location.position.z ?: totalElevationOffset else totalElevationOffset,
-                totalHeadingOffset,
+                if (location.position.hasZ) location.position.z!! else 0.0,
+                location.course,
                 90.0,
                 0.0
             )
         )
+    }
 
     internal fun resetHeadingOffset(){
         cameraController.setOriginCamera(cameraController.originCamera.value
@@ -187,6 +206,24 @@ internal class WorldTrackingCameraController(private val onLocationDataSourceFai
                     }
                 }
         }
+        scope.launch {
+            val heading = locationDataSource.headingChanged.first()
+            val location = cameraController.originCamera.value.location
+            cameraController.setOriginCamera(
+                Camera(
+                    location.x,
+                    location.y,
+                    if (location.hasZ) location.z!! else 0.0,
+                    heading + when (deviceRotation) {
+                        Surface.ROTATION_270 -> -90
+                        Surface.ROTATION_90 -> 90
+                        else -> 0
+                    },
+                    90.0,
+                    0.0
+                )
+            )
+        }
     }
 }
 
@@ -199,9 +236,44 @@ internal class WorldTrackingCameraController(private val onLocationDataSourceFai
  */
 @Composable
 internal fun rememberWorldTrackingCameraController(onLocationDataSourceFailedToStart: (Throwable) -> Unit): WorldTrackingCameraController {
+    val context = LocalContext.current
+    // saver for persisting heading/elevation offsets across rotations
+    val offsetSaver = run {
+        mapSaver(
+            save = {
+                mapOf(
+                    "TotalHeadingOffset" to it.totalHeadingOffset,
+                    "TotalElevationOffset" to it.totalElevationOffset,
+                    "X" to it.cameraController.originCamera.value.location.x,
+                    "Y" to it.cameraController.originCamera.value.location.y,
+                    "Z" to it.cameraController.originCamera.value.location.z,
+                    "Heading" to it.cameraController.originCamera.value.heading,
+                )
+            },
+            restore = {
+                WorldTrackingCameraController(context, onLocationDataSourceFailedToStart).apply {
+                    totalHeadingOffset = it["TotalHeadingOffset"] as Double
+                    totalElevationOffset = it["TotalElevationOffset"] as Double
+
+                    this.cameraController.setOriginCamera(
+                        Camera(
+                            it["X"] as Double,
+                            it["Y"] as Double,
+                            it["Z"] as Double,
+                            it["Heading"] as Double,
+                            90.0,
+                            0.0
+                        )
+                    )
+                    restoreCamera()
+                }
+            }
+        )
+    }
+
     ArcGISEnvironment.applicationContext = LocalContext.current.applicationContext
     val lifecycleOwner = LocalLifecycleOwner.current
-    val wrapper = remember { WorldTrackingCameraController(onLocationDataSourceFailedToStart) }
+    val wrapper = rememberSaveable(saver = offsetSaver) { WorldTrackingCameraController(context, onLocationDataSourceFailedToStart) }
     DisposableEffect(Unit) {
         lifecycleOwner.lifecycle.addObserver(wrapper)
         onDispose {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#5305](https://devtopia.esri.com/runtime/kotlin/issues/5305), but not really

<!-- link to design, if applicable -->

### Description:

First attempt at persisting camera heading across device rotations in `WorldTrackingCameraController`.
This is necessary because `SystemLocationDataSource` does not take device rotation into consideration when reporting a heading. Rotating a device from portrait to landscape results in a heading error of 90º. The issue should ultimately be addressed there, but this PR will fix the persistence issue for world scale for the time being (and make it easier to verify if future work persisting heading/elevaton offsets across device rotations is working).

This is a minimal PR, missing a lot of improvements to the microapp that aren't yet in the feature branch. So don't be too concerned that there's no buildings, terrain elevation, etc. There's [another branch](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/tree/oli12805/rotationPersistence) with all that stuff, but it makes reviewing these changes a bit harder.

### Summary of changes:

- Passes a context to `WorldTrackingCameraController`, allowing it to read the device's rotation state and adjust camera heading accordingly on activity resumption.
- Custom saver for `WorldTrackingCameraController`. It doesn't actually do anything here yet.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/399/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  