### PR TITLE
Scalebar: Autohide delay fix

### DIFF
--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -143,6 +143,8 @@ public fun Scalebar(
             isScalebarVisible.value = true
             delay(autoHideDelay)
             isScalebarVisible.value = false
+        } else {
+            isScalebarVisible.value = true
         }
     }
     val availableLineDisplayLength =

--- a/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
+++ b/toolkit/scalebar/src/main/java/com/arcgismaps/toolkit/scalebar/Scalebar.kt
@@ -137,14 +137,12 @@ public fun Scalebar(
     shapes: ScalebarShapes = ScalebarDefaults.shapes(),
     labelTypography: LabelTypography = ScalebarDefaults.typography()
 ) {
-    val isScalebarVisible = remember { mutableStateOf(true) }
+    val isScalebarVisible = remember(autoHideDelay) { mutableStateOf(true) }
     LaunchedEffect(viewpoint, autoHideDelay) {
         if (autoHideDelay > Duration.ZERO && autoHideDelay != Duration.INFINITE) {
             isScalebarVisible.value = true
             delay(autoHideDelay)
             isScalebarVisible.value = false
-        } else {
-            isScalebarVisible.value = true
         }
     }
     val availableLineDisplayLength =


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#5382](https://devtopia.esri.com/runtime/kotlin/issues/5382)

<!-- link to design, if applicable -->

### Description:
~~PR to set `isScalebarVisible` to true when `autoHideDelay` is set to `INFINITE`/`ZERO`~~
PR to add the `autoHideDelay` as the key to the remembered `isScalebarVisible` property of the Scalebar. 

Regarding `Duration.ZERO` delay: 
> if we are strictly talking about the wording, when an user sets autoHideDelay to 0, the user wants 0 seconds to pass in between auto hides. Meaning that it should not hide = always visible.

### Test code:

<details>
<summary>MainScreen.kt</summary>

```kotlin

@Composable
fun MainScreen(modifier: Modifier) {
    val arcGISMap by remember {
        mutableStateOf(
            ArcGISMap(BasemapStyle.ArcGISTopographic).apply {
                initialViewpoint = Viewpoint(
                    latitude = 39.8,
                    longitude = -98.6,
                    scale = 10e7
                )
            }
        )
    }
    var viewpoint: Viewpoint? by remember { mutableStateOf(null) }
    var unitsPerDip by remember { mutableDoubleStateOf(Double.NaN) }
    var spatialReference: SpatialReference? by remember { mutableStateOf(null) }
    val autoHideDelays = listOf(
        Duration.INFINITE,
        Duration.ZERO,
        1.toDuration(DurationUnit.SECONDS),
        5.toDuration(DurationUnit.SECONDS)
    )
    var currentAutoHideDelay by remember { mutableStateOf(Duration.INFINITE) }

    // show composable MapView with a Scalebar
    Column(
        modifier = modifier.fillMaxSize()
    ) {
        Box(
            modifier = Modifier
                .fillMaxSize()
                .weight(1f)
        ) {
            MapView(
                modifier = Modifier.fillMaxSize(),
                arcGISMap = arcGISMap,
                onSpatialReferenceChanged = { spatialReference = it },
                onUnitsPerDipChanged = { unitsPerDip = it },
                onViewpointChangedForCenterAndScale = { viewpoint = it }
            )
            Scalebar(
                modifier = Modifier
                    .padding(25.dp)
                    .align(Alignment.BottomStart),
                maxWidth = 175.dp,
                unitsPerDip = unitsPerDip,
                viewpoint = viewpoint,
                spatialReference = spatialReference,
                autoHideDelay = currentAutoHideDelay
            )
        }

        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
            Button({ currentAutoHideDelay = autoHideDelays[0] }) { Text("Infinite") }
            Button({ currentAutoHideDelay = autoHideDelays[1] }) { Text("0sec") }
            Button({ currentAutoHideDelay = autoHideDelays[2] }) { Text("1sec") }
            Button({ currentAutoHideDelay = autoHideDelays[3] }) { Text("5sec") }
        }

    }
}
```

</details>


### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/411/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  