### PR TITLE
`FeatureForm` : Remove validation errors filtering

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,4 +50,4 @@ artifactoryPassword=""
 # with CI, these versions are obtained from command line provided properties, see sdkVersionNumber
 # in settings.gradle.kts.
 sdkVersionNumber=200.7.0
-sdkBuildNumber=4446
+sdkBuildNumber=4521

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -38,9 +38,6 @@ import com.arcgismaps.geometry.Point
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.mapping.featureforms.FeatureForm
-import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.mapping.featureforms.FormElement
-import com.arcgismaps.mapping.featureforms.GroupFormElement
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.view.IdentifyLayerResult
 import com.arcgismaps.mapping.view.ScreenCoordinate
@@ -449,7 +446,13 @@ class MapViewModel @Inject constructor(
      */
     private fun validateEdits(featureForm: FeatureForm) {
         _uiState.value = UIState.Validating(featureForm)
-        val validationErrors = filterErrors(featureForm)
+        // map the validation errors to the ErrorInfo class
+        val validationErrors = featureForm.validationErrors.value.flatMap { entry ->
+            // each field can have multiple validation errors
+            entry.value.map { error ->
+                ErrorInfo(entry.key, error as FeatureFormValidationException)
+            }
+        }
         if (validationErrors.isNotEmpty()) {
             val errorText = validationErrors.joinToString(separator = "\n\n") { "$it" }
             _uiState.value = UIState.Error(
@@ -532,39 +535,6 @@ class MapViewModel @Inject constructor(
         // set the UI state to not editing
         _uiState.value = UIState.NotEditing
     }
-
-    /**
-     * Filters the validation errors in the [featureForm] to show only the errors for the editable
-     * fields and fields with value expressions.
-     */
-    private fun filterErrors(featureForm: FeatureForm): List<ErrorInfo> = buildList {
-        featureForm.validationErrors.value.forEach { entry ->
-            entry.value.forEach { error ->
-                featureForm.elements.getFieldFormElement(entry.key)?.let { formElement ->
-                    if (formElement.isEditable.value || formElement.hasValueExpression) {
-                        add(ErrorInfo(formElement.label, error as FeatureFormValidationException))
-                    }
-                }
-            }
-        }
-    }
-}
-
-/**
- * Returns the [FieldFormElement] with the given [fieldName] in the [FeatureForm]. If none exists
- * null is returned.
- */
-fun List<FormElement>.getFieldFormElement(fieldName: String): FieldFormElement? {
-    for (element in this) {
-        when (element) {
-            is FieldFormElement -> if (element.fieldName == fieldName) return element
-            is GroupFormElement -> element.elements.getFieldFormElement(fieldName)
-                ?.let { return it }
-
-            else -> continue
-        }
-    }
-    return null
 }
 
 /**


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: `apollo/1080`

<!-- link to design, if applicable -->

### Description:

Updates the FeatureForms micro-app to remove any filtering done to the `FeatureForm.validationErrors` property. This is because the API now only returns validation errors for fields that are visible and editable. Hence, the app does not need to check for this.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  