### PR TITLE
Load local.properties file only when it exists, so we don't throw an …

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,10 @@ val finalBuild: Boolean = (providers.gradleProperty("finalBuild").orNull ?: "fal
     .run { this == "true" }
 
 val localProperties = java.util.Properties().apply {
-    load(file("local.properties").inputStream())
+    val localPropertiesFile = file("local.properties")
+    if (localPropertiesFile.exists()) {
+        load(localPropertiesFile.inputStream())
+    }
 }
 
 // The version of the ArcGIS Maps SDK for Kotlin dependency.


### PR DESCRIPTION
…exception when it does not exist

<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5411

<!-- link to design, if applicable -->

### Description:

[2025-02-25T20:28:10.549Z] FAILURE: Build failed with an exception.
[2025-02-25T20:28:10.549Z] 
[2025-02-25T20:28:10.549Z] * Where:
[2025-02-25T20:28:10.549Z] Settings file '/home/jenkins/agent/workspace/main/daily_kotlin_APP_toolkit_release/arcgis-maps-sdk-kotlin-toolkit/settings.gradle.kts' line: 32
[2025-02-25T20:28:10.549Z] 
[2025-02-25T20:28:10.549Z] * What went wrong:

[2025-02-25T20:28:10.549Z] /home/jenkins/agent/workspace/main/daily_kotlin_APP_toolkit_release/arcgis-maps-sdk-kotlin-toolkit/local.properties (No such file or directory)

https://runtime-build.esri.com/job/main/job/daily_kotlin_APP_toolkit_release/190/parsed_console/

### Summary of changes:

- load `local.properties` only when it exists 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/464/
  - [x] https://runtime-kotlin.esri.com/job/vtest/job/toolkit/465/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  