### PR TITLE
Fix typo in api dump config for UtilityNetwork

### DIFF
--- a/toolkit/utilitynetworks/api/utilitynetworks.api
+++ b/toolkit/utilitynetworks/api/utilitynetworks.api
@@ -80,9 +80,3 @@ public final class com/arcgismaps/toolkit/utilitynetworks/TraceState {
 	public final fun getInitializationStatus ()Landroidx/compose/runtime/State;
 }
 
-public final class com/arcgismaps/toolkit/utilitynetworks/ui/ComposableSingletons$TraceResultScreenKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/utilitynetworks/ui/ComposableSingletons$TraceResultScreenKt;
-	public fun <init> ()V
-	public final fun getLambda-1$utilitynetworks_release ()Lkotlin/jvm/functions/Function3;
-}
-

--- a/toolkit/utilitynetworks/build.gradle.kts
+++ b/toolkit/utilitynetworks/build.gradle.kts
@@ -94,7 +94,7 @@ apiValidation {
         "com.arcgismaps.toolkit.utilitynetworks.ComposableSingletons\$TraceKt",
         "com.arcgismaps.toolkit.utilitynetworks.ui.ComposableSingletons\$TraceOptionsKt",
         "com.arcgismaps.toolkit.utilitynetworks.ui.ComposableSingletons\$TraceOptionsScreenKt",
-        "com.arcgismaps.toolkit.utilitynetworks.ui.ComposableSingletons\$TraceResultsScreenKt",
+        "com.arcgismaps.toolkit.utilitynetworks.ui.ComposableSingletons\$TraceResultScreenKt",
         "com.arcgismaps.toolkit.utilitynetworks.ui.ComposableSingletons\$AddStartingPointScreenKt",
         "com.arcgismaps.toolkit.utilitynetworks.ui.ComposableSingletons\$StartingPointDetailsScreenKt",
         "com.arcgismaps.toolkit.utilitynetworks.ui.ComposableSingletons\$ClearAllResultsDialogKt",


### PR DESCRIPTION
<!-- link to design, if applicable -->

### Summary of changes:

- Fix a typo in `apiValidation` block of utility network gradle file -> "TraceResultScreenKt" instead of "TraceResultsScreenKt"
- update api dump file

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/487
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  