### PR TITLE
Doc fix: replace "it's" with "its" where appropriate

### DIFF
--- a/microapps/ArTabletopApp/README.md
+++ b/microapps/ArTabletopApp/README.md
@@ -8,4 +8,4 @@ This micro-app demonstrates the use of the `TableTopSceneView` toolkit component
 
 Launch the app and follow on-screen instructions to point the camera towards a surface while moving the device slightly. When a surface is detected it will appear as a grid of white lines in the camera feed. Tap on the grid to choose an anchor location to place the 3D buildings. Shortly after tapping on the screen, the buildings will appear as shown in the screenshot above. 
 
-For more information on the `TableTopSceneView` component and how it works, see it's [Readme](../../toolkit/ar/README.md).
+For more information on the `TableTopSceneView` component and how it works, see its [Readme](../../toolkit/ar/README.md).

--- a/microapps/CompassApp/README.md
+++ b/microapps/CompassApp/README.md
@@ -9,4 +9,4 @@ This micro-app demonstrates the use of the `Compass` toolkit component which dis
 The application loads with the compass set to auto hide. Rotate the map to see the compass point to North. 
 To reset the orientation to North, tap on the compass icon.
 
-For more information on the `Compass` component and how it works, see it's [Readme](../../toolkit/compass/README.md).
+For more information on the `Compass` component and how it works, see its [Readme](../../toolkit/compass/README.md).

--- a/microapps/FeatureFormsApp/README.md
+++ b/microapps/FeatureFormsApp/README.md
@@ -15,4 +15,4 @@ Once you have signed in, you can access the web maps that are shared with your a
 
 If you'd rather use an ArcGIS Enterprise account, click the `Sign in with ArcGIS Enterprise` button in the app. This will open a dialog prompting for an Enterprise URL followed by another dialog to enter your credentials.
 
-For more information on the `FeatureForm` component and how it works, see it's [Readme](../../toolkit/featureforms/README.md).
+For more information on the `FeatureForm` component and how it works, see its [Readme](../../toolkit/featureforms/README.md).

--- a/microapps/MapViewGeometryEditorApp/README.md
+++ b/microapps/MapViewGeometryEditorApp/README.md
@@ -9,4 +9,4 @@ This micro-app demonstrates the use of `GeometryEditor` and `GraphicsOverlay` wi
 The application starts with a `GeometryEditor` set up and not enabled. Use the switch in the app bar to start/stop the geometry editor session.
 Use the overflow action button in the app bar to choose between different options to undo, redo, or clear all `Graphics` from the `GraphicsOverlay`.
 
-For more information on the composable `MapView` component and how it works, see it's [Readme](../../toolkit/geoview-compose/README.md).
+For more information on the composable `MapView` component and how it works, see its [Readme](../../toolkit/geoview-compose/README.md).

--- a/microapps/MapViewIdentifyApp/README.md
+++ b/microapps/MapViewIdentifyApp/README.md
@@ -8,5 +8,5 @@ This micro-app demonstrates the use of `MapViewProxy` to identify features with 
 
 The application starts with a MapView and displays a map with recent global earthquake events. A bottom sheet displays information about the last identified feature. Tap a feature in the MapView to populate the bottom sheet with information about the earthquake event at that location.
 
-For more information on the composable `MapView` component and how it works, see it's [Readme](../../toolkit/geoview-compose/README.md).
+For more information on the composable `MapView` component and how it works, see its [Readme](../../toolkit/geoview-compose/README.md).
 

--- a/microapps/MapViewInsetsApp/README.md
+++ b/microapps/MapViewInsetsApp/README.md
@@ -9,4 +9,4 @@ This micro-app demonstrates the use of `Insets` with a composable `MapView`.
 The application starts with a `Map` with no insets specifed. Use the corresponding text fields to specify left, right, top or bottom insets.
 The attribution bar at the bottom reacts to the inset values specified. The `Reset Insets` button resets all the insets.
 
-For more information on the composable `MapView` component and how it works, see it's [Readme](../../toolkit/geoview-compose/README.md).
+For more information on the composable `MapView` component and how it works, see its [Readme](../../toolkit/geoview-compose/README.md).

--- a/microapps/MapViewLocationDisplayApp/README.md
+++ b/microapps/MapViewLocationDisplayApp/README.md
@@ -9,4 +9,4 @@ This micro-app demonstrates the use of `LocationDisplay` with a composable `MapV
 The application starts with a `LocationDisplay` set up and started. Use the switch in the app bar to start/stop the location display.
 Use the overflow action button in the app bar to choose between different `LocationDisplayAutoPanMode` options.
 
-For more information on the composable `MapView` component and how it works, see it's [Readme](../../toolkit/geoview-compose/README.md).
+For more information on the composable `MapView` component and how it works, see its [Readme](../../toolkit/geoview-compose/README.md).

--- a/microapps/MapViewSetViewpointApp/README.md
+++ b/microapps/MapViewSetViewpointApp/README.md
@@ -8,4 +8,4 @@ This micro-app demonstrates setting the viewpoint on a composable `MapView`.
 
 The application starts with a MapView and displays a map. Use the overflow action button in the app bar to choose between different methods of setting a viewpoint on the composable MapView. Each operation will set the viewpoint to a different location.
 
-For more information on the composable `MapView` component and how it works, see it's [Readme](../../toolkit/geoview-compose/README.md).
+For more information on the composable `MapView` component and how it works, see its [Readme](../../toolkit/geoview-compose/README.md).

--- a/microapps/PopupApp/README.md
+++ b/microapps/PopupApp/README.md
@@ -6,4 +6,4 @@ This micro-app demonstrates the use of the `Popup` toolkit component which provi
 
 The application provides a map viewer, which invokes the form when GeoElements are tapped.
 
-For more information on the `Popup` component and how it works, see it's [Readme](../../toolkit/popup/README.md).
+For more information on the `Popup` component and how it works, see its [Readme](../../toolkit/popup/README.md).

--- a/microapps/ScalebarApp/README.md
+++ b/microapps/ScalebarApp/README.md
@@ -8,4 +8,4 @@ This micro-app demonstrates the use of the `Scalebar` toolkit component that vis
 
 The application shows a Scalebar on the MapView's bottom left corner. The Scalebar updates the visual distance on the Map when the viewpoint of the MapView is changed by zooming in/out or panning.
 
-For more information on the `Scalebar` component and how it works, see it's [Readme](../../toolkit/Scalebar/README.md).
+For more information on the `Scalebar` component and how it works, see its [Readme](../../toolkit/Scalebar/README.md).

--- a/microapps/SceneViewAnalysisOverlayApp/README.md
+++ b/microapps/SceneViewAnalysisOverlayApp/README.md
@@ -8,4 +8,4 @@ This micro-app demonstrates the use of composable `SceneView's` `analysisOverlay
 
 The application starts with a SceneView and displays a scene of Brest, France. Use the switch to turn on and off a viewshed analysis from the viewpoint of the cyan diamond marker.
 
-For more information on the composable `SceneView` component and how it works, see it's [Readme](../../toolkit/geoview-compose/README.md).
+For more information on the composable `SceneView` component and how it works, see its [Readme](../../toolkit/geoview-compose/README.md).

--- a/microapps/SceneViewCameraControllerApp/README.md
+++ b/microapps/SceneViewCameraControllerApp/README.md
@@ -8,4 +8,4 @@ This micro-app demonstrates the use of `CameraController` with a composable `Sce
 
 The application begins with a SceneView and displays a global scene. Utilize the overflow action button in the app bar to select from various CameraController options for execution on the composable SceneView. Each operation will create and use a different CameraController to change the camera's viewpoint on the scene.
 
-For more information on the composable `SceneView` component and how it works, see it's [Readme](../../toolkit/geoview-compose/README.md).
+For more information on the composable `SceneView` component and how it works, see its [Readme](../../toolkit/geoview-compose/README.md).

--- a/microapps/SceneViewLightingOptionsApp/README.md
+++ b/microapps/SceneViewLightingOptionsApp/README.md
@@ -14,5 +14,5 @@ The application starts with a `SceneView` displaying a scene. Use the overflow m
 - Atmosphere Effect: allows you to choose how the scene's atmosphere is rendered.
 - Space Effect: allows you to choose how outer space is displayed in the scene.
 
-For more information on the composable `SceneView` component and how it works, see it's [Readme](../../toolkit/geoview-compose/README.md).
+For more information on the composable `SceneView` component and how it works, see its [Readme](../../toolkit/geoview-compose/README.md).
 

--- a/microapps/SceneViewSetViewpointApp/README.md
+++ b/microapps/SceneViewSetViewpointApp/README.md
@@ -8,5 +8,5 @@ This micro-app demonstrates setting the viewpoint on a composable `SceneView`.
 
 The application starts with a SceneView and displays a scene. Use the overflow action button in the app bar to choose between different methods of setting a viewpoint on the composable SceneView. Each operation will set the viewpoint to a different location.
 
-For more information on the composable `SceneView` component and how it works, see it's [Readme](../../toolkit/geoview-compose/README.md).
+For more information on the composable `SceneView` component and how it works, see its [Readme](../../toolkit/geoview-compose/README.md).
 

--- a/microapps/UtilityNetworkTraceApp/README.md
+++ b/microapps/UtilityNetworkTraceApp/README.md
@@ -16,7 +16,7 @@ The app showcases how the Trace tool allows you to select a named trace configur
 |:--:|
 |![Trace Configurations](screenshots/traceconfigs.png)|
 
-The user can add startpoints by tapping on the `Add new starting point` button and can view it's properties. 
+The user can add startpoints by tapping on the `Add new starting point` button and can view its properties. 
 
 |Starting Point Properties|
 |:--:|
@@ -35,4 +35,4 @@ The Trace tool shows the feature and function results in the UI and draws the ge
 |![Trace Results](screenshots/traceresults.png)|
 
 
-For more information on the composable `Trace` component and how it works, see it's [Readme](../../toolkit/utilitynetworks/README.md).
+For more information on the composable `Trace` component and how it works, see its [Readme](../../toolkit/utilitynetworks/README.md).

--- a/toolkit/compass/README.md
+++ b/toolkit/compass/README.md
@@ -1,6 +1,6 @@
 # Compass
 The Compass displays the current viewpoint rotation of a MapView by displaying a compass icon that points north.
-The Compass supports resetting the rotation by tapping the icon, which resets the map to it's default 0 degree orientation.
+The Compass supports resetting the rotation by tapping the icon, which resets the map to its default 0 degree orientation.
 
 By default the Compass is set to auto hide, hence it will only appear when the map is rotated and is hidden when the current map orientation is 0 degrees. This behavior is configurable.
 

--- a/toolkit/compass/src/androidTest/java/com/arcgismaps/toolkit/compass/CompassTests.kt
+++ b/toolkit/compass/src/androidTest/java/com/arcgismaps/toolkit/compass/CompassTests.kt
@@ -69,7 +69,7 @@ class CompassTests {
     /**
      * Given a [Compass]
      * When it is tapped
-     * Then it's onClick event is called
+     * Then its onClick event is called
      */
     @Test
     fun testCompassOnClick() {

--- a/toolkit/compass/src/main/java/com/arcgismaps/toolkit/compass/Compass.kt
+++ b/toolkit/compass/src/main/java/com/arcgismaps/toolkit/compass/Compass.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 
 /**
  * Creates a Compass that shows the geographic orientation of a [ComposableMap] using the
- * [rotation] property. By default, the compass hides when the map is pointing to it's default
+ * [rotation] property. By default, the compass hides when the map is pointing to its default
  * North orientation. This auto hide behavior can be changed using the [autoHide] property.
  * Size and color of the icon can be customized using [size] and [color]. Resetting behavior can
  * be implemented using the [onClick] callback which is raised when the Compass is tapped.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/picker/date/SnapFlingBehavior.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/picker/date/SnapFlingBehavior.kt
@@ -57,7 +57,7 @@ import kotlin.math.sign
  * @param snapAnimationSpec an [AnimationSpec] that is used for the snap animation
  * @param density the current display [Density]
  */
-// TODO(b/264687693): Replace with the framework's rememberSnapFlingBehavior ones it's stable.
+// TODO(b/264687693): Replace with the framework's rememberSnapFlingBehavior once it's stable.
 internal class SnapFlingBehavior(
     private val lazyListState: LazyListState,
     private val decayAnimationSpec: DecayAnimationSpec<Float>,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Utils.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Utils.kt
@@ -28,7 +28,7 @@ import com.arcgismaps.data.CodedValue
 /**
  * Changes the visual output of the placeholder and label properties of a TextField. Using this
  * transformation, the placeholder is always visible even if empty and puts the label above the
- * TextField as it's default position.
+ * TextField as its default position.
  */
 internal class PlaceholderTransformation(private val placeholder: String) : VisualTransformation {
     

--- a/toolkit/popup/README.md
+++ b/toolkit/popup/README.md
@@ -70,7 +70,7 @@ MapView(
 
 #### Rendering the composable Popup function
 
-A `Popup` can be rendered within a composition by simply calling the `Popup` composable with a [Popup object](https://developers.arcgis.com/kotlin/api-reference/arcgis-maps-kotlin/com.arcgismaps.mapping.popup/-popup/index.html). The Popup should be displayed in a container. It's visibility and the container are external and should be controlled by the calling Composable.
+A `Popup` can be rendered within a composition by simply calling the `Popup` composable with a [Popup object](https://developers.arcgis.com/kotlin/api-reference/arcgis-maps-kotlin/com.arcgismaps.mapping.popup/-popup/index.html). The Popup should be displayed in a container. Its visibility and the container are external and should be controlled by the calling Composable.
 
 ```kotlin  
 @Composable  

--- a/toolkit/utilitynetworks/README.md
+++ b/toolkit/utilitynetworks/README.md
@@ -56,7 +56,7 @@ To display an ArcGISMap containing a UtilityNetwork, create a new `TraceState` o
 
 #### Rendering the composable Trace function
 
-The `Trace tool` can be rendered within a composition by simply calling the `Trace` composable function). The Trace should be displayed in a container. It's visibility and the container are external and should be controlled by the calling Composable.
+The `Trace tool` can be rendered within a composition by simply calling the `Trace` composable function). The Trace should be displayed in a container. Its visibility and the container are external and should be controlled by the calling Composable.
 
 ```kotlin
 import com.arcgismaps.toolkit.utilitynetworks.TraceState


### PR DESCRIPTION
Related to issue: `runtime/kotlin#5433`

### Description:

Correct all instances of `it's` that were intended to be `its` instead.
Guidance for reviewing this PR:
 - **it's** = contraction of "**it is**"
 - **its** = possessive form of "**it**"

I also glanced through for incorrect usages of "its" that should have been "it's" but did not find any.

### Summary of changes:

- 18 affected `README.md` files
- 4 affected `.kt` files

### Pre-merge Checklist

- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
  - [x] n/a
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  