### PR TITLE
Changes to add support for reverseLayerOrder

### DIFF
--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -78,11 +78,11 @@ public fun Legend(
 
             // Add the layers to the layer content data
             // Add the operational layers first
-            addLayersToLayerContentData(operationalLayers, reverseLayerOrder, density, layerContentData)
+            addLayersAndSubLayersDataToLayerContentData(operationalLayers, reverseLayerOrder, density, layerContentData)
             // Add the basemap layers
-            addLayersToLayerContentData(basemap?.baseLayers, reverseLayerOrder, density, layerContentData, addAtIndexZero = reverseLayerOrder)
+            addLayersAndSubLayersDataToLayerContentData(basemap?.baseLayers, reverseLayerOrder, density, layerContentData, addAtIndexZero = reverseLayerOrder)
             // Add the reference layers
-            addLayersToLayerContentData(basemap?.referenceLayers, reverseLayerOrder, density, layerContentData, addAtIndexZero = !reverseLayerOrder)
+            addLayersAndSubLayersDataToLayerContentData(basemap?.referenceLayers, reverseLayerOrder, density, layerContentData, addAtIndexZero = !reverseLayerOrder)
 
             initialized = true
         }
@@ -99,7 +99,7 @@ public fun Legend(
     }
 }
 
-private suspend fun addLayersToLayerContentData(
+private suspend fun addLayersAndSubLayersDataToLayerContentData(
     layers: List<LayerContent>?,
     reverseLayerOrder: Boolean,
     density: Float,
@@ -110,16 +110,16 @@ private suspend fun addLayersToLayerContentData(
         // The order of the layers is reversed to match the order in the legend
         val orderedLayers = if (reverseLayerOrder) layerList.reversed() else layerList
         val filteredLayers = orderedLayers.filter { it.isVisible && it.showInLegend }
-        val newLayerContentData = filteredLayers.flatMap { layerContentData(it, density) }
+        val layersAndSubLayersLayerContentData = filteredLayers.flatMap { getLayerContentData(it, density) }
         if (addAtIndexZero) {
-            layerContentData.addAll(0, newLayerContentData)
+            layerContentData.addAll(0, layersAndSubLayersLayerContentData)
         } else {
-            layerContentData.addAll(newLayerContentData)
+            layerContentData.addAll(layersAndSubLayersLayerContentData)
         }
     }
 }
 
-private suspend fun layerContentData(
+private suspend fun getLayerContentData(
     layerContent: LayerContent,
     density: Float
 ): List<LayerContentData> {
@@ -138,7 +138,7 @@ private suspend fun layerContentData(
         listOf(data)
     } else {
         listOf(data) + layerContent.subLayerContents.value.flatMap { sublayer ->
-            layerContentData(sublayer, density)
+            getLayerContentData(sublayer, density)
         }
     }
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5493

<!-- link to design, if applicable -->

### Description:

Add the parameter reverseLayerOrder: Boolean to the Legend composable, along with its functionality.

### Summary of changes:

- Add `reverseLayerOrder: Boolean` parameter
- Add logic to reverse the layer order

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  