### PR TITLE
add parameter for respectScaleRange

### DIFF
--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -59,6 +59,7 @@ public fun Legend(
     operationalLayers: List<LayerContent>,
     basemap: Basemap?,
     currentScale: Double,
+    respectScaleRange: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     val density = LocalContext.current.resources.displayMetrics.density
@@ -106,7 +107,7 @@ public fun Legend(
     }
 
     if (initialized) {
-        Legend(modifier, layerContentData, currentScale)
+        Legend(modifier, layerContentData, currentScale, respectScaleRange)
     } else {
         CircularProgressIndicator()
     }
@@ -141,10 +142,11 @@ private fun Legend(
     modifier: Modifier,
     legendItems: List<LayerContentData>,
     currentScale: Double,
+    respectScaleRange: Boolean,
     ) {
     LazyColumn(modifier = modifier) {
         itemsIndexed(legendItems) { index, item ->
-            if (item.isVisible(currentScale)) {
+            if (!respectScaleRange || item.isVisible(currentScale)) {
                 if (index == legendItems.size - 1 || item.name != legendItems[index + 1].name) {
                     Row {
                         Text(text = item.name)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5492

<!-- link to design, if applicable -->

### Description:

Add a parameter respectScaleRange: Boolean which would determine if the LayerContent's visibility at a given scaleRange is honored or not.

### Summary of changes:

- Add parameter `respectScaleRange`
- Add functionality to honor it

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/528/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  