### PR TITLE
Add logic to display sublayers differently than the layers

### DIFF
--- a/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
+++ b/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
@@ -77,7 +77,7 @@ fun MainScreen(viewModel: LegendViewModel = viewModel()) {
                 label = "legend",
                 modifier = Modifier.heightIn(min = 0.dp, max = 400.dp)
             ) {
-                Legend(viewModel.arcGISMap.operationalLayers, baseMap.value, currentScale)
+                Legend(viewModel.arcGISMap.operationalLayers, baseMap.value, currentScale, modifier = Modifier.fillMaxSize())
             }
         },
         modifier = Modifier.fillMaxSize(),

--- a/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
+++ b/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
@@ -34,16 +34,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.LoadStatus
-import com.arcgismaps.mapping.ArcGISMap
-import com.arcgismaps.mapping.PortalItem
-import com.arcgismaps.portal.Portal
 import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.arcgismaps.toolkit.legend.Legend
 
@@ -77,7 +73,12 @@ fun MainScreen(viewModel: LegendViewModel = viewModel()) {
                 label = "legend",
                 modifier = Modifier.heightIn(min = 0.dp, max = 400.dp)
             ) {
-                Legend(viewModel.arcGISMap.operationalLayers, baseMap.value, currentScale, modifier = Modifier.fillMaxSize())
+                Legend(
+                    operationalLayers = viewModel.arcGISMap.operationalLayers,
+                    basemap = baseMap.value,
+                    currentScale = currentScale,
+                    modifier = Modifier.fillMaxSize()
+                )
             }
         },
         modifier = Modifier.fillMaxSize(),

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.CircularProgressIndicator
@@ -57,6 +58,7 @@ private data class LegendItem(
 @Parcelize
 private data class LayerContentData(
     val name: String,
+    val isLayer: Boolean,
     val legendItems: MutableList<LegendItem> = mutableListOf(),
     val isVisible: (Double) -> Boolean
 ) : Parcelable
@@ -133,8 +135,8 @@ private suspend fun getLayerContentData(
     layerContent: LayerContent,
     density: Float
 ): List<LayerContentData> {
-    val data = LayerContentData(layerContent.name) { scale ->
-        layerContent.isVisibleAtScale(scale)
+    val data = LayerContentData(layerContent.name, layerContent is Layer) { scale ->
+    layerContent.isVisibleAtScale(scale)
     }
     layerContent.fetchLegendInfos().onSuccess {
         it.map { info ->
@@ -176,9 +178,17 @@ private fun Legend(
             itemsIndexed(legendItems) { index, item ->
                 if (!respectScaleRange || item.isVisible(currentScale)) {
                     if (index == legendItems.size - 1 || item.name != legendItems[index + 1].name) {
-                        Row {
-                            Text(text = item.name, style = typography.layerName)
+                        Row(
+                            modifier = Modifier.then(
+                                if (!item.isLayer) Modifier.padding(horizontal = 10.dp) else Modifier
+                            )
+                        ) {
+                            Text(
+                                text = item.name,
+                                style = if (item.isLayer) typography.layerName else typography.subLayerName
+                            )
                         }
+
                     }
                     if (item.legendItems.isNotEmpty()) {
                         item.legendItems.forEach { legendInfo ->

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -21,9 +21,11 @@ package com.arcgismaps.toolkit.legend
 import android.graphics.Bitmap
 import android.os.Parcelable
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -107,7 +109,12 @@ public fun Legend(
     if (initialized) {
         Legend(modifier, layerContentData, currentScale, respectScaleRange, title, typography)
     } else {
-        CircularProgressIndicator()
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
     }
 }
 
@@ -180,7 +187,7 @@ private fun Legend(
                     if (index == legendItems.size - 1 || item.name != legendItems[index + 1].name) {
                         Row(
                             modifier = Modifier.then(
-                                if (!item.isLayer) Modifier.padding(horizontal = 10.dp) else Modifier
+                                if (item.isLayer) Modifier else Modifier.padding(horizontal = 10.dp)
                             )
                         ) {
                             Text(
@@ -192,7 +199,17 @@ private fun Legend(
                     }
                     if (item.legendItems.isNotEmpty()) {
                         item.legendItems.forEach { legendInfo ->
-                            LegendInfoRow(legendInfo, typography)
+                            LegendInfoRow(
+                                legendInfo = legendInfo,
+                                typography = typography,
+                                modifier = if (item.isLayer) Modifier.padding(
+                                    horizontal = 5.dp,
+                                    vertical = 2.dp
+                                ) else Modifier.padding(
+                                    horizontal = 15.dp,
+                                    vertical = 2.dp
+                                )
+                            )
                         }
                     }
                 }
@@ -205,8 +222,9 @@ private fun Legend(
 private fun LegendInfoRow(
     legendInfo: LegendItem,
     typography: Typography,
+    modifier: Modifier
 ) {
-    Row {
+    Row(modifier = modifier) {
         legendInfo.bitmap?.let {
             Image(
                 bitmap = it.asImageBitmap(),

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -239,10 +240,15 @@ private fun Legend(
             itemsIndexed(legendItems) { index, item ->
                 if (!respectScaleRange || item.isVisible(currentScale)) {
                     if (index == legendItems.size - 1 || item.name != legendItems[index + 1].name) {
+                        if (item.isLayer && index < legendItems.size - 1) {
+                            HorizontalDivider(modifier = Modifier.padding(top = 6.dp))
+                        }
                         Row(
                             modifier = Modifier.then(
-                                if (item.isLayer) Modifier.padding(horizontal = 5.dp) else Modifier.padding(
-                                    horizontal = 10.dp
+                                if (item.isLayer) Modifier.padding(
+                                    start = 8.dp, top = 8.dp
+                                ) else Modifier.padding(
+                                    start = 16.dp, top = 8.dp
                                 )
                             )
                         ) {
@@ -251,7 +257,6 @@ private fun Legend(
                                 style = if (item.isLayer) typography.layerName else typography.subLayerName
                             )
                         }
-
                     }
                     if (item.legendItems.isNotEmpty()) {
                         item.legendItems.forEach { legendInfo ->
@@ -259,11 +264,11 @@ private fun Legend(
                                 legendInfo = legendInfo,
                                 typography = typography,
                                 modifier = if (item.isLayer) Modifier.padding(
-                                    horizontal = 10.dp,
-                                    vertical = 2.dp
+                                    start = 16.dp,
+                                    top = 8.dp
                                 ) else Modifier.padding(
-                                    horizontal = 20.dp,
-                                    vertical = 2.dp
+                                    start = 24.dp,
+                                    top = 8.dp
                                 )
                             )
                         }
@@ -287,6 +292,7 @@ private fun LegendInfoRow(
                 contentDescription = stringResource(R.string.symbol_description)
             )
         }
+        Spacer(modifier = Modifier.padding(start = 8.dp))
         Text(text = legendInfo.name, style = typography.legendInfoName)
     }
 }

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -70,7 +70,7 @@ import kotlinx.parcelize.Parcelize
  * fun MainScreen(viewModel: LegendViewModel = viewModel()) {
  *
  *     val loadState by viewModel.arcGISMap.loadStatus.collectAsState()
- *     val baseMap = viewModel.arcGISMap.basemap.collectAsState()
+ *     val basemap = viewModel.arcGISMap.basemap.collectAsState()
  *     var currentScale: Double by remember { mutableDoubleStateOf(Double.NaN) }
  *     ...
  *
@@ -79,14 +79,11 @@ import kotlinx.parcelize.Parcelize
  *         sheetContent = {
  *             AnimatedVisibility(
  *                 visible = loadState is LoadStatus.Loaded,
- *                 enter = slideInVertically { h -> h },
- *                 exit = slideOutVertically { h -> h },
- *                 label = "legend",
- *                 modifier = Modifier.heightIn(min = 0.dp, max = 400.dp)
+ *                 ...
  *             ) {
  *                 Legend(
  *                     operationalLayers = viewModel.arcGISMap.operationalLayers,
- *                     basemap = baseMap.value,
+ *                     basemap = basemap.value,
  *                     currentScale = currentScale,
  *                     modifier = Modifier.fillMaxSize()
  *                 )

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -21,7 +21,10 @@ package com.arcgismaps.toolkit.legend
 import android.graphics.Bitmap
 import android.os.Parcelable
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.CircularProgressIndicator
@@ -32,10 +35,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.arcgismaps.mapping.Basemap
 import com.arcgismaps.mapping.layers.Layer
 import com.arcgismaps.mapping.layers.LayerContent
@@ -61,9 +66,10 @@ public fun Legend(
     operationalLayers: List<LayerContent>,
     basemap: Basemap?,
     currentScale: Double,
+    modifier: Modifier = Modifier,
     reverseLayerOrder: Boolean = false,
     respectScaleRange: Boolean = true,
-    modifier: Modifier = Modifier,
+    title: String = stringResource(R.string.title),
     typography: Typography = LegendDefaults.typography()
 ) {
     val density = LocalContext.current.resources.displayMetrics.density
@@ -97,7 +103,7 @@ public fun Legend(
     }
 
     if (initialized) {
-        Legend(modifier, layerContentData, currentScale, respectScaleRange, typography)
+        Legend(modifier, layerContentData, currentScale, respectScaleRange, title, typography)
     } else {
         CircularProgressIndicator()
     }
@@ -153,19 +159,31 @@ private fun Legend(
     legendItems: List<LayerContentData>,
     currentScale: Double,
     respectScaleRange: Boolean,
+    title: String,
     typography: Typography
     ) {
-    LazyColumn(modifier = modifier) {
-        itemsIndexed(legendItems) { index, item ->
-            if (!respectScaleRange || item.isVisible(currentScale)) {
-                if (index == legendItems.size - 1 || item.name != legendItems[index + 1].name) {
-                    Row {
-                        Text(text = item.name, style = typography.layerName)
+    Column(modifier = modifier) {
+        if (title.isNotEmpty()) {
+            Text(
+                text = title,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                style = typography.title
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        LazyColumn {
+            itemsIndexed(legendItems) { index, item ->
+                if (!respectScaleRange || item.isVisible(currentScale)) {
+                    if (index == legendItems.size - 1 || item.name != legendItems[index + 1].name) {
+                        Row {
+                            Text(text = item.name, style = typography.layerName)
+                        }
                     }
-                }
-                if (item.legendItems.isNotEmpty()) {
-                    item.legendItems.forEach { legendInfo ->
-                        LegendInfoRow(legendInfo, typography)
+                    if (item.legendItems.isNotEmpty()) {
+                        item.legendItems.forEach { legendInfo ->
+                            LegendInfoRow(legendInfo, typography)
+                        }
                     }
                 }
             }

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -197,7 +197,7 @@ private suspend fun getLayerContentData(
     density: Float
 ): List<LayerContentData> {
     val data = LayerContentData(layerContent.name, layerContent is Layer) { scale ->
-    layerContent.isVisibleAtScale(scale)
+        layerContent.isVisibleAtScale(scale)
     }
     layerContent.fetchLegendInfos().onSuccess {
         it.map { info ->

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -28,10 +28,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.CircularProgressIndicator

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/theme/Theme.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/theme/Theme.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.TextStyle
  *
  * @param title The text style for the title.
  * @param layerName The text style for the layer name.
+ * @param subLayerName The text style for the sub layer name.
  * @param legendInfoName The text style for the legend info name.
  *
  * @since 200.7.0
@@ -33,7 +34,8 @@ import androidx.compose.ui.text.TextStyle
 @Immutable
 public data class Typography internal constructor(
     val title: TextStyle,
-    val layerName : TextStyle,
+    val layerName: TextStyle,
+    val subLayerName: TextStyle,
     val legendInfoName: TextStyle,
 )
 
@@ -49,6 +51,7 @@ public object LegendDefaults {
      *
      * @param title The text style for the title.
      * @param layerName The text style for the layer name.
+     * @param subLayerName The text style for the sub layer name.
      * @param legendInfoName The text style for the legend info name.
      * @since 200.7.0
      */
@@ -56,10 +59,12 @@ public object LegendDefaults {
     public fun typography(
         title: TextStyle = MaterialTheme.typography.titleMedium,
         layerName: TextStyle = MaterialTheme.typography.titleSmall,
+        subLayerName: TextStyle = MaterialTheme.typography.bodyMedium,
         legendInfoName: TextStyle = MaterialTheme.typography.bodyMedium,
         ): Typography = Typography(
         title = title,
         layerName = layerName,
+        subLayerName = subLayerName,
         legendInfoName = legendInfoName,
     )
 }

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/theme/Theme.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/theme/Theme.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.TextStyle
 /**
  * Typography styling properties for the Legend composable.
  *
+ * @param title The text style for the title.
  * @param layerName The text style for the layer name.
  * @param legendInfoName The text style for the legend info name.
  *
@@ -31,6 +32,7 @@ import androidx.compose.ui.text.TextStyle
  */
 @Immutable
 public data class Typography internal constructor(
+    val title: TextStyle,
     val layerName : TextStyle,
     val legendInfoName: TextStyle,
 )
@@ -45,15 +47,18 @@ public object LegendDefaults {
     /**
      * Creates default typography values for the Legend composable.
      *
+     * @param title The text style for the title.
      * @param layerName The text style for the layer name.
      * @param legendInfoName The text style for the legend info name.
      * @since 200.7.0
      */
     @Composable
     public fun typography(
-        layerName: TextStyle = MaterialTheme.typography.labelLarge,
+        title: TextStyle = MaterialTheme.typography.titleMedium,
+        layerName: TextStyle = MaterialTheme.typography.titleSmall,
         legendInfoName: TextStyle = MaterialTheme.typography.bodyMedium,
         ): Typography = Typography(
+        title = title,
         layerName = layerName,
         legendInfoName = legendInfoName,
     )

--- a/toolkit/legend/src/main/res/values/strings.xml
+++ b/toolkit/legend/src/main/res/values/strings.xml
@@ -15,5 +15,6 @@
   -->
 
 <resources>
+    <string name="title">Legend</string>
     <string name="symbol_description">symbol of a legend item</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5511

<!-- link to design, if applicable -->

### Description:

Add logic to display sublayer names not in bold and more indented than their parent layers

### Summary of changes:

- Add doc to the Legend Composable
- Add `val isLayer: Boolean` to `layerContentData` to differentiate between layer and a sublayer
- Add logic to indent layer, sublayer and legendInfo at different levels
- Add TextStyle for sublayers
- move the location of Private data classes 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/532/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  