### PR TITLE
update the legend when sublayercontents change.

### DIFF
--- a/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
+++ b/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
@@ -34,16 +34,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.LoadStatus
-import com.arcgismaps.mapping.ArcGISMap
-import com.arcgismaps.mapping.PortalItem
-import com.arcgismaps.portal.Portal
 import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.arcgismaps.toolkit.legend.Legend
 

--- a/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
+++ b/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier

--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -106,8 +106,11 @@ public fun Legend(
             initialized = true
         }
     } else {
-        // establish the sublayerContents observation after initialization and after a config change.
+        // Get the operational layers' and basemaps' sublayer contents or, if there are none,
+        // the basemaps' reference layers sublayer contents. If no sublayer content is available
+        // just get an empty list
         LaunchedEffect(Unit) {
+            // Establish the sublayerContents observation after initialization and after a config change.
             val sublayerContent = operationalLayers.map {
                 it.subLayerContents
             } + (basemap?.baseLayers?.map {
@@ -116,7 +119,7 @@ public fun Legend(
                 it.subLayerContents
             } ?: emptyList())
 
-            // drop the first values -- the initial sublayer contents are already in the Legend.
+            // Drop the first values -- the initial sublayer contents are already in the Legend.
             val dropList = sublayerContent.map {
                 it.drop(1)
             }
@@ -188,6 +191,19 @@ private fun LegendInfoRow(
     }
 }
 
+/**
+ * Provides the row data for LayerContent and their sublayer content.
+ *
+ * @param layerContentData the output list. It is a SnapshotStateList which when altered will cause recomposition.
+ * @param layers the operational layers of the map
+ * @param baseLayers the baseLayers of the Basemap
+ * @param referenceLayers the referenceLayers of the Basemap
+ * @param reverseOrder build the list in reverse order when true
+ * @param density the screen metrics used to create symbol swatches for the Symbols returned by
+ * LayerContent.fetchLegendInfos()
+ *
+ * @since 200.7.0
+ */
 private suspend fun legendContent(
     layerContentData: MutableList<LayerContentData>,
     layers: List<LayerContent>,
@@ -223,6 +239,18 @@ private suspend fun legendContent(
     )
 }
 
+/**
+ * Provides LayerContentData for a list of LayerContent. Descends recursively into any sublayer content
+ *
+ * @param layers the LayerContents to evaluate
+ * @param reverseLayerOrder build the LegendContent in reverse order when trye
+ * @param density the screen metrics to use to create bitmaps from Symbol swatches
+ * @param layerContentData the output list of LayerContentData
+ * @param addAtIndexZero used in reverse ordering to build the overall list for operational, base,
+ * and reference layers
+ *
+ * @since 200.7.0
+ */
 private suspend fun addLayersAndSubLayersDataToLayerContentData(
     layers: List<LayerContent>?,
     reverseLayerOrder: Boolean,
@@ -244,6 +272,15 @@ private suspend fun addLayersAndSubLayersDataToLayerContentData(
     }
 }
 
+/**
+ * Gets the LayerContentData for a single LayerContent. Descends recursively into any sublayerContents
+ *
+ * @param layerContent the LayerContent to evaluate
+ * @param density the screen metrics density to use to create bitmaps from Symbol swatches
+ * @return a list of LayerContentData representing the LayerContent in addition to any
+ * LayerContent.sublayerContents
+ * @since 200.7.0
+ */
 private suspend fun getLayerContentData(
     layerContent: LayerContent,
     density: Float
@@ -268,6 +305,11 @@ private suspend fun getLayerContentData(
     }
 }
 
+/**
+ * Preserves a SnapshotStateList across compositions
+ *
+ * @since 200.7.0
+ */
 private fun <T : Parcelable> snapshotStateListSaver(): Saver<SnapshotStateList<T>, Any> = listSaver(
     {
         it.toList()


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5491

<!-- link to design, if applicable -->

### Description:

observe changes to the sublayer contents of all the LayerContents in the Legend.
just rebuild the Legend when any change.

### Summary of changes:

- create a flow that merges all the LayerContents.sublayerContent StateFlows into a single shared flow.
- ensure this is collected after initialization and in each new composition (after orientation changes)
- make the LayerContentData list a snapshot state list so the composition can observe changes to it.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/533/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  