### PR TITLE
Alan/map view image overlays

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,4 +50,4 @@ artifactoryPassword=""
 # with CI, these versions are obtained from command line provided properties, see sdkVersionNumber
 # in settings.gradle.kts.
 sdkVersionNumber=200.7.0
-sdkBuildNumber=4446
+sdkBuildNumber=4544

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
@@ -54,6 +54,7 @@ import com.arcgismaps.mapping.view.DrawStatus
 import com.arcgismaps.mapping.view.GeoView
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.arcgismaps.mapping.view.Grid
+import com.arcgismaps.mapping.view.ImageOverlay
 import com.arcgismaps.mapping.view.LocationDisplay
 import com.arcgismaps.mapping.view.LongPressEvent
 import com.arcgismaps.mapping.view.MapView
@@ -84,6 +85,7 @@ import kotlinx.coroutines.launch
  * @param viewpointPersistence the [ViewpointPersistence] to specify how the viewpoint of the composable MapView is persisted
  * across configuration changes.
  * @param graphicsOverlays graphics overlays used by this composable MapView
+ * @param imageOverlays image overlays for displaying images in the composable SceneView
  * @param locationDisplay the [LocationDisplay] used by the composable MapView
  * @param geometryEditor the [GeometryEditor] used by the composable MapView to create and edit geometries by user interaction.
  * @param mapViewProxy the [MapViewProxy] to associate with the composable MapView
@@ -123,7 +125,7 @@ import kotlinx.coroutines.launch
  * - <a href="https://developers.arcgis.com/kotlin/maps-2d/tutorials/display-a-map/">Display a map tutorial</a>
  * - <a href="https://developers.arcgis.com/kotlin/maps-2d/tutorials/display-a-web-map/">Display a web map tutorial</a>
  * - <a href="https://developers.arcgis.com/kotlin/maps-2d/tutorials/add-a-point-line-and-polygon/">Add a point, line, and polygon tutorial</a>
- * @since 200.4.0
+ * @since 200.7.0
  */
 @Composable
 public fun MapView(
@@ -134,6 +136,7 @@ public fun MapView(
     onVisibleAreaChanged: ((Polygon) -> Unit)? = null,
     viewpointPersistence: ViewpointPersistence = MapViewDefaults.DefaultViewpointPersistence,
     graphicsOverlays: List<GraphicsOverlay> = remember { emptyList() },
+    imageOverlays: List<ImageOverlay> = remember { emptyList() },
     locationDisplay: LocationDisplay = rememberLocationDisplay(),
     geometryEditor: GeometryEditor? = null,
     mapViewProxy: MapViewProxy? = null,
@@ -197,6 +200,12 @@ public fun MapView(
                     it.graphicsOverlays.apply {
                         clear()
                         addAll(graphicsOverlays)
+                    }
+                }
+                if (it.imageOverlays != imageOverlays) {
+                    it.imageOverlays.apply {
+                        clear()
+                        addAll(imageOverlays)
                     }
                 }
             })
@@ -267,6 +276,148 @@ public fun MapView(
         onViewpointChangedForCenterAndScale = onViewpointChangedForCenterAndScale,
         onViewpointChangedForBoundingGeometry = onViewpointChangedForBoundingGeometry,
         onVisibleAreaChanged = onVisibleAreaChanged
+    )
+}
+/**
+ * A compose equivalent of the view-based [MapView].
+ *
+ * @param arcGISMap the [ArcGISMap] to be rendered by this composable MapView
+ * @param modifier Modifier to be applied to the composable MapView
+ * @param onViewpointChangedForCenterAndScale lambda invoked when the viewpoint changes, passing a viewpoint
+ * type of [ViewpointType.CenterAndScale]
+ * @param onViewpointChangedForBoundingGeometry lambda invoked when the viewpoint changes, passing a viewpoint
+ * type of [ViewpointType.BoundingGeometry]
+ * @param onVisibleAreaChanged lambda invoked when the visible area of the composable MapView has changed
+ * @param viewpointPersistence the [ViewpointPersistence] to specify how the viewpoint of the composable MapView is persisted
+ * across configuration changes.
+ * @param graphicsOverlays graphics overlays used by this composable MapView
+ * @param locationDisplay the [LocationDisplay] used by the composable MapView
+ * @param geometryEditor the [GeometryEditor] used by the composable MapView to create and edit geometries by user interaction.
+ * @param mapViewProxy the [MapViewProxy] to associate with the composable MapView
+ * @param mapViewInteractionOptions the [MapViewInteractionOptions] used by this composable MapView
+ * @param viewLabelProperties the [ViewLabelProperties] used by the composable MapView
+ * @param selectionProperties the [SelectionProperties] used by the composable MapView
+ * @param insets the inset values to control the active visible area, instructing the MapView to ignore parts that may be obstructed
+ * by overlaid UI elements and affecting the MapView's logical center, the reported visible area and the location display
+ * @param grid represents the display of a coordinate system [Grid] on the composable MapView
+ * @param backgroundGrid the default color and context grid behind the map surface
+ * @param wrapAroundMode the [WrapAroundMode] to specify whether continuous panning across the international date line is enabled
+ * @param isAttributionBarVisible true if attribution bar is visible in the composable MapView, false otherwise
+ * @param onAttributionTextChanged lambda invoked when the attribution text of the composable MapView has changed
+ * @param onAttributionBarLayoutChanged lambda invoked when the attribution bar's position or size changes
+ * @param timeExtent the [TimeExtent] used by the composable MapView
+ * @param onTimeExtentChanged lambda invoked when the composable MapView's [TimeExtent] is changed
+ * @param onNavigationChanged lambda invoked when the navigation status of the composable MapView has changed
+ * @param onMapRotationChanged lambda invoked when the rotation of this composable MapView has changed
+ * @param onMapScaleChanged lambda invoked when the scale of this composable MapView has changed
+ * @param onUnitsPerDipChanged lambda invoked when the Units per DIP of this composable MapView has changed
+ * @param onSpatialReferenceChanged lambda invoked when the spatial reference of the composable MapView has changed
+ * @param onLayerViewStateChanged lambda invoked when the composable MapView's layer view state is changed
+ * @param onInteractingChanged lambda invoked when the user starts and ends interacting with the composable MapView
+ * @param onRotate lambda invoked when a user performs a rotation gesture on the composable MapView
+ * @param onScale lambda invoked when a user performs a pinch gesture on the composable MapView
+ * @param onUp lambda invoked when the user removes all their pointers from the composable MapView
+ * @param onDown lambda invoked when the user first presses on the composable MapView
+ * @param onSingleTapConfirmed lambda invoked when the user taps once on the composable MapView
+ * @param onDoubleTap lambda invoked the user double taps on the composable MapView
+ * @param onLongPress lambda invoked when a user holds a pointer on the composable MapView
+ * @param onTwoPointerTap lambda invoked when a user taps two pointers on the composable MapView
+ * @param onPan lambda invoked when a user drags a pointer or pointers across composable MapView
+ * @param onDrawStatusChanged lambda invoked when the draw status of the composable MapView is changed
+ * @param content the content of the composable MapView
+ * @sample com.arcgismaps.toolkit.geoviewcompose.samples.MapViewSample
+ * @see
+ * - <a href="https://developers.arcgis.com/kotlin/maps-2d/tutorials/display-a-map/">Display a map tutorial</a>
+ * - <a href="https://developers.arcgis.com/kotlin/maps-2d/tutorials/display-a-web-map/">Display a web map tutorial</a>
+ * - <a href="https://developers.arcgis.com/kotlin/maps-2d/tutorials/add-a-point-line-and-polygon/">Add a point, line, and polygon tutorial</a>
+ * @since 200.4.0
+ */
+@Deprecated("Deprecation added for backwards compatibility. Use MapView function with imageOverlays instead.", level = DeprecationLevel.HIDDEN)
+@Composable
+public fun MapView(
+    arcGISMap: ArcGISMap,
+    modifier: Modifier = Modifier,
+    onViewpointChangedForCenterAndScale: ((Viewpoint) -> Unit)? = null,
+    onViewpointChangedForBoundingGeometry: ((Viewpoint) -> Unit)? = null,
+    onVisibleAreaChanged: ((Polygon) -> Unit)? = null,
+    viewpointPersistence: ViewpointPersistence = MapViewDefaults.DefaultViewpointPersistence,
+    graphicsOverlays: List<GraphicsOverlay> = remember { emptyList() },
+    locationDisplay: LocationDisplay = rememberLocationDisplay(),
+    geometryEditor: GeometryEditor? = null,
+    mapViewProxy: MapViewProxy? = null,
+    mapViewInteractionOptions: MapViewInteractionOptions = remember { MapViewInteractionOptions() },
+    viewLabelProperties: ViewLabelProperties = remember { ViewLabelProperties() },
+    selectionProperties: SelectionProperties = remember { SelectionProperties() },
+    insets: PaddingValues = MapViewDefaults.DefaultInsets,
+    grid: Grid? = null,
+    backgroundGrid: BackgroundGrid = remember { BackgroundGrid() },
+    wrapAroundMode: WrapAroundMode = WrapAroundMode.EnabledWhenSupported,
+    isAttributionBarVisible: Boolean = true,
+    onAttributionTextChanged: ((String) -> Unit)? = null,
+    onAttributionBarLayoutChanged: ((AttributionBarLayoutChangeEvent) -> Unit)? = null,
+    timeExtent: TimeExtent? = null,
+    onTimeExtentChanged: ((TimeExtent?) -> Unit)? = null,
+    onNavigationChanged: ((isNavigating: Boolean) -> Unit)? = null,
+    onMapRotationChanged: ((Double) -> Unit)? = null,
+    onMapScaleChanged: ((Double) -> Unit)? = null,
+    onUnitsPerDipChanged: ((Double) -> Unit)? = null,
+    onSpatialReferenceChanged: ((spatialReference: SpatialReference?) -> Unit)? = null,
+    onLayerViewStateChanged: ((GeoView.GeoViewLayerViewStateChanged) -> Unit)? = null,
+    onInteractingChanged: ((isInteracting: Boolean) -> Unit)? = null,
+    onRotate: ((RotationChangeEvent) -> Unit)? = null,
+    onScale: ((ScaleChangeEvent) -> Unit)? = null,
+    onUp: ((UpEvent) -> Unit)? = null,
+    onDown: ((DownEvent) -> Unit)? = null,
+    onSingleTapConfirmed: ((SingleTapConfirmedEvent) -> Unit)? = null,
+    onDoubleTap: ((DoubleTapEvent) -> Unit)? = null,
+    onLongPress: ((LongPressEvent) -> Unit)? = null,
+    onTwoPointerTap: ((TwoPointerTapEvent) -> Unit)? = null,
+    onPan: ((PanChangeEvent) -> Unit)? = null,
+    onDrawStatusChanged: ((DrawStatus) -> Unit)? = null,
+    content: (@Composable MapViewScope.() -> Unit)? = null
+) {
+    MapView(
+        arcGISMap = arcGISMap,
+        modifier = modifier,
+        onViewpointChangedForCenterAndScale = onViewpointChangedForCenterAndScale,
+        onViewpointChangedForBoundingGeometry = onViewpointChangedForBoundingGeometry,
+        onVisibleAreaChanged = onVisibleAreaChanged,
+        viewpointPersistence = viewpointPersistence,
+        graphicsOverlays = graphicsOverlays,
+        imageOverlays = remember { emptyList() },
+        locationDisplay = locationDisplay,
+        geometryEditor = geometryEditor,
+        mapViewProxy = mapViewProxy,
+        mapViewInteractionOptions = mapViewInteractionOptions,
+        viewLabelProperties = viewLabelProperties,
+        selectionProperties = selectionProperties,
+        insets = insets,
+        grid = grid,
+        backgroundGrid = backgroundGrid,
+        wrapAroundMode = wrapAroundMode,
+        isAttributionBarVisible = isAttributionBarVisible,
+        onAttributionTextChanged = onAttributionTextChanged,
+        onAttributionBarLayoutChanged = onAttributionBarLayoutChanged,
+        timeExtent = timeExtent,
+        onTimeExtentChanged = onTimeExtentChanged,
+        onNavigationChanged = onNavigationChanged,
+        onMapRotationChanged = onMapRotationChanged,
+        onMapScaleChanged = onMapScaleChanged,
+        onUnitsPerDipChanged = onUnitsPerDipChanged,
+        onSpatialReferenceChanged = onSpatialReferenceChanged,
+        onLayerViewStateChanged = onLayerViewStateChanged,
+        onInteractingChanged = onInteractingChanged,
+        onRotate = onRotate,
+        onScale = onScale,
+        onUp = onUp,
+        onDown = onDown,
+        onSingleTapConfirmed = onSingleTapConfirmed,
+        onDoubleTap = onDoubleTap,
+        onLongPress = onLongPress,
+        onTwoPointerTap = onTwoPointerTap,
+        onPan = onPan,
+        onDrawStatusChanged = onDrawStatusChanged,
+        content = content
     )
 }
 

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/MapView.kt
@@ -376,6 +376,7 @@ public fun MapView(
     onDrawStatusChanged: ((DrawStatus) -> Unit)? = null,
     content: (@Composable MapViewScope.() -> Unit)? = null
 ) {
+    // Just call through to the new MapView function that takes imageOverlays
     MapView(
         arcGISMap = arcGISMap,
         modifier = modifier,
@@ -384,7 +385,7 @@ public fun MapView(
         onVisibleAreaChanged = onVisibleAreaChanged,
         viewpointPersistence = viewpointPersistence,
         graphicsOverlays = graphicsOverlays,
-        imageOverlays = remember { emptyList() },
+        imageOverlays = remember { emptyList() }, // pass an empty list for imageOverlays
         locationDisplay = locationDisplay,
         geometryEditor = geometryEditor,
         mapViewProxy = mapViewProxy,


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5466

<!-- link to design, if applicable -->

### Description:

Adds an `imageOverlays` parameter on the composable `MapView()` function.

### Summary of changes:

- In `gradle.properties`, increase the `sdkBuildNumber` to gain access to the recently enhanced underlying GeoView that includes an `imageOverlays` property.
- Duplicate the `MapView()` function.
- In the new `MapView()` overload:
   - Add the `imageOverlays` parameter.
   - Bump the `@since` to 200.7.0.
   - In the `update` callback passed to `AndroidView`, update the `imageOverlays` in the underlying MapView if the `imageOverlays` have changed.
- In the old (200.4.0) `MapView()` overload:
   - Replace the body with a simple call to the new (200.7.0) overload. Pass an empty list for `imageOverlays`.
   - Deprecate this version with `DeprecationLevel.HIDDEN`. This hides the old overload from client source code, but retains it in our compiled code, preserving binary compatibility with previously compiled client code.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  