### PR TITLE
Show error message in alert dialog when layers fail to load

### DIFF
--- a/toolkit/legend/src/main/res/values/strings.xml
+++ b/toolkit/legend/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
 
 <resources>
     <string name="symbol_description">symbol of a legend item</string>
+    <string name="error">Error</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5520

<!-- link to design, if applicable -->

### Description:

currently if a layer fails to load, the legend will not display. We need to fix this behavior. Online shows a alert dialog showing the load error message.

### Summary of changes:

- Add alert dialog to display the error message and not just return from loading the legend content when ever a layers fails to load

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/539/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  