### PR TITLE
`Forms` : Fix how Attachment states are created

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -245,24 +245,22 @@ private fun FeatureForm(
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)?
 ) {
     val featureForm = stateData.featureForm
-    // hold the list of form elements in a mutable state to make them observable
-    val formElements = remember(featureForm) {
-        mutableStateOf(featureForm.elements)
+    // Hold the list of form elements.
+    val formElements: List<FormElement> = remember(featureForm) {
+        // Add the default attachments element, if present.
+        featureForm.elements + listOfNotNull(featureForm.defaultAttachmentsElement)
     }
     val scope = rememberCoroutineScope()
     val states = rememberStates(
         form = featureForm,
-        elements = formElements.value,
+        elements = formElements,
         scope = scope
     )
     FeatureFormBody(
         form = featureForm,
         states = states,
         modifier = modifier,
-        onExpressionsEvaluated = {
-            // expressions evaluated, load attachments
-            formElements.value = featureForm.elements
-        },
+        onExpressionsEvaluated = { },
         onBarcodeButtonClick = onBarcodeButtonClick
     )
     FeatureFormDialog(states)
@@ -478,6 +476,12 @@ internal fun rememberStates(
     val states = MutableFormStateCollection()
     elements.forEach { element ->
         when (element) {
+
+            is AttachmentsFormElement -> {
+                val state = rememberAttachmentElementState(form, element)
+                states.add(element, state)
+            }
+
             is FieldFormElement -> {
                 val state = rememberFieldState(element, form, scope)
                 if (state != null) {
@@ -507,9 +511,6 @@ internal fun rememberStates(
             else -> {}
         }
     }
-    // The Toolkit currently only supports AttachmentsFormElements via the
-    // default attachments element. Once AttachmentsFormElements can be authored
-    // the switch case above should have a case added for AttachmentsFormElement.
     if (form.defaultAttachmentsElement != null) {
         val state = rememberAttachmentElementState(form, form.defaultAttachmentsElement!!)
         states.add(form.defaultAttachmentsElement!!, state)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -260,7 +260,6 @@ private fun FeatureForm(
         form = featureForm,
         states = states,
         modifier = modifier,
-        onExpressionsEvaluated = { },
         onBarcodeButtonClick = onBarcodeButtonClick
     )
     FeatureFormDialog(states)
@@ -299,7 +298,6 @@ private fun FeatureFormBody(
     form: FeatureForm,
     states: FormStateCollection,
     modifier: Modifier = Modifier,
-    onExpressionsEvaluated: () -> Unit,
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)?
 ) {
     var initialEvaluation by rememberSaveable(form) { mutableStateOf(false) }
@@ -387,7 +385,6 @@ private fun FeatureFormBody(
         // ensure expressions are evaluated
         form.evaluateExpressions()
         initialEvaluation = true
-        onExpressionsEvaluated()
     }
 }
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/1145](https://devtopia.esri.com/runtime/apollo/issues/1145)

<!-- link to design, if applicable -->

### Description:

Fixes an issue where the attachments are not updated after adding or deleting them.

### Summary of changes:

- Duplicated states were being added if there were `GroupFormElement` in the form since the `FeatureForm.defaultAttachmentsElement` is not part of the elements list. This PR fixes this and moves it out of the state creation routine.
- Updated the implementation of `FormStateCollection` to use a `LinkedHashSet` which preserves insertion order.
- Updated `FormStateCollection.Entry` to implement `equals` and `hashCode` so that duplicate states for a `FormElement` are not added.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/552/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  