### PR TITLE
Exclude from tests

### DIFF
--- a/toolkit/basemapgallery/build.gradle.kts
+++ b/toolkit/basemapgallery/build.gradle.kts
@@ -71,6 +71,12 @@ android {
         val connectedTestReportsPath: String by project
         reportDir = "$connectedTestReportsPath/${project.name}"
     }
+
+    // Avoids an empty test report showing up in the CI integration test report.
+    // Remove this if tests will be added.
+    tasks.withType<Test> {
+        enabled = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #5584

<!-- link to design, if applicable -->

### Description:

Exclude basemap gallery from the test report as it has no tests

### Summary of changes:

- add code to build file to exclude from the results

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/564/Test_20Report_20-_20Integration/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  