### PR TITLE
retrieve artifactory info from local.properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,30 @@ buildscript {
         // before any dependent subproject uses its symbols to configure a dokka task.
         classpath(libs.dokka.versioning)
     }
+    val localProperties = java.util.Properties().apply {
+        val localPropertiesFile = file("local.properties")
+        if (localPropertiesFile.exists()) {
+            load(localPropertiesFile.inputStream())
+        }
+    }
+    // Find these in properties passed through command line or read from local.properties and
+    // set them as project properties
+    val artifactoryUrl: String? = project.findProperty("artifactoryUrl") as String?
+        ?: localProperties.getProperty("artifactoryUrl")
+        ?: ""
+    val artifactoryUsername: String? = project.findProperty("artifactoryUsername") as String?
+        ?: localProperties.getProperty("artifactoryUsername")
+        ?: ""
+    val artifactoryPassword: String? = project.findProperty("artifactoryPassword") as String?
+        ?: localProperties.getProperty("artifactoryPassword")
+        ?: ""
+
+    if (artifactoryUrl != "") {
+        project.extra.set("artifactoryUrl", artifactoryUrl)
+        project.extra.set("artifactoryUsername", artifactoryUsername)
+        project.extra.set("artifactoryPassword", artifactoryPassword)
+    }
+
     val finalBuild: Boolean = (project.properties["finalBuild"] ?: "false")
         .run { this == "true" }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ buildscript {
     // set them as project properties
     val artifactoryUrl: String? = project.findProperty("artifactoryUrl") as String?
         ?: localProperties.getProperty("artifactoryUrl")
-        ?: ""
+        ?: "https://esri.jfrog.io/artifactory/arcgis"
     val artifactoryUsername: String? = project.findProperty("artifactoryUsername") as String?
         ?: localProperties.getProperty("artifactoryUsername")
         ?: ""
@@ -57,11 +57,9 @@ buildscript {
         ?: localProperties.getProperty("artifactoryPassword")
         ?: ""
 
-    if (artifactoryUrl != "") {
-        project.extra.set("artifactoryUrl", artifactoryUrl)
-        project.extra.set("artifactoryUsername", artifactoryUsername)
-        project.extra.set("artifactoryPassword", artifactoryPassword)
-    }
+    project.extra.set("artifactoryUrl", artifactoryUrl)
+    project.extra.set("artifactoryUsername", artifactoryUsername)
+    project.extra.set("artifactoryPassword", artifactoryPassword)
 
     val finalBuild: Boolean = (project.properties["finalBuild"] ?: "false")
         .run { this == "true" }

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -27,9 +27,9 @@ function _display_help_dialog() {
   echo "              and publishes the build to artifactory. It will build the"
   echo "              artifacts if any build dependency is not up to date"
   echo
-  echo "              This script requires the ARTIFACTORY_USR and ARTIFACTORY_PSW "
-  echo "              environment variables to be set to the artifactory username"
-  echo "              and encrypted password"
+  echo "              This script requires the ARTIFACTORY_URL, ARTIFACTORY_USR,"
+  echo "              and ARTIFACTORY_PSW environment variables to be set to the"
+  echo "              Artifactory url, username and encrypted password"
   echo
   echo " -h      Displays this help dialog."
   echo "          Optional"
@@ -46,6 +46,11 @@ function _display_help() {
 }
 
 function _check_options_and_set_variables() {
+  if [ -z "${ARTIFACTORY_URL}"]; then
+    echo "error: ARTIFACTORY_URL is empty but publishing is being requested"
+    exit 1
+  fi
+
   if [ -z "${ARTIFACTORY_USR}" ]; then
     echo "error: ARTIFACTORY_USR is empty but publishing is being requested"
     exit 1
@@ -70,7 +75,7 @@ function _check_options_and_set_variables() {
 function _publish() {
   _log "Publish the release build to artifactory"
 
-  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PfinalBuild=${FINAL_BUILD}" ; then
+  if ! ${apps_path}/arcgis-maps-sdk-kotlin-toolkit/ci/run_gradle_task.sh -t publish -x "-PartifactoryUrl=${ARTIFACTORY_URL} -PartifactoryUsername=${ARTIFACTORY_USR} -PartifactoryPassword=${ARTIFACTORY_PSW} -PversionNumber=${BUILDVER} -PbuildNumber=${BUILDNUM} -PfinalBuild=${FINAL_BUILD}" ; then
     echo "error: Running the publish gradle task failed"
     exit 1
   fi

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,11 +39,8 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-artifactoryUrl=https://olympus.esri.com/artifactory/arcgisruntime-snapshot-local
 artifactoryGroupId=com.esri
 artifactoryArtifactBaseId=arcgis-maps-kotlin-toolkit
-artifactoryUsername=""
-artifactoryPassword=""
 
 # These versions define the dependency of the ArcGIS Maps SDK for Kotlin dependency
 # when building the toolkit locally, typically from Android Studio.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,25 @@ val sdkBuildNumber: String =
         ?: localProperties.getProperty("sdkBuildNumber")
         ?: ""
 
+// The Artifactory credentials for the ArcGIS Maps SDK for Kotlin repository.
+// First look for the credentials provided via command line (for CI builds), if not found,
+// take the one defined in local.properties.
+// CI builds pass -PartifactoryURL=${ARTIFACTORY_URL} -PartifactoryUsername=${ARTIFACTORY_USER} -PartifactoryPassword=${ARTIFACTORY_PASSWORD}
+val artifactoryUrl: String =
+    providers.gradleProperty("artifactoryUrl").orNull
+        ?: localProperties.getProperty("artifactoryUrl")
+        ?: ""
+
+val artifactoryUsername: String =
+    providers.gradleProperty("artifactoryUsername").orNull
+        ?: localProperties.getProperty("artifactoryUsername")
+        ?: ""
+
+val artifactoryPassword: String =
+    providers.gradleProperty("artifactoryPassword").orNull
+        ?: localProperties.getProperty("artifactoryPassword")
+        ?: ""
+
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
@@ -65,10 +84,14 @@ dependencyResolutionManagement {
                 "https://esri.jfrog.io/artifactory/arcgis"
             )
         }
-        maven {
-            url = java.net.URI(
-                "https://olympus.esri.com/artifactory/arcgisruntime-repo/"
-            )
+        if (artifactoryUrl != "") {
+            maven {
+                url = java.net.URI(artifactoryUrl)
+                credentials {
+                    username = artifactoryUsername
+                    password = artifactoryPassword
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: 

<!-- link to design, if applicable -->

### Description:
Removing internal Artifactory information from public repo to `local.propreties`

### Summary of changes:
- Removed artifactory URL from `gradle.properties`
- Updated `settings.gradle.kts` to retrieve credentials from command line first then `local.properties`
- Updated `build.gradle.kts`  to retrieve credentials from command line first then `local.properties` then set the credentials as project variables to be used for other tasks in the build

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a vTest Job for this PR has been run to test retrieving credentials from the command line
  - [ ] link: 
- Changes were test as well using `./ci/run_gradle_task.sh -t assembleDebug`
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  