### PR TITLE
fix the micro app for mapview workflow

### DIFF
--- a/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
+++ b/microapps/LegendApp/app/src/main/java/com/arcgismaps/toolkit/legendapp/screens/MainScreen.kt
@@ -91,9 +91,8 @@ fun MainScreen(viewModel: LegendViewModel = viewModel()) {
                 .padding(padding)
                 .fillMaxSize(),
             arcGISMap = viewModel.arcGISMap,
-            onViewpointChangedForCenterAndScale = {
-                // does not emit after rotation.
-                currentScale = it.targetScale
+            onMapScaleChanged = {
+                currentScale = it
             }
         )
     }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5606

<!-- link to design, if applicable -->

### Description:

Fixes the issue in the micro app where the spinner shows in the bottomsheet instead of the Legend on initial launch and the spinner does not go away till the user pans or zooms

### Summary of changes:

- Use `onMapScaleChanged` callback that works consistently instead of `onViewpointChangedForCenterAndScale`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/571/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  