### PR TITLE
Authenticator: Specify fallback behavior when OAuth config is invalid 

### DIFF
--- a/toolkit/authentication/README.md
+++ b/toolkit/authentication/README.md
@@ -63,6 +63,8 @@ You will also need to declare the `OAuthUserSignInActivity` in your app's manife
 </activity>
 ```
 
+**Note**: If the OAuth configuration is invalid, the Authenticator will not launch an OAuth browser page and will prompt for for username and password instead.
+
 ### Intercepting Challenges
 
 `AuthenticatorState` acts as the `NetworkAuthenticationChallengeHandler` and `ArcGISAuthenticationChallengeHandler` for your app by default. When you create it, you can choose not to set it as the default challenge handler if you wish:

--- a/toolkit/authentication/README.md
+++ b/toolkit/authentication/README.md
@@ -63,7 +63,7 @@ You will also need to declare the `OAuthUserSignInActivity` in your app's manife
 </activity>
 ```
 
-**Note**: If the OAuth configuration is invalid, the Authenticator will not launch an OAuth browser page and will prompt for for username and password instead.
+**Note**: If the OAuth configuration is invalid, the Authenticator will not launch an OAuth browser page and will prompt for a username and password instead.
 
 ### Intercepting Challenges
 

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -57,7 +57,8 @@ public sealed interface AuthenticatorState : NetworkAuthenticationChallengeHandl
 
     /**
      * The [OAuthUserConfiguration] to use for any sign ins. If null, OAuth will not be used for any
-     * [ArcGISAuthenticationChallenge].
+     * [ArcGISAuthenticationChallenge]. If the OAuth configuration is invalid, the Authenticator will not launch an OAuth
+     * browser page and will prompt for for username and password instead.
      *
      * @since 200.2.0
      */

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -58,7 +58,7 @@ public sealed interface AuthenticatorState : NetworkAuthenticationChallengeHandl
     /**
      * The [OAuthUserConfiguration] to use for any sign ins. If null, OAuth will not be used for any
      * [ArcGISAuthenticationChallenge]. If the OAuth configuration is invalid, the Authenticator will not launch an OAuth
-     * browser page and will prompt for for username and password instead.
+     * browser page and will prompt for a username and password instead.
      *
      * @since 200.2.0
      */


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5452

### Summary of changes:
- Adds information on fallback when OAuth config is invalid 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  