### PR TITLE
rebuild the legend when Layers visibility changes

### DIFF
--- a/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
+++ b/toolkit/legend/src/main/java/com/arcgismaps/toolkit/legend/Legend.kt
@@ -58,6 +58,7 @@ import com.arcgismaps.mapping.layers.LayerContent
 import com.arcgismaps.toolkit.legend.theme.LegendDefaults
 import com.arcgismaps.toolkit.legend.theme.Typography
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.merge
@@ -219,8 +220,30 @@ public fun Legend(
                     )
                 }
         }
-    }
 
+        // observe any changes to Layer's visibility and rebuild the legend if anything changes.
+        LaunchedEffect(Unit) {
+            val visibilityChanges: List<SharedFlow<Boolean>> =
+                operationalLayers.filterIsInstance<Layer>().map {
+                    it.visibilityChanged
+                } + (basemap?.baseLayers?.map {
+                    it.visibilityChanged
+                } ?: emptyList()) + (basemap?.referenceLayers?.map {
+                    it.visibilityChanged
+                } ?: emptyList())
+
+            merge(*visibilityChanges.toTypedArray()).shareIn(this, SharingStarted.Lazily).collect {
+                legendContent(
+                    layerContentData,
+                    operationalLayers,
+                    basemap?.baseLayers ?: emptyList(),
+                    basemap?.referenceLayers ?: emptyList(),
+                    reverseLayerOrder,
+                    density
+                )
+            }
+        }
+    }
 
     val validScale = (currentScale != 0.0 && !currentScale.isNaN())
     if (validScale && initialized) {
@@ -318,7 +341,9 @@ private suspend fun addLayersAndSubLayersDataToLayerContentData(
     layers?.let { layerList ->
         // The order of the layers is reversed to match the order in the legend
         val orderedLayers = if (reverseLayerOrder) layerList else layerList.reversed()
-        val filteredLayers = orderedLayers.filter { it.isVisible && it.showInLegend }
+        val filteredLayers = orderedLayers.filter {
+            it.isVisible && it.showInLegend
+        }
         val layersAndSubLayersLayerContentData =
             filteredLayers.flatMap { getLayerContentData(it, density) }
         if (addAtIndexZero) {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5605

<!-- link to design, if applicable -->

### Description:

When a Layer's visibility changes, rebuild the legend.


### Summary of changes:

- rebuild the legend when any Layer's visibility changes. Use a merged flow of all the Layer's `visibilityChanged` flows. `isVisible` property is already respected and used, we just need to observe the StateFlow visibilityChanged and rebuild the legend.

- Tested by repeatedly changed visibility in a loop.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/574/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  