### PR TITLE
Colinanderson/exclude tests

### DIFF
--- a/toolkit/basemapgallery/build.gradle.kts
+++ b/toolkit/basemapgallery/build.gradle.kts
@@ -60,23 +60,6 @@ android {
             }
         }
     }
-
-//    /**
-//     * Configures the test report for connected (instrumented) tests to be copied to a central
-//     * folder in the project's root directory.
-//     */
-//    @Suppress("UnstableApiUsage")
-//    testOptions {
-//        targetSdk = libs.versions.compileSdk.get().toInt()
-//        val connectedTestReportsPath: String by project
-//        reportDir = "$connectedTestReportsPath/${project.name}"
-//    }
-
-    // Avoids an empty test report showing up in the CI integration test report.
-    // Remove this if tests will be added.
-//    tasks.withType<Test> {
-//        enabled = false
-//    }
 }
 
 dependencies {

--- a/toolkit/basemapgallery/build.gradle.kts
+++ b/toolkit/basemapgallery/build.gradle.kts
@@ -60,6 +60,12 @@ android {
             }
         }
     }
+
+    // Avoids an empty test report showing up in the CI integration test report.
+    // Remove this if tests will be added.
+    tasks.withType<Test> {
+        enabled = false
+    }
 }
 
 dependencies {

--- a/toolkit/basemapgallery/build.gradle.kts
+++ b/toolkit/basemapgallery/build.gradle.kts
@@ -61,22 +61,22 @@ android {
         }
     }
 
-    /**
-     * Configures the test report for connected (instrumented) tests to be copied to a central
-     * folder in the project's root directory.
-     */
-    @Suppress("UnstableApiUsage")
-    testOptions {
-        targetSdk = libs.versions.compileSdk.get().toInt()
-        val connectedTestReportsPath: String by project
-        reportDir = "$connectedTestReportsPath/${project.name}"
-    }
+//    /**
+//     * Configures the test report for connected (instrumented) tests to be copied to a central
+//     * folder in the project's root directory.
+//     */
+//    @Suppress("UnstableApiUsage")
+//    testOptions {
+//        targetSdk = libs.versions.compileSdk.get().toInt()
+//        val connectedTestReportsPath: String by project
+//        reportDir = "$connectedTestReportsPath/${project.name}"
+//    }
 
     // Avoids an empty test report showing up in the CI integration test report.
     // Remove this if tests will be added.
-    tasks.withType<Test> {
-        enabled = false
-    }
+//    tasks.withType<Test> {
+//        enabled = false
+//    }
 }
 
 dependencies {

--- a/toolkit/basemapgallery/build.gradle.kts
+++ b/toolkit/basemapgallery/build.gradle.kts
@@ -75,7 +75,6 @@ android {
     // Avoids an empty test report showing up in the CI integration test report.
     // Remove this if tests will be added.
     tasks.withType<Test> {
-        fiugsfdg
         enabled = false
     }
 }

--- a/toolkit/basemapgallery/build.gradle.kts
+++ b/toolkit/basemapgallery/build.gradle.kts
@@ -75,6 +75,7 @@ android {
     // Avoids an empty test report showing up in the CI integration test report.
     // Remove this if tests will be added.
     tasks.withType<Test> {
+        fiugsfdg
         enabled = false
     }
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5584

<!-- link to design, if applicable -->

### Description:

Remove basemap gallery tests from the results since there are no tests. The change made was based on the build file of the popup toolkit component which does not set the common folder.

### Summary of changes:

- remove the test options that sets tests to go to the central location

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/582/Test_20Report_20-_20Integration/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  