### PR TITLE
Colinanderson/basemap gallery configuration change

### DIFF
--- a/toolkit/basemapgallery/src/main/java/com/arcgismaps/toolkit/basemapgallery/BasemapGallery.kt
+++ b/toolkit/basemapgallery/src/main/java/com/arcgismaps/toolkit/basemapgallery/BasemapGallery.kt
@@ -122,7 +122,6 @@ public fun BasemapGallery(
                     modifier = Modifier
                         .padding(8.dp)
                         .clickable {
-                            //selection = basemapGalleryItem
                             selection = index
                             onItemClick(basemapGalleryItem)
                         },

--- a/toolkit/basemapgallery/src/main/java/com/arcgismaps/toolkit/basemapgallery/BasemapGallery.kt
+++ b/toolkit/basemapgallery/src/main/java/com/arcgismaps/toolkit/basemapgallery/BasemapGallery.kt
@@ -35,8 +35,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -110,20 +112,21 @@ public fun BasemapGallery(
     onItemClick: (BasemapGalleryItem) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var selection: BasemapGalleryItem? by remember { mutableStateOf(null) }
+    var selection by rememberSaveable { mutableIntStateOf(-1) }
 
     LazyVerticalGrid(modifier = modifier, columns = GridCells.Adaptive(minSize = 128.dp)) {
-        basemapGalleryItems.forEach { basemapGalleryItem ->
+        basemapGalleryItems.forEachIndexed { index, basemapGalleryItem ->
             item {
                 BasemapGalleryItem(
                     basemapGalleryItem,
                     modifier = Modifier
                         .padding(8.dp)
                         .clickable {
-                            selection = basemapGalleryItem
+                            //selection = basemapGalleryItem
+                            selection = index
                             onItemClick(basemapGalleryItem)
                         },
-                    selection === basemapGalleryItem
+                    index == selection
                 )
             }
         }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5620

<!-- link to design, if applicable -->

### Description:

Saves selection when the configuration changes

### Summary of changes:

- use the list index as the selection marker rather than the basemap gallery item since an `Int` is easy to make `rememberSaveable`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/587/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  