### PR TITLE
Worldscale microapp improvements

### DIFF
--- a/microapps/ArWorldScaleApp/app/src/main/java/com/arcgismaps/toolkit/arworldscaleapp/screens/MainScreen.kt
+++ b/microapps/ArWorldScaleApp/app/src/main/java/com/arcgismaps/toolkit/arworldscaleapp/screens/MainScreen.kt
@@ -167,6 +167,7 @@ fun MainScreen() {
                             text = { Text("${trackingMode::class.java.simpleName} tracking") },
                             onClick = {
                                 selectedTrackingMode = trackingMode
+                                actionsExpanded = false
                             },
                             contentPadding = PaddingValues(end = 12.dp),
                             leadingIcon = {
@@ -174,6 +175,7 @@ fun MainScreen() {
                                     selected = selectedTrackingMode == trackingMode,
                                     onClick = {
                                         selectedTrackingMode = trackingMode
+                                        actionsExpanded = false
                                     }
                                 )
                             }
@@ -227,6 +229,7 @@ fun MainScreen() {
                         .padding(it)
                         .fillMaxSize(),
                     worldScaleTrackingMode = selectedTrackingMode,
+                    clippingDistance = 100.0,
                     onInitializationStatusChanged = {
                         initializationStatus = it
                     },


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#5537](https://devtopia.esri.com/runtime/kotlin/issues/5537)

<!-- link to design, if applicable -->

### Description:

A few tweaks to the worldscale AR microapp

### Summary of changes:

- Radio buttons in tracking mode dropdown
- Basemap 100% opaque
- Buildings layer 50% transparent
- Clipping distance 100m

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/585/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  