### PR TITLE
Modifies UsernamePassword Authenticator supporting text

### DIFF
--- a/toolkit/authentication/api/authentication.api
+++ b/toolkit/authentication/api/authentication.api
@@ -70,10 +70,12 @@ public final class com/arcgismaps/toolkit/authentication/UsernamePasswordAuthent
 
 public final class com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun cancel ()V
 	public final fun continueWithCredentials (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getAdditionalMessage ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun getCause ()Ljava/lang/Throwable;
 	public final fun getHostname ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;
 	public final fun setAdditionalMessage (Ljava/lang/String;)V

--- a/toolkit/authentication/api/authentication.api
+++ b/toolkit/authentication/api/authentication.api
@@ -70,8 +70,9 @@ public final class com/arcgismaps/toolkit/authentication/UsernamePasswordAuthent
 
 public final class com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;)V
 	public final fun cancel ()V
 	public final fun continueWithCredentials (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getAdditionalMessage ()Lkotlinx/coroutines/flow/StateFlow;

--- a/toolkit/authentication/build.gradle.kts
+++ b/toolkit/authentication/build.gradle.kts
@@ -86,6 +86,11 @@ android {
             // This is the default variant.
         }
     }
+
+    lint {
+        // TODO: Remove this when strings.xml lint is fixed via localization
+        disable += "MissingTranslation"
+    }
 }
 
 apiValidation {

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
@@ -340,7 +340,6 @@ class UsernamePasswordTests {
         }
 
         // ensure the dialog prompt is displayed as expected
-        // ensure the dialog prompt is displayed as expected
         advanceUntilIdle()
         composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_password_login_title)).assertIsDisplayed()
 

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
@@ -258,7 +258,8 @@ class UsernamePasswordTests {
     /**
      * Given a UsernamePasswordAuthenticatorDialog,
      * When a username and password challenge is issued with null cause,
-     * Then the dialog prompt should be displayed with the default message,
+     * Then the dialog prompt should be displayed
+     * With a message informing the user that credentials are required.
      *
      * @since 200.8.0
      */
@@ -288,7 +289,8 @@ class UsernamePasswordTests {
     /**
      * Given a UsernamePasswordAuthenticator,
      * When a username and password challenge is issued with an ArcGISAuthenticationException cause,
-     * Then the dialog prompt should be displayed with the appropriate message,
+     * Then the dialog prompt should be displayed
+     * With a message informing the user that the credentials are incorrect.
      *
      * @since 200.8.0
      */
@@ -303,10 +305,9 @@ class UsernamePasswordTests {
         every { usernamePasswordChallengeMock.cause } returns mockCause
 
         composeTestRule.setContent {
-            UsernamePasswordAuthenticatorDialog(usernamePasswordChallengeMock)
+            UsernamePasswordAuthenticator(usernamePasswordChallengeMock)
         }
 
-        // ensure the dialog prompt is displayed as expected
         // ensure the dialog prompt is displayed as expected
         advanceUntilIdle()
         composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_password_login_title)).assertIsDisplayed()
@@ -317,9 +318,10 @@ class UsernamePasswordTests {
     }
 
     /**
-     * Given a UsernamePasswordAuthenticator,
-     * When a username and password challenge is issued with an ArcGISAuthenticationException cause,
-     * Then the dialog prompt should be displayed with the appropriate message,
+     * Given a UsernamePasswordAuthenticatorDialog,
+     * When a username and password challenge is issued with an IllegalStateException cause,
+     * Then the dialog prompt should be displayed
+     * With a message informing the user that an error occurred.
      *
      * @since 200.8.0
      */

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
@@ -344,7 +344,7 @@ class UsernamePasswordTests {
         composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_password_login_title)).assertIsDisplayed()
 
         // verify that the default message is displayed
-        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.sing_in_error_occurred, "arcgis.com"))
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.sign_in_error_occurred, "arcgis.com"))
             .assertIsDisplayed()
     }
 

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.text.input.ImeAction
 import androidx.test.platform.app.InstrumentationRegistry
 import com.arcgismaps.ArcGISEnvironment
+import com.arcgismaps.exceptions.ArcGISAuthenticationException
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeResponse
 import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallenge
 import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallengeResponse
@@ -63,7 +64,7 @@ class UsernamePasswordTests {
     @After
     fun after() = signOut()
 
-    fun signOut() {
+    private fun signOut() {
         runBlocking {
             ArcGISEnvironment.authenticationManager.signOut()
         }
@@ -162,6 +163,7 @@ class UsernamePasswordTests {
     fun keyboardActions() = runTest {
         val usernamePasswordChallengeMock = mockk<UsernamePasswordChallenge>()
         every { usernamePasswordChallengeMock.hostname } returns "arcgis.com"
+        every { usernamePasswordChallengeMock.cause } returns null
         every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
         every { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) } just Runs
 
@@ -226,6 +228,7 @@ class UsernamePasswordTests {
         val usernamePasswordChallengeMock = mockk<UsernamePasswordChallenge>()
         every { usernamePasswordChallengeMock.hostname } returns "arcgis.com"
         every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
+        every { usernamePasswordChallengeMock.cause } returns null
         every { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) } just Runs
 
         composeTestRule.setContent {
@@ -250,6 +253,98 @@ class UsernamePasswordTests {
             .assertIsDisplayed()
             .performClick()
         composeTestRule.onNodeWithText("••••••••••").assertExists()
+    }
+
+    /**
+     * Given a UsernamePasswordAuthenticatorDialog,
+     * When a username and password challenge is issued with null cause,
+     * Then the dialog prompt should be displayed with the default message,
+     *
+     * @since 200.8.0
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testDefaultSupportingText() = runTest {
+        val usernamePasswordChallengeMock = mockk<UsernamePasswordChallenge>()
+        val hostname = "arcgis.com"
+        every { usernamePasswordChallengeMock.hostname } returns hostname
+        every { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) } just Runs
+        every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
+        every { usernamePasswordChallengeMock.cause } returns null
+
+        composeTestRule.setContent {
+            UsernamePasswordAuthenticatorDialog(usernamePasswordChallengeMock)
+        }
+
+        // ensure the dialog prompt is displayed as expected
+        advanceUntilIdle()
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_password_login_title)).assertIsDisplayed()
+
+        // verify that the default message is displayed
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_password_login_message, hostname))
+            .assertIsDisplayed()
+    }
+
+    /**
+     * Given a UsernamePasswordAuthenticator,
+     * When a username and password challenge is issued with an ArcGISAuthenticationException cause,
+     * Then the dialog prompt should be displayed with the appropriate message,
+     *
+     * @since 200.8.0
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testArcGISAuthenticationSupportingText() = runTest {
+        val mockCause = mockk<ArcGISAuthenticationException>()
+        val usernamePasswordChallengeMock = mockk<UsernamePasswordChallenge>()
+        every { usernamePasswordChallengeMock.hostname } returns "arcgis.com"
+        every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
+        every { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) } just Runs
+        every { usernamePasswordChallengeMock.cause } returns mockCause
+
+        composeTestRule.setContent {
+            UsernamePasswordAuthenticatorDialog(usernamePasswordChallengeMock)
+        }
+
+        // ensure the dialog prompt is displayed as expected
+        // ensure the dialog prompt is displayed as expected
+        advanceUntilIdle()
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_password_login_title)).assertIsDisplayed()
+
+        // verify that the default message is displayed
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.incorrect_credentials, "arcgis.com"))
+            .assertIsDisplayed()
+    }
+
+    /**
+     * Given a UsernamePasswordAuthenticator,
+     * When a username and password challenge is issued with an ArcGISAuthenticationException cause,
+     * Then the dialog prompt should be displayed with the appropriate message,
+     *
+     * @since 200.8.0
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testAnyOtherExceptionSupportingText() = runTest {
+
+        val usernamePasswordChallengeMock = mockk<UsernamePasswordChallenge>()
+        every { usernamePasswordChallengeMock.hostname } returns "arcgis.com"
+        every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
+        every { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) } just Runs
+        every { usernamePasswordChallengeMock.cause } returns IllegalStateException("Test")
+
+        composeTestRule.setContent {
+            UsernamePasswordAuthenticatorDialog(usernamePasswordChallengeMock)
+        }
+
+        // ensure the dialog prompt is displayed as expected
+        // ensure the dialog prompt is displayed as expected
+        advanceUntilIdle()
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.username_password_login_title)).assertIsDisplayed()
+
+        // verify that the default message is displayed
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.sing_in_error_occurred, "arcgis.com"))
+            .assertIsDisplayed()
     }
 
     /**

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -326,6 +326,7 @@ private class AuthenticatorStateImpl(
      * as a [Flow].
      *
      * @param url the url of the server that issued the challenge.
+     * @param exception the exception that caused the challenge, if any.
      * @return a [Flow] with a [UsernamePassword] provided by the user, or null if the user cancelled.
      * @since 200.2.0
      */
@@ -356,7 +357,7 @@ public fun AuthenticatorState(
 )
 
 /**
- * Creates an [OAuthUserCredential] for this [OAuthUserConfiguration]. SuspendsApri
+ * Creates an [OAuthUserCredential] for this [OAuthUserConfiguration]. Suspends
  * while the credential is being created, ie. until the user has signed in or cancelled the sign in.
  *
  * @param onPendingSignIn Called when an [OAuthUserSignIn] is available. Use this to display UI to the user.

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -46,7 +46,6 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
 
 /**
  * Handles authentication challenges and exposes state for the [Authenticator] to display to the user.
@@ -166,27 +165,26 @@ private class AuthenticatorStateImpl(
     }
 
     override suspend fun handleArcGISAuthenticationChallenge(challenge: ArcGISAuthenticationChallenge): ArcGISAuthenticationChallengeResponse {
-        return oAuthUserConfiguration?.let { oAuthUserConfiguration ->
-            if (oAuthUserConfiguration.canBeUsedForUrl(challenge.requestUrl)) {
-                val oAuthUserCredential =
-                    oAuthUserConfiguration.handleOAuthChallenge {
-                        // A composable observing [pendingOAuthUserSignIn] can launch the OAuth prompt
-                        // when this value changes.
-                        _pendingOAuthUserSignIn.value = it
-                    }.also {
-                        // At this point we have suspended until the OAuth workflow is complete, so
-                        // we can get rid of the pending sign in. Composables observing this can know
-                        // to remove the OAuth prompt when this value changes.
-                        _pendingOAuthUserSignIn.value = null
-                    }.getOrThrow()
+        val oAuthUserConfiguration = oAuthUserConfiguration
+        return if (oAuthUserConfiguration != null && oAuthUserConfiguration.canBeUsedForUrl(challenge.requestUrl)) {
+            val oAuthUserCredential =
+                oAuthUserConfiguration.handleOAuthChallenge {
+                    // A composable observing [pendingOAuthUserSignIn] can launch the OAuth prompt
+                    // when this value changes.
+                    _pendingOAuthUserSignIn.value = it
+                }.also {
+                    // At this point we have suspended until the OAuth workflow is complete, so
+                    // we can get rid of the pending sign in. Composables observing this can know
+                    // to remove the OAuth prompt when this value changes.
+                    _pendingOAuthUserSignIn.value = null
+                }.getOrThrow()
 
-                ArcGISAuthenticationChallengeResponse.ContinueWithCredential(
-                    oAuthUserCredential
-                )
-            } else {
-                handleArcGISTokenChallenge(challenge)
-            }
-        } ?: handleArcGISTokenChallenge(challenge)
+            ArcGISAuthenticationChallengeResponse.ContinueWithCredential(
+                oAuthUserCredential
+            )
+        } else {
+            handleArcGISTokenChallenge(challenge)
+        }
     }
 
     /**
@@ -204,7 +202,7 @@ private class AuthenticatorStateImpl(
         val maxRetryCount = 5
         var error: Throwable? = null
         repeat(maxRetryCount) {
-            val credential = awaitUsernamePassword(challenge.requestUrl).firstOrNull()
+            val credential = awaitUsernamePassword(challenge.requestUrl, error).firstOrNull()
                 ?: return ArcGISAuthenticationChallengeResponse.Cancel
             TokenCredential.createWithChallenge(challenge, credential.username, credential.password)
                 .onSuccess {
@@ -331,10 +329,11 @@ private class AuthenticatorStateImpl(
      * @return a [Flow] with a [UsernamePassword] provided by the user, or null if the user cancelled.
      * @since 200.2.0
      */
-    private suspend fun awaitUsernamePassword(url: String): Flow<UsernamePassword?> =
+    private suspend fun awaitUsernamePassword(url: String, exception: Throwable? = null): Flow<UsernamePassword?> =
         callbackFlow<UsernamePassword?> {
             _pendingUsernamePasswordChallenge.value = UsernamePasswordChallenge(
                 url = url,
+                cause = exception,
                 onUsernamePasswordReceived = { username, password ->
                     trySendBlocking(UsernamePassword(username, password))
                 },
@@ -357,7 +356,7 @@ public fun AuthenticatorState(
 )
 
 /**
- * Creates an [OAuthUserCredential] for this [OAuthUserConfiguration]. Suspends
+ * Creates an [OAuthUserCredential] for this [OAuthUserConfiguration]. SuspendsApri
  * while the credential is being created, ie. until the user has signed in or cancelled the sign in.
  *
  * @param onPendingSignIn Called when an [OAuthUserSignIn] is available. Use this to display UI to the user.

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
@@ -51,7 +51,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -65,7 +64,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arcgismaps.exceptions.ArcGISAuthenticationException
 
 /**
@@ -316,6 +314,6 @@ private fun getSupportingText(challengeException: Throwable?): Int {
     return when (challengeException) {
         null -> R.string.username_password_login_message
         is ArcGISAuthenticationException -> R.string.incorrect_credentials
-        else -> R.string.sing_in_error_occurred
+        else -> R.string.sign_in_error_occurred
     }
 }

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
@@ -85,7 +85,6 @@ public fun UsernamePasswordAuthenticator(
     usernamePasswordChallenge: UsernamePasswordChallenge,
     modifier: Modifier = Modifier
 ) {
-    val additionalInfo = usernamePasswordChallenge.additionalMessage.collectAsStateWithLifecycle().value
     Surface(modifier = Modifier.fillMaxSize()) {
         UsernamePasswordAuthenticatorImpl(
             hostname = usernamePasswordChallenge.hostname,
@@ -142,7 +141,7 @@ private fun UsernamePasswordAuthenticatorImpl(
     var usernameFieldText by rememberSaveable { mutableStateOf("") }
     var passwordFieldText by rememberSaveable { mutableStateOf("") }
     var passwordVisibility by remember { mutableStateOf(false) }
-    val supportingText = LocalContext.current.getString(getSupportingText(challengeCause), hostname)
+    val supportingText = stringResource(getSupportingText(challengeCause), hostname)
 
     fun submitUsernamePassword() {
         if (usernameFieldText.isNotEmpty() && passwordFieldText.isNotEmpty()) {

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordAuthenticator.kt
@@ -260,7 +260,6 @@ private fun UsernamePasswordAuthenticatorImplPreview() {
     val modifier = Modifier
     UsernamePasswordAuthenticatorImpl(
         hostname = "https://www.arcgis.com",
-        challengeCause = null,
         onConfirm = { _, _ -> },
         onCancel = {},
         modifier = modifier
@@ -275,7 +274,7 @@ private fun UsernamePasswordAuthenticatorPreview() {
     UsernamePasswordAuthenticator(
         usernamePasswordChallenge = UsernamePasswordChallenge(
             url = "https://www.arcgis.com",
-            cause = null,
+            cause = IllegalStateException("Exception"),
             onUsernamePasswordReceived = { _, _ -> },
             onCancel = {}
         ),
@@ -290,7 +289,6 @@ private fun UsernamePasswordAuthenticatorDialogPreview() {
     UsernamePasswordAuthenticatorDialog(
         usernamePasswordChallenge = UsernamePasswordChallenge(
             url = "https://www.arcgis.com",
-            cause = null,
             onUsernamePasswordReceived = { _, _ -> },
             onCancel = {}
         ),
@@ -304,13 +302,17 @@ private fun UsernamePasswordAuthenticatorDialogLocalePreview() {
     UsernamePasswordAuthenticatorDialog(
         usernamePasswordChallenge = UsernamePasswordChallenge(
             url = "https://www.arcgis.com/",
-            cause = null,
             onUsernamePasswordReceived = { _, _ -> },
             onCancel = {}
         )
     )
 }
 
+/**
+ * Returns the string resource ID for the supporting text based on the challenge exception.
+ *
+ * @since 200.8.0
+ */
 private fun getSupportingText(challengeException: Throwable?): Int {
     return when (challengeException) {
         null -> R.string.username_password_login_message

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge.kt
@@ -100,6 +100,10 @@ public class UsernamePasswordChallenge(
      *
      * @since 200.2.0
      */
+    @Deprecated(
+        message = "The `additionalMessage` property is no longer in use. Please use the `cause` property to display relevant error messages instead.",
+        level = DeprecationLevel.WARNING,
+    )
     public fun setAdditionalMessage(message: String?) {
         _additionalMessage.value = message
     }

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge.kt
@@ -27,23 +27,43 @@ import androidx.core.net.toUri
  * Represents an authentication challenge requiring a username and password.
  *
  * @property url the name of the server that initiated this challenge
- * @property cause the exception that caused this challenge
  * @property onUsernamePasswordReceived called when the username and password should be submitted
+ * @property cause the exception that caused this challenge
  * @property onCancel called when the challenge should be cancelled
- * @since 200.2.0
+ * @since 200.8.0
  */
 public class UsernamePasswordChallenge(
     public val url: String,
+    private val onUsernamePasswordReceived: ((username: String, password: String) -> Unit),
     public val cause: Throwable? = null,
-    private val onUsernamePasswordReceived: (username: String, password: String) -> Unit,
-    onCancel: () -> Unit,
+    onCancel: () -> Unit
 ) {
+    /**
+     * Represents an authentication challenge requiring a username and password.
+     *
+     * @property url the name of the server that initiated this challenge
+     * @property onUsernamePasswordReceived called when the username and password should be submitted
+     * @property onCancel called when the challenge should be cancelled
+     *
+     * @since 200.2.0
+     */
+    @Deprecated(
+        message = "Use the constructor with `cause` instead. Ths deprecated method remains to maintain binary compatibility",
+        level = DeprecationLevel.HIDDEN,
+    )
+    public constructor(
+        url: String,
+        onUsernamePasswordReceived: (username: String, password: String) -> Unit,
+        onCancel: () -> Unit,
+    ) : this(
+        url, onUsernamePasswordReceived, cause = null, onCancel
+    )
 
     private var onCancel: (() -> Unit)? = onCancel
     private val _additionalMessage: MutableStateFlow<String?> = MutableStateFlow(null)
 
     @Deprecated(
-        message = "additionalMessage is not used anymore. Use property `cause` to display the appropriate error message.",
+        message = "The `additionalMessage` property is no longer in use. Please use the `cause` property to display relevant error messages instead.",
         level = DeprecationLevel.WARNING,
         replaceWith = ReplaceWith("cause")
     )

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge.kt
@@ -18,30 +18,32 @@
 
 package com.arcgismaps.toolkit.authentication
 
-import android.net.Uri
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import androidx.core.net.toUri
 
 /**
  * Represents an authentication challenge requiring a username and password.
  *
  * @property url the name of the server that initiated this challenge
+ * @property cause the exception that caused this challenge
  * @property onUsernamePasswordReceived called when the username and password should be submitted
  * @property onCancel called when the challenge should be cancelled
  * @since 200.2.0
  */
 public class UsernamePasswordChallenge(
     public val url: String,
-    private val onUsernamePasswordReceived: ((username: String, password: String) -> Unit),
-    onCancel: () -> Unit
+    public val cause: Throwable? = null,
+    private val onUsernamePasswordReceived: (username: String, password: String) -> Unit,
+    onCancel: () -> Unit,
 ) {
 
     private var onCancel: (() -> Unit)? = onCancel
     private val _additionalMessage: MutableStateFlow<String?> = MutableStateFlow(null)
     public val additionalMessage: StateFlow<String?> = _additionalMessage.asStateFlow()
     public val hostname: String by lazy {
-        Uri.parse(url).host ?: url
+        url.toUri().host ?: url
     }
 
 

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/UsernamePasswordChallenge.kt
@@ -41,6 +41,12 @@ public class UsernamePasswordChallenge(
 
     private var onCancel: (() -> Unit)? = onCancel
     private val _additionalMessage: MutableStateFlow<String?> = MutableStateFlow(null)
+
+    @Deprecated(
+        message = "additionalMessage is not used anymore. Use property `cause` to display the appropriate error message.",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith("cause")
+    )
     public val additionalMessage: StateFlow<String?> = _additionalMessage.asStateFlow()
     public val hostname: String by lazy {
         url.toUri().host ?: url

--- a/toolkit/authentication/src/main/res/values-ar/strings.xml
+++ b/toolkit/authentication/src/main/res/values-ar/strings.xml
@@ -14,7 +14,8 @@
   ~  See the License for the specific language governing permissions and
   ~  limitations under the License.
   ~
-  --><resources>
+  -->
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation" >
     <string name="server_trust_title">مضيف غير موثوق به</string>
     <string name="server_trust_message">شهادة الخادم لـ %1$s غير موثوقة. قد يؤدي الاتصال إلى تعريض بياناتك للخطر. هل تريد المتابعة؟</string>
     <string name="cancel">إلغاء الأمر</string>

--- a/toolkit/authentication/src/main/res/values-ar/strings.xml
+++ b/toolkit/authentication/src/main/res/values-ar/strings.xml
@@ -14,8 +14,7 @@
   ~  See the License for the specific language governing permissions and
   ~  limitations under the License.
   ~
-  -->
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation" >
+  --><resources>
     <string name="server_trust_title">مضيف غير موثوق به</string>
     <string name="server_trust_message">شهادة الخادم لـ %1$s غير موثوقة. قد يؤدي الاتصال إلى تعريض بياناتك للخطر. هل تريد المتابعة؟</string>
     <string name="cancel">إلغاء الأمر</string>

--- a/toolkit/authentication/src/main/res/values/strings.xml
+++ b/toolkit/authentication/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
   ~
   -->
 
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation" >
+<resources>
     <string name="server_trust_title">Untrusted host</string>
     <string name="server_trust_message">The server certificate for %1$s is not trusted. Connecting could compromise your data. Do you want to proceed?</string>
     <string name="cancel">Cancel</string>

--- a/toolkit/authentication/src/main/res/values/strings.xml
+++ b/toolkit/authentication/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="username_password_login_title">Authentication required</string>
     <string name="username_password_login_message">You need to sign in to access %1$s</string>
     <string name="incorrect_credentials">The credentials were incorrect for %1$s. Please try again.</string>
-    <string name="error_occurred">An error occurred signing in to %1$s. Please try again.</string>
+    <string name="sing_in_error_occurred">An error occurred signing in to %1$s. Please try again.</string>
     <!-- This text is a label on a textfield that can fit 23 chars -->
     <string name="username_label">Username</string>
     <!-- This text is a label on a textfield that can fit 23 chars -->

--- a/toolkit/authentication/src/main/res/values/strings.xml
+++ b/toolkit/authentication/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="username_password_login_title">Authentication required</string>
     <string name="username_password_login_message">You need to sign in to access %1$s</string>
     <string name="incorrect_credentials">The credentials were incorrect for %1$s. Please try again.</string>
-    <string name="sing_in_error_occurred">An error occurred signing in to %1$s. Please try again.</string>
+    <string name="sign_in_error_occurred">An error occurred signing in to %1$s. Please try again.</string>
     <!-- This text is a label on a textfield that can fit 23 chars -->
     <string name="username_label">Username</string>
     <!-- This text is a label on a textfield that can fit 23 chars -->

--- a/toolkit/authentication/src/main/res/values/strings.xml
+++ b/toolkit/authentication/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
   ~
   -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation" >
     <string name="server_trust_title">Untrusted host</string>
     <string name="server_trust_message">The server certificate for %1$s is not trusted. Connecting could compromise your data. Do you want to proceed?</string>
     <string name="cancel">Cancel</string>

--- a/toolkit/authentication/src/main/res/values/strings.xml
+++ b/toolkit/authentication/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="allow_connection">Allow connection</string>
     <string name="username_password_login_title">Authentication required</string>
     <string name="username_password_login_message">You need to sign in to access %1$s</string>
+    <string name="incorrect_credentials">The credentials were incorrect for %1$s. Please try again.</string>
+    <string name="error_occurred">An error occurred signing in to %1$s. Please try again.</string>
     <!-- This text is a label on a textfield that can fit 23 chars -->
     <string name="username_label">Username</string>
     <!-- This text is a label on a textfield that can fit 23 chars -->


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5108
https://devtopia.esri.com/runtime/kotlin/issues/5755

<!-- link to design, if applicable -->

### Description:
- Modifies UsernamePasswordAuthenticator to pass on the challenge cause to the UI 
- This gives the UI the option to choose the appropriate supporting message depending on the challenge cause. 
- By the UI driving the supporting message, it can be localized 

### Summary of changes:
- Adds automated UI test to verify that the correct messages are displayed when different challenge causes are given
- Cleans up `AuthenticatorState.handleArcGISAuthenticationChallenge` so that `handleArcGISTokenChallenge` is only called once.
- adds `exception` property to `awaitUsernamePassword `
- Modifies `UsernamePasswordAuthenticatorImpl ` to take in a parameter `challengeCause: Throwable?` instead of `additonalMessage`
- Adds a new parameter `cause: Throwable` to `UsernamePasswordChallenge` 
- Adds new `supportingMessage` strings 
- Deprecates `challenge.additionalMessage` to use `challenge.cause` instead
### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: ~https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/643/Test_20Report_20-_20Integration/~
  - [x] https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/645/Test_20Report_20-_20Integration/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  