### PR TITLE
Colinanderson/appapp

### DIFF
--- a/new-microapp-starter.sh
+++ b/new-microapp-starter.sh
@@ -52,7 +52,7 @@ function convertTemplateApp {
     find "${appDirName}" -type f -exec rename -s Template $composableFunctionName {} \; > /dev/null 2>&1
     # replace the string "template" in the contents of any file
     find "${appDirName}" -type f -exec perl -i -pe s/template/$componentName/ {} \; > /dev/null 2>&1
-    # replace the string "Template" in the contents of any file
+    # replace the string "TemplateApp" in the contents of any file
     find "${appDirName}" -type f -exec perl -i -pe s/TemplateApp/$composableFunctionName/ {} \; > /dev/null 2>&1
 
     popd > /dev/null

--- a/new-microapp-starter.sh
+++ b/new-microapp-starter.sh
@@ -53,7 +53,7 @@ function convertTemplateApp {
     # replace the string "template" in the contents of any file
     find "${appDirName}" -type f -exec perl -i -pe s/template/$componentName/ {} \; > /dev/null 2>&1
     # replace the string "Template" in the contents of any file
-    find "${appDirName}" -type f -exec perl -i -pe s/Template/$composableFunctionName/ {} \; > /dev/null 2>&1
+    find "${appDirName}" -type f -exec perl -i -pe s/TemplateApp/$composableFunctionName/ {} \; > /dev/null 2>&1
 
     popd > /dev/null
 }
@@ -79,7 +79,7 @@ componentName="${name,,}"
 componentName="${componentName%app}"
 composableFunctionName="${name^}"
 appDirName="${composableFunctionName}"
-if [[ ! "${appDirName}" =~ .+App$ ]] ; then
+if [[ ! "${appDirName}" =~ .+[Aa]pp$ ]] ; then
     appDirName="${composableFunctionName}App"
 fi
 

--- a/new-microapp-starter.sh
+++ b/new-microapp-starter.sh
@@ -72,7 +72,7 @@ if [ "$1" == "-h" ]; then
 fi
 
 # prompt for component name
-echo "Please enter the name of the new microapp in CamelCase without spaces."
+echo "Please enter the name of the new microapp in CamelCase without spaces. The name should end with App e.g. CompassApp"
 read name
 
 componentName="${name,,}"

--- a/new-microapp-starter.sh
+++ b/new-microapp-starter.sh
@@ -72,7 +72,7 @@ if [ "$1" == "-h" ]; then
 fi
 
 # prompt for component name
-echo "Please enter the name of the new microapp in CamelCase without spaces. The name should end with App e.g. CompassApp"
+echo "Please enter the name of the new microapp in CamelCase without spaces. The name should end with App e.g. CompassApp."
 read name
 
 componentName="${name,,}"


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5807

<!-- link to design, if applicable -->

### Description:

Fixes hopefully all cases where "AppApp" appears rather than "App" e.g.
```
<resources>
    <string name="app_name">ComponentAppApp</string>
</resources>
```
Testing it like
```
arcgis-maps-sdk-kotlin-toolkit % ./new-microapp-starter.sh 
Please enter the name of the new microapp in CamelCase without spaces.
TestApp
copying and converting app files, componentName test composableFunctionName TestApp estimated time 1 minute.
App creation Done
```
produced correct names in the strings, theme and manifest e.g.
```xml
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:tools="http://schemas.android.com/tools">

    <uses-permission android:name="android.permission.INTERNET" />

    <application
        android:allowBackup="true"
        android:dataExtractionRules="@xml/data_extraction_rules"
        android:fullBackupContent="@xml/backup_rules"
        android:icon="@mipmap/ic_launcher"
        android:label="@string/app_name"
        android:roundIcon="@mipmap/ic_launcher_round"
        android:supportsRtl="true"
        android:theme="@style/Theme.TestApp"
        tools:targetApi="31">
        <activity
            android:name=".MainActivity"
            android:exported="true"
            android:theme="@style/Theme.TestApp">
            <intent-filter>
                <action android:name="android.intent.action.MAIN" />

                <category android:name="android.intent.category.LAUNCHER" />
            </intent-filter>
        </activity>
    </application>

</manifest>
```

### Summary of changes:

- instead of replacing "Template" in all files replace "TemplateApp" since the string being used as the replacement already ends in "App"
- when determining if `appDirName` ends in "App" also consider it might end in "app"

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  