### PR TITLE
Hud10837/update tabletop microapp data

### DIFF
--- a/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/MainActivity.kt
+++ b/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/MainActivity.kt
@@ -20,6 +20,7 @@ package com.arcgismaps.toolkit.artabletopapp
 
 import android.os.Bundle
 import android.util.Log
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
@@ -60,6 +61,7 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 
     override fun onResume() {

--- a/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/screens/MainScreen.kt
+++ b/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/screens/MainScreen.kt
@@ -72,7 +72,7 @@ private const val KEY_PREF_ACCEPTED_PRIVACY_INFO = "ACCEPTED_PRIVACY_INFO"
 @Composable
 fun MainScreen() {
     val arcGISSceneLayer = remember {
-        ArcGISSceneLayer("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/DevA_BuildingShells/SceneServer")
+        ArcGISSceneLayer("https://tiles.arcgis.com/tiles/nSZVuSZjHpEZZbRo/arcgis/rest/services/Rotterdam_3D_getextureerd_WGS/SceneServer")
     }
     val arcGISScene = remember {
         ArcGISScene().apply {
@@ -82,7 +82,7 @@ fun MainScreen() {
         }
     }
     val arcGISSceneAnchor = remember {
-        Point(-122.68350326165559, 45.53257485106716, 0.0, arcGISScene.spatialReference)
+        Point(4.487801, 51.916874,0.0, arcGISScene.spatialReference)
     }
 
     // Tracks the currently selected building
@@ -124,9 +124,9 @@ fun MainScreen() {
             TableTopSceneView(
                 arcGISScene = arcGISScene,
                 arcGISSceneAnchor = arcGISSceneAnchor,
-                translationFactor = 400.0,
+                translationFactor = 600.0,
                 modifier = Modifier.fillMaxSize(),
-                clippingDistance = 400.0,
+                clippingDistance = 200.0,
                 tableTopSceneViewProxy = tableTopSceneViewProxy,
                 onInitializationStatusChanged = {
                     initializationStatus = it

--- a/microapps/ArWorldScaleApp/app/src/main/java/com/arcgismaps/toolkit/arworldscaleapp/MainActivity.kt
+++ b/microapps/ArWorldScaleApp/app/src/main/java/com/arcgismaps/toolkit/arworldscaleapp/MainActivity.kt
@@ -20,6 +20,7 @@ package com.arcgismaps.toolkit.arworldscaleapp
 
 import android.os.Bundle
 import android.util.Log
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -56,6 +57,7 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 
     override fun onResume() {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5628

<!-- link to design, if applicable -->

### Description:

The existing data used for the tabletop microapp floats slightly above the surface, even in ArcGIS online. This PR changes the data to an integrated mesh scene which performs decently on old hardware, given the clipping distance.

### Summary of changes:

- Change the scene layer in the microapp
- Change the anchor point, clipping distance, and translation factor to match
- Set the "keep screen on" flag on the microapp -- this was bothering me while testing, because the screen kept turning off when not interacting with the app.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/684/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  