### PR TITLE
Colinanderson/package fix

### DIFF
--- a/new-component-starter.sh
+++ b/new-component-starter.sh
@@ -83,6 +83,11 @@
 	find "${componentName}" -type f -name "*Template*" | while read file; do
            mv "$file" "${file//Template/$composableFunctionName}"
         done
+
+	# replace the string "template" in any file names
+	find "${componentName}" -type f -name "*template*" | while read file; do
+           mv "$file" "${file//template/$componentName}"
+        done
 	
 	# replace the string "template" in the contents of any file
 	find "${componentName}" -type f -exec perl -i -pe s/template/$componentName/g {} \; > /dev/null 2>&1

--- a/new-component-starter.sh
+++ b/new-component-starter.sh
@@ -80,7 +80,11 @@
         done
 	
 	# replace the string "Template" in any file names
-	find "${componentName}" -type f -exec rename -s Template $composableFunctionName {} \; > /dev/null 2>&1
+	find "${componentName}" -type f -name "*Template*"
+	find "${componentName}" -type f -name "*Template*" | while read file; do
+           mv "$file" "${file//Template/$composableFunctionName}"
+        done
+	
 	# replace the string "template" in the contents of any file
 	find "${componentName}" -type f -exec perl -i -pe s/template/$componentName/g {} \; > /dev/null 2>&1
 	# replace the string "Template" in the contents of any file	

--- a/new-component-starter.sh
+++ b/new-component-starter.sh
@@ -80,7 +80,6 @@
         done
 	
 	# replace the string "Template" in any file names
-	find "${componentName}" -type f -name "*Template*"
 	find "${componentName}" -type f -name "*Template*" | while read file; do
            mv "$file" "${file//Template/$composableFunctionName}"
         done

--- a/new-component-starter.sh
+++ b/new-component-starter.sh
@@ -74,8 +74,11 @@
 
     function convertTemplate {
 	pushd toolkit > /dev/null
-	# replace the string "template" in any directory names
-	find "${componentName}" -type d -exec rename -s template $componentName {} \; > /dev/null 2>&1
+        # replace the string "template" in any directory names
+        find "${componentName}" -type d -name "*template*" | while read dir; do
+           mv "$dir" "${dir//template/$componentName}"
+        done
+	
 	# replace the string "Template" in any file names
 	find "${componentName}" -type f -exec rename -s Template $composableFunctionName {} \; > /dev/null 2>&1
 	# replace the string "template" in the contents of any file

--- a/new-microapp-starter.sh
+++ b/new-microapp-starter.sh
@@ -51,8 +51,6 @@ function convertTemplateApp {
        mv "$dir" "${dir//template/$componentName}"
     done
     
-    # replace the string "Template" in any file names
-    find "${appDirName}" -type f -exec rename -s Template $composableFunctionName {} \; > /dev/null 2>&1
     # replace the string "template" in the contents of any file
     find "${appDirName}" -type f -exec perl -i -pe s/template/$componentName/ {} \; > /dev/null 2>&1
     # replace the string "TemplateApp" in the contents of any file

--- a/new-microapp-starter.sh
+++ b/new-microapp-starter.sh
@@ -87,8 +87,6 @@ if [[ ! "${appDirName}" =~ .+[Aa]pp$ ]] ; then
     appDirName="${composableFunctionName}App"
 fi
 
-echo $appDirName
-
 echo copying and converting app files, componentName $componentName composableFunctionName $composableFunctionName estimated time 1 minute.
 copyTemplateApp
 convertTemplateApp

--- a/new-microapp-starter.sh
+++ b/new-microapp-starter.sh
@@ -47,21 +47,17 @@ function copyTemplateApp {
 function convertTemplateApp {
     pushd microapps > /dev/null
     # replace the string "template" in any directory names
-    find "${appDirName}" -type d -name "*template*"
-
-find "${appDirName}" -type d -name "*template*" | while read dir; do
-    mv "$dir" "${dir//template/$componentName}"
-done
+    find "${appDirName}" -type d -name "*template*" | while read dir; do
+       mv "$dir" "${dir//template/$componentName}"
+    done
     
     #find "${appDirName}" -type d -exec rename -s "*template*" $componentName {} \;
     # replace the string "Template" in any file names
     find "${appDirName}" -type f -exec rename -s Template $composableFunctionName {} \; > /dev/null 2>&1
-    #find "${appDirName}" -type f -exec rename -s template $composableFunctionName {} \; > /dev/null 2>&1
     # replace the string "template" in the contents of any file
     find "${appDirName}" -type f -exec perl -i -pe s/template/$componentName/ {} \; > /dev/null 2>&1
     # replace the string "TemplateApp" in the contents of any file
     find "${appDirName}" -type f -exec perl -i -pe s/TemplateApp/$composableFunctionName/ {} \; > /dev/null 2>&1
-    #find "${appDirName}" -type f -exec perl -i -pe s/templateapp/$composableFunctionName/ {} \; > /dev/null 2>&1
 
     popd > /dev/null
 }

--- a/new-microapp-starter.sh
+++ b/new-microapp-starter.sh
@@ -47,13 +47,21 @@ function copyTemplateApp {
 function convertTemplateApp {
     pushd microapps > /dev/null
     # replace the string "template" in any directory names
-    find "${appDirName}" -type d -exec rename -s template $componentName {} \; > /dev/null 2>&1
+    find "${appDirName}" -type d -name "*template*"
+
+find "${appDirName}" -type d -name "*template*" | while read dir; do
+    mv "$dir" "${dir//template/$componentName}"
+done
+    
+    #find "${appDirName}" -type d -exec rename -s "*template*" $componentName {} \;
     # replace the string "Template" in any file names
     find "${appDirName}" -type f -exec rename -s Template $composableFunctionName {} \; > /dev/null 2>&1
+    #find "${appDirName}" -type f -exec rename -s template $composableFunctionName {} \; > /dev/null 2>&1
     # replace the string "template" in the contents of any file
     find "${appDirName}" -type f -exec perl -i -pe s/template/$componentName/ {} \; > /dev/null 2>&1
     # replace the string "TemplateApp" in the contents of any file
     find "${appDirName}" -type f -exec perl -i -pe s/TemplateApp/$composableFunctionName/ {} \; > /dev/null 2>&1
+    #find "${appDirName}" -type f -exec perl -i -pe s/templateapp/$composableFunctionName/ {} \; > /dev/null 2>&1
 
     popd > /dev/null
 }
@@ -82,6 +90,8 @@ appDirName="${composableFunctionName}"
 if [[ ! "${appDirName}" =~ .+[Aa]pp$ ]] ; then
     appDirName="${composableFunctionName}App"
 fi
+
+echo $appDirName
 
 echo copying and converting app files, componentName $componentName composableFunctionName $composableFunctionName estimated time 1 minute.
 copyTemplateApp

--- a/new-microapp-starter.sh
+++ b/new-microapp-starter.sh
@@ -51,7 +51,6 @@ function convertTemplateApp {
        mv "$dir" "${dir//template/$componentName}"
     done
     
-    #find "${appDirName}" -type d -exec rename -s "*template*" $componentName {} \;
     # replace the string "Template" in any file names
     find "${appDirName}" -type f -exec rename -s Template $composableFunctionName {} \; > /dev/null 2>&1
     # replace the string "template" in the contents of any file


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5242

<!-- link to design, if applicable -->

### Description:

Fixes microapp script problem that fails to rename directories.

Renames the directory from `templateapp` to `****app` so directory is now correct for the package. Code came from Copilot...

>Explanation:
find /path/to/search -type d -name "*template*": Finds directories containing "template".
while read dir; do ... done: Loops through each directory found.
mv "$dir" "${dir//template/yourReplacement}": Renames the directory by replacing "template" with yourReplacement. Replace yourReplacement with the desired string.

After this change I get 
![image](https://github.com/user-attachments/assets/6fec5e04-ba19-4e30-ae57-68e962ace77a)

### Summary of changes:

- change the directory rename code

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  