### PR TITLE
WorldScaleSceneView: Add depth api for hit tests

### DIFF
--- a/microapps/ArWorldScaleApp/app/src/main/java/com/arcgismaps/toolkit/arworldscaleapp/screens/MainScreen.kt
+++ b/microapps/ArWorldScaleApp/app/src/main/java/com/arcgismaps/toolkit/arworldscaleapp/screens/MainScreen.kt
@@ -120,7 +120,6 @@ fun MainScreen() {
             // is calculated with elevation
             baseSurface.elevationSources.add(ElevationSource.fromTerrain3dService())
             baseSurface.backgroundGrid.isVisible = false
-            baseSurface.opacity = 0.5f
             // add the Esri 3D Buildings layer
             operationalLayers.add(
                 ArcGISSceneLayer("https://www.arcgis.com/home/item.html?id=b8fec5af7dfe4866b1b8ac2d2800f282").apply {

--- a/microapps/ArWorldScaleApp/app/src/main/java/com/arcgismaps/toolkit/arworldscaleapp/screens/MainScreen.kt
+++ b/microapps/ArWorldScaleApp/app/src/main/java/com/arcgismaps/toolkit/arworldscaleapp/screens/MainScreen.kt
@@ -113,6 +113,7 @@ fun MainScreen() {
             // is calculated with elevation
             baseSurface.elevationSources.add(ElevationSource.fromTerrain3dService())
             baseSurface.backgroundGrid.isVisible = false
+            baseSurface.opacity = 0.5f
             // add the Esri 3D Buildings layer
             operationalLayers.add(
                 ArcGISSceneLayer("https://www.arcgis.com/home/item.html?id=b8fec5af7dfe4866b1b8ac2d2800f282").apply {

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/WorldScaleSceneView.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/WorldScaleSceneView.kt
@@ -76,6 +76,7 @@ import com.arcgismaps.toolkit.ar.internal.update
 import com.arcgismaps.toolkit.geoviewcompose.SceneView
 import com.arcgismaps.toolkit.geoviewcompose.SceneViewDefaults
 import com.google.ar.core.Config.PlaneFindingMode
+import com.google.ar.core.DepthPoint
 import com.google.ar.core.Frame
 import com.google.ar.core.Plane
 import com.google.ar.core.Point
@@ -140,8 +141,10 @@ import java.time.Instant
  * @param onDown lambda invoked when the user first presses on the WorldScaleSceneView.
  * @param onSingleTapConfirmed lambda invoked when the user taps once on the WorldScaleSceneView. The
  * [SingleTapConfirmedEvent.mapPoint] passed to this lambda is calculated by performing a hit test against
- * detected planes in the camera feed. If no planes are detected at the tapped point, the mapPoint
- * will be null.
+ * objects in the camera feed using ARCore's Depth API. If the device does not support the Depth API,
+ * the hit test will be calculated against detected planes in the camera feed. If no hits are detected
+ * at the tapped point, the mapPoint will be null. For more information, see the [Depth API](https://developers.google.com/ar/develop/depth)
+ * and [Hit result types](https://developers.google.com/ar/develop/hit-test#hit_result_types).
  * @param onDoubleTap lambda invoked the user double taps on the WorldScaleSceneView.
  * @param onLongPress lambda invoked when a user holds a pointer on the WorldScaleSceneView.
  * @param onTwoPointerTap lambda invoked when a user taps two pointers on the WorldScaleSceneView.
@@ -306,7 +309,7 @@ public fun WorldScaleSceneView(
             },
             onTapWithHitResult = { },
             onFirstPlaneDetected = { },
-            visualizePlanes = false
+            visualizePlanes = true
         )
         // Don't display the scene view if the camera has not been set up yet, or else a globe will appear
         // If the initialization status is FailedToInitialize, we don't want to display the scene view
@@ -393,7 +396,7 @@ private fun handleOnSingleTapConfirmedEvent(
             )
             val hit = hitResult.firstOrNull {
                 when (it.trackable) {
-                    is Plane, is Point -> true
+                    is Plane, is Point, is DepthPoint -> true
                     else -> false
                 }
             }

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/WorldScaleSceneView.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/WorldScaleSceneView.kt
@@ -316,7 +316,7 @@ public fun WorldScaleSceneView(
             },
             onTapWithHitResult = { },
             onFirstPlaneDetected = { },
-            visualizePlanes = true
+            visualizePlanes = false
         )
         // Don't display the scene view if the camera has not been set up yet, or else a globe will appear
         // If the initialization status is FailedToInitialize, we don't want to display the scene view

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
@@ -85,6 +85,11 @@ internal class ArSessionWrapper(
                     }
                     geospatialMode = Config.GeospatialMode.ENABLED
                 }
+                if (planeFindingMode != PlaneFindingMode.DISABLED) {
+                    if (session?.isDepthModeSupported(Config.DepthMode.AUTOMATIC) == true) {
+                        depthMode = Config.DepthMode.AUTOMATIC
+                    }
+                }
                 // We only want to detect horizontal planes.
                 setPlaneFindingMode(planeFindingMode)
             }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5805

<!-- link to design, if applicable -->

### Description:

Enables depth mode when supported, and if plane-finding mode is enabled for the session, so that hit tests can use the detph api. This improves the accuracy of hit tests quite a bit, and there's no need to visualize planes for hit tests.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/718/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  