### PR TITLE
OfflineMapInfo patch changes & cleanup

### DIFF
--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapInfo.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapInfo.kt
@@ -36,7 +36,7 @@ import java.io.FileOutputStream
  */
 public class OfflineMapInfo private constructor(
     private val info: CodableInfo,
-    public val thumbnail: Bitmap?
+    private val _thumbnail: Bitmap?
 ) {
 
     /**
@@ -56,7 +56,7 @@ public class OfflineMapInfo private constructor(
                 portalItemURL = itemUrl
             )
         },
-        thumbnail = runBlocking {
+        _thumbnail = runBlocking {
             portalItem.thumbnail?.let { loadableImage ->
                 runCatching { loadableImage.load() }
                 loadableImage.image?.bitmap
@@ -71,6 +71,14 @@ public class OfflineMapInfo private constructor(
      */
     public val id: String
         get() = info.portalItemID
+
+    /**
+     * The thumbnail of the portal item associated with the map.
+     *
+     * @since 200.8.0
+     */
+    public val thumbnail: Bitmap?
+        get() = _thumbnail
 
     /**
      * The title of the portal item associated with the map.
@@ -165,7 +173,7 @@ public class OfflineMapInfo private constructor(
             infoFile.writeText(jsonString, Charsets.UTF_8)
         }
 
-        thumbnail?.let { bmp ->
+        _thumbnail?.let { bmp ->
             val thumbFile = File(directory, offlineMapInfoThumbnailFile)
             runCatching {
                 FileOutputStream(thumbFile).use { out ->

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineRepository.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineRepository.kt
@@ -184,14 +184,13 @@ public class OfflineRepository(private val context: Context) {
         val pendingInfoFile = File(pendingDir, offlineMapInfoJsonFile).takeIf { it.exists() }
             ?: return
         val pendingThumbnailFile = File(pendingDir, offlineMapInfoThumbnailFile)
-        // do not overwrite map info if it already exists
-        val destInfoFile = File(destDir, offlineMapInfoJsonFile).takeIf { it.exists() }
-            ?: return
-        val destThumbnailFile = File(destDir, offlineMapInfoThumbnailFile)
+        // null if map info file already exists to prevent overwrite
+        val destInfoFile = File(destDir, offlineMapInfoJsonFile).takeIf { !it.exists() }
+        val destThumbnailFile = File(destDir, offlineMapInfoThumbnailFile).takeIf { !it.exists() }
         // copy pending map info to destination
-        pendingInfoFile.copyRecursively(destInfoFile)
+        destInfoFile?.let { pendingInfoFile.copyRecursively(it) }
         // copy map info thumbnail if pending thumbnail file exists
-        if (pendingThumbnailFile.exists()) {
+        if (pendingThumbnailFile.exists() && destThumbnailFile != null) {
             pendingThumbnailFile.copyRecursively(destThumbnailFile)
         }
         pendingDir.deleteRecursively()

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/workmanager/Constants.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/workmanager/Constants.kt
@@ -28,7 +28,7 @@ internal const val mobileMapPackagePathKey = "MobileMapPackagePath"
 internal const val downloadJobJsonFile = "Job.json"
 
 // Offline URLs constants
-internal const val offlineManagerDir = "com.arcgismaps.toolkit.offline"
+internal const val offlineRepositoryDir = "com.arcgismaps.toolkit.offline"
 internal const val pendingMapInfoDir = "PendingMapInfo"
 internal const val pendingJobsDir = "PendingJobs"
 internal const val offlineMapAreasCacheDir = "OfflineMapAreasCache"

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/workmanager/OfflineURLs.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/workmanager/OfflineURLs.kt
@@ -55,12 +55,12 @@ internal object OfflineURLs {
      * Returns the path to the offline manager directory,
      * creates the directory if it doesn’t already exist:
      *
-     * - `<your-app-files-dir>/com.esri.ArcGISToolkit.offlineManager`
+     * - `<your-app-files-dir>/com.esri.toolkit.offline`
      *
      * @since 200.8.0
      */
-    internal fun offlineManagerDirectory(context: Context): String {
-        val dir = File(getExternalDirPath(context), offlineManagerDir)
+    internal fun offlineRepositoryDirectory(context: Context): String {
+        val dir = File(getExternalDirPath(context), offlineRepositoryDir)
             .makeDirectoryIfItDoesNotExist()
         return dir.absolutePath
     }
@@ -69,12 +69,12 @@ internal object OfflineURLs {
      * Returns the path to the web‐map directory for a specific portal item ID,
      * creates the directory if it doesn’t already exist:
      *
-     * - `<your-app-files-dir>/com.esri.ArcGISToolkit.offlineManager/<portalItemID>`
+     * - `<your-app-files-dir>/com.esri.toolkit.offline/<portalItemID>`
      *
      * @since 200.8.0
      */
-    internal fun portalItemDirectory(context: Context, portalItemID: String): String {
-        val base = File(offlineManagerDirectory(context))
+    internal fun portalItemDirectoryPath(context: Context, portalItemID: String): String {
+        val base = File(offlineRepositoryDirectory(context))
         val itemDir = File(base, portalItemID).makeDirectoryIfItDoesNotExist()
         return itemDir.absolutePath
     }
@@ -83,11 +83,11 @@ internal object OfflineURLs {
      * Returns the path to the “Preplanned” subdirectory for a portal item,
      * creates the directory if it doesn’t already exist:
      *
-     * - `<your-app-files-dir>/com.esri.ArcGISToolkit.offlineManager/<portalItemID>/Preplanned/<preplannedMapAreaID>`
+     * - `<your-app-files-dir>/com.esri.toolkit.offline/<portalItemID>/Preplanned/<preplannedMapAreaID>`
      *
      * If [preplannedMapAreaID] is null:
      *
-     * - `<your-app-files-dir>/com.esri.ArcGISToolkit.offlineManager/<portalItemID>/Preplanned`
+     * - `<your-app-files-dir>/com.esri.toolkit.offline/<portalItemID>/Preplanned`
      *
      * @since 200.8.0
      */
@@ -96,7 +96,7 @@ internal object OfflineURLs {
         portalItemID: String,
         preplannedMapAreaID: String? = null
     ): String {
-        val itemDir = File(portalItemDirectory(context, portalItemID))
+        val itemDir = File(portalItemDirectoryPath(context, portalItemID))
         val preplannedDir = File(itemDir, preplannedMapAreas).makeDirectoryIfItDoesNotExist()
         return if (preplannedMapAreaID != null) {
             val areaDir = File(preplannedDir, preplannedMapAreaID).makeDirectoryIfItDoesNotExist()
@@ -110,12 +110,12 @@ internal object OfflineURLs {
      * Returns the path to the “OnDemand” subdirectory for a portal item,
      * creates the directory if it doesn’t already exist:
      *
-     * - `<your-app-files-dir>/com.esri.ArcGISToolkit.offlineManager/<portalItemID>/OnDemand/<onDemandMapAreaID>`
+     * - `<your-app-files-dir>/com.esri.toolkit.offline/<portalItemID>/OnDemand/<onDemandMapAreaID>`
      *
      *
      * If [onDemandMapAreaID] is null:
      *
-     * - `<your-app-files-dir>/com.esri.ArcGISToolkit.offlineManager/<portalItemID>/OnDemand`
+     * - `<your-app-files-dir>/com.esri.toolkit.offline/<portalItemID>/OnDemand`
      *
      * @since 200.8.0
      */
@@ -124,7 +124,7 @@ internal object OfflineURLs {
         portalItemID: String,
         onDemandMapAreaID: String? = null
     ): String {
-        val itemDir = File(portalItemDirectory(context, portalItemID))
+        val itemDir = File(portalItemDirectoryPath(context, portalItemID))
         val onDemandDir = File(itemDir, onDemandAreas).makeDirectoryIfItDoesNotExist()
         return if (onDemandMapAreaID != null) {
             val areaDir = File(onDemandDir, onDemandMapAreaID).makeDirectoryIfItDoesNotExist()


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#5760](https://devtopia.esri.com/runtime/kotlin/issues/5760)

<!-- link to design, if applicable -->

### Description:

PR to add patch fix for concurrent downloads and update relevant docs.  

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/730/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  