### PR TITLE
AR: use 3d buildings scene layer for tabletop microapp

### DIFF
--- a/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/screens/MainScreen.kt
+++ b/microapps/ArTabletopApp/app/src/main/java/com/arcgismaps/toolkit/artabletopapp/screens/MainScreen.kt
@@ -72,8 +72,9 @@ private const val KEY_PREF_ACCEPTED_PRIVACY_INFO = "ACCEPTED_PRIVACY_INFO"
 
 @Composable
 fun MainScreen() {
+    // Esri 3d Buildings Scene Layer
     val arcGISSceneLayer = remember {
-        ArcGISSceneLayer("https://tiles.arcgis.com/tiles/nSZVuSZjHpEZZbRo/arcgis/rest/services/Rotterdam_3D_getextureerd_WGS/SceneServer")
+        ArcGISSceneLayer("https://www.arcgis.com/home/item.html?id=b8fec5af7dfe4866b1b8ac2d2800f282")
     }
     val arcGISScene = remember {
         ArcGISScene().apply {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5925

<!-- link to design, if applicable -->

### Description:

We weren't sure on the licensing of the data for tabletop, so just use the 3d buildings scene layer

### Summary of changes:

- Change the microapp data to 3d buildings scene layer

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/736/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  