### PR TITLE
Changes to make OfflineRepository Singleton, to support single instan…

### DIFF
--- a/toolkit/offline/api/offline.api
+++ b/toolkit/offline/api/offline.api
@@ -72,7 +72,10 @@ public final class com/arcgismaps/toolkit/offline/OfflineMapState {
 
 public final class com/arcgismaps/toolkit/offline/OfflineRepository {
 	public static final field $stable I
-	public fun <init> (Landroid/content/Context;)V
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/offline/OfflineRepository;
 	public final fun getOfflineMapInfos ()Ljava/util/List;
+	public final fun refreshOfflineMapInfos (Landroid/content/Context;)V
+	public final fun removeAllDownloads (Landroid/content/Context;)V
+	public final fun removeDownloadsForWebmap (Landroid/content/Context;Lcom/arcgismaps/toolkit/offline/OfflineMapInfo;)V
 }
 

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -55,8 +55,6 @@ public class OfflineMapState(
         onSelectionChanged = onSelectionChanged
     )
 
-    private lateinit var _offlineRepository: OfflineRepository
-
     private var _mode: OfflineMapMode = OfflineMapMode.Unknown
     internal val mode: OfflineMapMode
         get() = _mode
@@ -96,7 +94,7 @@ public class OfflineMapState(
             throw it
         }
 
-        _offlineRepository = OfflineRepository(context)
+        OfflineRepository.refreshOfflineMapInfos(context)
         offlineMapTask = OfflineMapTask(arcGISMap)
         portalItem = (arcGISMap.item as? PortalItem)
             ?: throw IllegalStateException("Item not found")
@@ -112,14 +110,15 @@ public class OfflineMapState(
                 .sortedBy { it.portalItem.title }
                 .forEach { mapArea ->
                     val preplannedMapAreaState = PreplannedMapAreaState(
+                        context = context,
                         preplannedMapArea = mapArea,
                         offlineMapTask = offlineMapTask,
                         portalItem = portalItem,
-                        offlineRepository = _offlineRepository,
                         onSelectionChanged = onSelectionChanged
                     )
                     preplannedMapAreaState.initialize()
-                    val preplannedPath = _offlineRepository.isPrePlannedAreaDownloaded(
+                    val preplannedPath = OfflineRepository.isPrePlannedAreaDownloaded(
+                        context = context,
                         portalItemID = portalItem.itemId,
                         preplannedMapAreaID = mapArea.portalItem.itemId
                     )

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineRepository.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineRepository.kt
@@ -18,6 +18,8 @@
 package com.arcgismaps.toolkit.offline
 
 import android.content.Context
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
@@ -47,22 +49,26 @@ import java.util.UUID
  *
  * @since 200.8.0
  */
-public class OfflineRepository(private val context: Context) {
+public object OfflineRepository {
 
-    private val workManager = WorkManager.getInstance(context)
-
-    private var _offlineMapInfos: MutableList<OfflineMapInfo> = mutableListOf()
+    private var _offlineMapInfos: SnapshotStateList<OfflineMapInfo> = mutableStateListOf()
 
     /**
      * The portal item information for web maps that have downloaded map areas.
      *
      * @since 200.8.0
      */
-    public val offlineMapInfos: List<OfflineMapInfo>
-        get() = _offlineMapInfos.toList()
+    public val offlineMapInfos: List<OfflineMapInfo> = _offlineMapInfos
 
-    init {
-        _offlineMapInfos.addAll(loadOfflineMapInfos())
+    /**
+     * Initializes the offline map repository by loading existing offline map infos from disk.
+     *
+     * @param context The application context.
+     * @since 200.8.0
+     */
+    public fun refreshOfflineMapInfos(context: Context) {
+        _offlineMapInfos.clear()
+        _offlineMapInfos.addAll(loadOfflineMapInfos(context))
     }
 
     /**
@@ -70,7 +76,7 @@ public class OfflineRepository(private val context: Context) {
      *
      * @since 200.8.0
      */
-    public fun removeAllDownloads() {
+    public fun removeAllDownloads(context: Context) {
         _offlineMapInfos.clear()
         val baseDir = File(OfflineURLs.offlineRepositoryDirectoryPath(context))
         if (baseDir.exists()) {
@@ -85,7 +91,7 @@ public class OfflineRepository(private val context: Context) {
      * @param offlineMapInfo The [OfflineMapInfo] to remove.
      * @since 200.8.0
      */
-    public fun removeDownloadsForWebmap(offlineMapInfo: OfflineMapInfo) {
+    public fun removeDownloadsForWebmap(context: Context, offlineMapInfo: OfflineMapInfo) {
         _offlineMapInfos.remove(offlineMapInfo)
         val baseDir = File(OfflineURLs.offlineRepositoryDirectoryPath(context))
         val offlineMapInfoDir = File(baseDir, offlineMapInfo.id)
@@ -98,7 +104,7 @@ public class OfflineRepository(private val context: Context) {
      * Saves the [OfflineMapInfo] to the pending folder for a particular web map's portal item.
      * The info will stay in that folder until the job completes.
      */
-    private fun savePendingMapInfo(portalItem: PortalItem) {
+    private fun savePendingMapInfo(context: Context, portalItem: PortalItem) {
         val pendingMapInfoDir = File(
             OfflineURLs.pendingMapInfoDirectoryPath(context, portalItem.itemId)
         )
@@ -117,6 +123,7 @@ public class OfflineRepository(private val context: Context) {
      * @since 200.8.0
      */
     internal fun createPendingPreplannedJobPath(
+        context: Context,
         portalItemID: String,
         preplannedMapAreaID: String
     ): File {
@@ -154,7 +161,7 @@ public class OfflineRepository(private val context: Context) {
      *
      * @since 200.8.0
      */
-    private fun loadOfflineMapInfos(): List<OfflineMapInfo> {
+    private fun loadOfflineMapInfos(context: Context): List<OfflineMapInfo> {
         val baseDir = File(OfflineURLs.offlineRepositoryDirectoryPath(context))
         val offlineMapInfos = mutableListOf<OfflineMapInfo>()
         if (!baseDir.exists() || !baseDir.isDirectory) {
@@ -179,7 +186,10 @@ public class OfflineRepository(private val context: Context) {
      *
      * @since 200.8.0
      */
-    private fun movePreplannedJobResultToDestination(offlineMapCacheDownloadPath: String): File {
+    private fun movePreplannedJobResultToDestination(
+        context: Context,
+        offlineMapCacheDownloadPath: String
+    ): File {
         val cacheAreaDir = File(offlineMapCacheDownloadPath)
         val areaItemID = cacheAreaDir.name
         val portalDir = cacheAreaDir.parentFile
@@ -194,7 +204,7 @@ public class OfflineRepository(private val context: Context) {
             val target = File(destDir, child.name)
             child.copyRecursively(target, overwrite = true)
         }
-        movePreplannedOfflineMapInfoToDestination(portalItemID)
+        movePreplannedOfflineMapInfoToDestination(context, portalItemID)
         cacheAreaDir.deleteRecursively()
         return destDir
     }
@@ -204,7 +214,10 @@ public class OfflineRepository(private val context: Context) {
      *
      * @since 200.8.0
      */
-    internal fun deleteContentsForDirectory(offlineMapDirectoryPath: String): Boolean {
+    internal fun deleteContentsForDirectory(
+        context: Context,
+        offlineMapDirectoryPath: String
+    ): Boolean {
         return File(offlineMapDirectoryPath).deleteRecursively()
     }
 
@@ -216,7 +229,7 @@ public class OfflineRepository(private val context: Context) {
      * @param portalItemID The ID of the portal item whose offline map info should be removed.
      * @since 200.8.0
      */
-    internal fun removeOfflineMapInfo(portalItemID: String) {
+    internal fun removeOfflineMapInfo(context: Context, portalItemID: String) {
         _offlineMapInfos.removeAll { it.id == portalItemID }
         val baseDir = File(OfflineURLs.offlineRepositoryDirectoryPath(context))
         val offlineMapInfoDir = File(baseDir, portalItemID)
@@ -231,7 +244,7 @@ public class OfflineRepository(private val context: Context) {
      *
      * @since 200.8.0
      */
-    private fun movePreplannedOfflineMapInfoToDestination(portalItemID: String) {
+    private fun movePreplannedOfflineMapInfoToDestination(context: Context, portalItemID: String) {
         val pendingDir = File(OfflineURLs.pendingMapInfoDirectoryPath(context, portalItemID))
         val destDir = File(OfflineURLs.portalItemDirectoryPath(context, portalItemID))
         // use pending map info file only if it exists
@@ -259,6 +272,7 @@ public class OfflineRepository(private val context: Context) {
      * @since 200.8.0
      */
     internal fun isPrePlannedAreaDownloaded(
+        context: Context,
         portalItemID: String,
         preplannedMapAreaID: String
     ): String? {
@@ -283,6 +297,7 @@ public class OfflineRepository(private val context: Context) {
      * @since 200.8.0
      */
     internal fun createPreplannedMapAreaRequestAndQueueDownload(
+        context: Context,
         jsonJobPath: String,
         preplannedMapAreaTitle: String
     ): UUID {
@@ -303,7 +318,7 @@ public class OfflineRepository(private val context: Context) {
         // only one instance of OfflineJobWorker is running at any time
         // if any new work request with the uniqueWorkName is enqueued, it replaces any existing
         // ones that are active
-        workManager.enqueueUniqueWork(
+        WorkManager.getInstance(context).enqueueUniqueWork(
             uniqueWorkName = jobWorkerUuidKey + workRequest.id,
             existingWorkPolicy = ExistingWorkPolicy.KEEP,
             request = workRequest
@@ -324,12 +339,14 @@ public class OfflineRepository(private val context: Context) {
      * @since 200.8.0
      */
     internal suspend fun observeStatusForPreplannedWork(
+        context: Context,
         offlineWorkerUUID: UUID,
         preplannedMapAreaState: PreplannedMapAreaState,
         portalItem: PortalItem,
         onWorkInfoStateChanged: (WorkInfo) -> Unit,
     ) {
-        savePendingMapInfo(portalItem)
+        val workManager = WorkManager.getInstance(context)
+        savePendingMapInfo(context, portalItem)
         // collect the flow to get the latest work info list
         workManager.getWorkInfoByIdFlow(offlineWorkerUUID)
             .collect { workInfo ->
@@ -347,7 +364,7 @@ public class OfflineRepository(private val context: Context) {
                             preplannedMapAreaState.updateStatus(Status.Downloaded)
                             workInfo.outputData.getString(mobileMapPackagePathKey)?.let { path ->
                                 // using the pending path, move the result to final destination path
-                                val destDir = movePreplannedJobResultToDestination(path)
+                                val destDir = movePreplannedJobResultToDestination(context, path)
                                 // create & load the downloaded map
                                 preplannedMapAreaState.createAndLoadMMPKAndOfflineMap(
                                     mobileMapPackagePath = destDir.absolutePath
@@ -409,7 +426,7 @@ public class OfflineRepository(private val context: Context) {
      * @param workerUUID The UUID of the WorkManager request to cancel.
      * @since 200.8.0
      */
-    internal fun cancelWorkRequest(workerUUID: UUID) {
-        workManager.cancelWorkById(workerUUID)
+    internal fun cancelWorkRequest(context: Context, workerUUID: UUID) {
+        WorkManager.getInstance(context).cancelWorkById(workerUUID)
     }
 }

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreas.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreas.kt
@@ -36,7 +36,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BrokenImage
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.ImageNotSupported
 import androidx.compose.material3.Button

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
@@ -18,6 +18,7 @@
 
 package com.arcgismaps.toolkit.offline.preplanned
 
+import android.content.Context
 import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
@@ -51,10 +52,10 @@ import java.util.UUID
  * @since 200.8.0
  */
 internal class PreplannedMapAreaState(
+    private val context: Context,
     internal val preplannedMapArea: PreplannedMapArea,
     private val offlineMapTask: OfflineMapTask,
     private val portalItem: PortalItem,
-    private val offlineRepository: OfflineRepository,
     private val onSelectionChanged: (ArcGISMap) -> Unit
 ) {
     private lateinit var workerUUID: UUID
@@ -66,7 +67,7 @@ internal class PreplannedMapAreaState(
     private var _isSelectedToOpen by mutableStateOf(false)
     internal val isSelectedToOpen: Boolean
         get() = _isSelectedToOpen
-    
+
     // The status of the preplanned map area.
     private var _status by mutableStateOf<Status>(Status.NotLoaded)
     internal val status: Status
@@ -125,7 +126,8 @@ internal class PreplannedMapAreaState(
                     preplannedMapArea = preplannedMapArea
                 )
             )
-            offlineRepository.observeStatusForPreplannedWork(
+            OfflineRepository.observeStatusForPreplannedWork(
+                context = context,
                 onWorkInfoStateChanged = ::logWorkInfo,
                 preplannedMapAreaState = this@PreplannedMapAreaState,
                 portalItem = portalItem,
@@ -172,7 +174,8 @@ internal class PreplannedMapAreaState(
         }
 
         // Define the path where the map will be saved
-        val preplannedMapAreaDownloadDirectory = offlineRepository.createPendingPreplannedJobPath(
+        val preplannedMapAreaDownloadDirectory = OfflineRepository.createPendingPreplannedJobPath(
+            context = context,
             portalItemID = portalItem.itemId,
             preplannedMapAreaID = preplannedMapArea.portalItem.itemId
         )
@@ -199,12 +202,13 @@ internal class PreplannedMapAreaState(
      * @since 200.8.0
      */
     private fun startOfflineMapJob(downloadPreplannedOfflineMapJob: DownloadPreplannedOfflineMapJob): UUID {
-        val jsonJobFile = offlineRepository.saveJobToDisk(
+        val jsonJobFile = OfflineRepository.saveJobToDisk(
             jobPath = downloadPreplannedOfflineMapJob.downloadDirectoryPath,
             jobJson = downloadPreplannedOfflineMapJob.toJson()
         )
 
-        workerUUID = offlineRepository.createPreplannedMapAreaRequestAndQueueDownload(
+        workerUUID = OfflineRepository.createPreplannedMapAreaRequestAndQueueDownload(
+            context = context,
             jsonJobPath = jsonJobFile.path,
             preplannedMapAreaTitle = preplannedMapArea.portalItem.title
         )
@@ -224,12 +228,13 @@ internal class PreplannedMapAreaState(
      * @since 200.8.0
      */
     internal fun removeDownloadedMapArea(shouldRemoveOfflineMapInfo: () -> Boolean) {
-        if (offlineRepository.deleteContentsForDirectory(mobileMapPackage.path)) {
+        if (OfflineRepository.deleteContentsForDirectory(context = context, mobileMapPackage.path)) {
             Log.d(TAG, "Deleted preplanned map area: ${mobileMapPackage.path}")
             // Reset the status to reflect the deletion
             _status = Status.NotLoaded
             if (shouldRemoveOfflineMapInfo()) {
-                offlineRepository.removeOfflineMapInfo(
+                OfflineRepository.removeOfflineMapInfo(
+                    context = context,
                     portalItemID = portalItem.itemId
                 )
             }
@@ -259,7 +264,7 @@ internal class PreplannedMapAreaState(
     }
 
     internal fun cancelDownload() {
-        offlineRepository.cancelWorkRequest(workerUUID)
+        OfflineRepository.cancelWorkRequest(context = context, workerUUID)
     }
 
     internal suspend fun createAndLoadMMPKAndOfflineMap(

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
@@ -228,7 +228,7 @@ internal class PreplannedMapAreaState(
      * @since 200.8.0
      */
     internal fun removeDownloadedMapArea(shouldRemoveOfflineMapInfo: () -> Boolean) {
-        if (OfflineRepository.deleteContentsForDirectory(context = context, mobileMapPackage.path)) {
+        if (OfflineRepository.deleteContentsForDirectory(context, mobileMapPackage.path)) {
             Log.d(TAG, "Deleted preplanned map area: ${mobileMapPackage.path}")
             // Reset the status to reflect the deletion
             _status = Status.NotLoaded
@@ -264,7 +264,7 @@ internal class PreplannedMapAreaState(
     }
 
     internal fun cancelDownload() {
-        OfflineRepository.cancelWorkRequest(context = context, workerUUID)
+        OfflineRepository.cancelWorkRequest(context, workerUUID)
     }
 
     internal suspend fun createAndLoadMMPKAndOfflineMap(


### PR DESCRIPTION
…ce of OfflineMapInfos to work as a SnapShotStateList

<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5993

<!-- link to design, if applicable -->

### Description:

With having OfflineRepository as a class the user can create an instance of it and can access the offlineMapInfos from the disk via the OfflineInfos list, but it is not the same instance of the list used by the component. So when the list is changed by the component user does not get notified as they are observing a different instant of the list that does not change.

### Summary of changes:

- Make OfflineRepository a singleton
- Pass context to each fun that needs it
- Add public fun refreshOfflineMapInfos(context: Context)

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/742/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  