### PR TITLE
Support map areas various fail reasons and errors

### DIFF
--- a/toolkit/offline/api/offline.api
+++ b/toolkit/offline/api/offline.api
@@ -79,3 +79,23 @@ public final class com/arcgismaps/toolkit/offline/OfflineRepository {
 	public final fun removeDownloadsForWebmap (Landroid/content/Context;Lcom/arcgismaps/toolkit/offline/OfflineMapInfo;)V
 }
 
+public final class com/arcgismaps/toolkit/offline/ui/ComposableSingletons$OfflineMapAreasStatusScreenKt {
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/offline/ui/ComposableSingletons$OfflineMapAreasStatusScreenKt;
+	public fun <init> ()V
+	public final fun getLambda$-1094547781$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1287580256$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1445843172$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1698195191$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1787592928$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1876134971$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-520693156$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-686159615$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-887752594$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1824889706$offline_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1944045702$offline_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$227649284$offline_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$299921591$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$57279093$offline_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$77200048$offline_release ()Lkotlin/jvm/functions/Function2;
+}
+

--- a/toolkit/offline/api/offline.api
+++ b/toolkit/offline/api/offline.api
@@ -79,23 +79,3 @@ public final class com/arcgismaps/toolkit/offline/OfflineRepository {
 	public final fun removeDownloadsForWebmap (Landroid/content/Context;Lcom/arcgismaps/toolkit/offline/OfflineMapInfo;)V
 }
 
-public final class com/arcgismaps/toolkit/offline/ui/ComposableSingletons$OfflineMapAreasStatusScreenKt {
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/offline/ui/ComposableSingletons$OfflineMapAreasStatusScreenKt;
-	public fun <init> ()V
-	public final fun getLambda$-1094547781$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1287580256$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1445843172$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1698195191$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1787592928$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1876134971$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-520693156$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-686159615$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-887752594$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1824889706$offline_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1944045702$offline_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$227649284$offline_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$299921591$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$57279093$offline_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$77200048$offline_release ()Lkotlin/jvm/functions/Function2;
-}
-

--- a/toolkit/offline/build.gradle.kts
+++ b/toolkit/offline/build.gradle.kts
@@ -84,7 +84,8 @@ apiValidation {
     // this may be resolved in the compose compiler.
      val composableSingletons = listOf(
              "com.arcgismaps.toolkit.offline.preplanned.ComposableSingletons\$PreplannedMapAreasKt",
-             "com.arcgismaps.toolkit.offline.ui.ComposableSingletons\$MapAreaDetailsScreenKt"
+             "com.arcgismaps.toolkit.offline.ui.ComposableSingletons\$MapAreaDetailsScreenKt",
+             "com.arcgismaps.toolkit.offline.ui.ComposableSingletons\$OfflineMapAreasStatusScreenKt",
      )
      ignoredClasses.addAll(composableSingletons)
 }

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapAreas.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapAreas.kt
@@ -100,7 +100,9 @@ public fun OfflineMapAreas(
                                     modifier = modifier
                                 )
                                 if (offlineMapState.isShowingOnlyOfflineModels) {
-                                    NoInternetNoAreas(onRefresh = { isRefreshEnabled = true })
+                                    NoInternetNoAreas(
+                                        onlyFooterVisible = true,
+                                        onRefresh = { isRefreshEnabled = true })
                                 }
                             }
                         }

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapAreas.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapAreas.kt
@@ -18,19 +18,11 @@
 
 package com.arcgismaps.toolkit.offline
 
-import android.util.Log
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -40,8 +32,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.offline.preplanned.PreplannedMapAreas
 import com.arcgismaps.toolkit.offline.ui.EmptyOnDemandOfflineAreas
 import com.arcgismaps.toolkit.offline.ui.EmptyPreplannedOfflineAreas

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapAreas.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapAreas.kt
@@ -43,8 +43,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.offline.preplanned.PreplannedMapAreas
+import com.arcgismaps.toolkit.offline.ui.EmptyOnDemandOfflineAreas
+import com.arcgismaps.toolkit.offline.ui.EmptyPreplannedOfflineAreas
 import com.arcgismaps.toolkit.offline.ui.NoInternetNoAreas
 import com.arcgismaps.toolkit.offline.ui.OfflineDisabled
+import com.arcgismaps.toolkit.offline.ui.OfflineMapAreasError
 
 /**
  * Take a web map offline by downloading map areas.
@@ -82,9 +85,9 @@ public fun OfflineMapAreas(
             }
 
             is InitializationStatus.FailedToInitialize -> {
-                NonRecoveredErrorIndicator(
-                    error = (initializationStatus as InitializationStatus.FailedToInitialize).error,
-                    onRefresh = { isRefreshEnabled = true }
+                OfflineMapAreasError(
+                    onRefresh = { isRefreshEnabled = true },
+                    error = (initializationStatus as InitializationStatus.FailedToInitialize).error
                 )
             }
 
@@ -101,34 +104,24 @@ public fun OfflineMapAreas(
                                 )
                                 if (offlineMapState.isShowingOnlyOfflineModels) {
                                     NoInternetNoAreas(
-                                        onlyFooterVisible = true,
-                                        onRefresh = { isRefreshEnabled = true })
+                                        onlyFooterVisible = offlineMapState.preplannedMapAreaStates.isNotEmpty(),
+                                        onRefresh = { isRefreshEnabled = true }
+                                    )
+                                } else if (offlineMapState.preplannedMapAreaStates.isEmpty()){
+                                    EmptyPreplannedOfflineAreas(onRefresh = { isRefreshEnabled = true })
                                 }
                             }
                         }
 
                         OfflineMapMode.OnDemand, OfflineMapMode.Unknown -> {
                             // TODO: Init OnDemand screen...
+                            EmptyOnDemandOfflineAreas(onAdd = {
+                                // TODO: Add new on demand map area
+                            })
                         }
                     }
                 }
             }
         }
-    }
-}
-
-
-@Composable
-private fun NonRecoveredErrorIndicator(error: Throwable, onRefresh: () -> Unit) {
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        Icon(
-            Icons.Default.Info,
-            contentDescription = stringResource(id = R.string.error),
-            tint = MaterialTheme.colorScheme.error
-        )
-        Text(
-            text = error.message.toString(),
-            color = MaterialTheme.colorScheme.error
-        )
     }
 }

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapAreas.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapAreas.kt
@@ -67,9 +67,7 @@ public fun OfflineMapAreas(
         if (isRefreshEnabled) {
             offlineMapState.resetInitialize()
         }
-        offlineMapState.initialize(context).onFailure {
-            Log.e("TAG", it.stackTraceToString())
-        }
+        offlineMapState.initialize(context)
         isRefreshEnabled = false
     }
 
@@ -92,10 +90,13 @@ public fun OfflineMapAreas(
             }
 
             is InitializationStatus.Initialized -> {
+                // Check if the map has offline mode disabled
                 if (offlineMapState.mapIsOfflineDisabled) {
                     OfflineDisabled(onRefresh = { isRefreshEnabled = true })
                 } else {
+                    // If offline mode is enabled, display the offline modes
                     when (offlineMapState.mode) {
+                        // For preplanned, display online & offline map areas.
                         OfflineMapMode.Preplanned -> {
                             Column {
                                 PreplannedMapAreas(
@@ -112,7 +113,7 @@ public fun OfflineMapAreas(
                                 }
                             }
                         }
-
+                        // If not preplanned state & map has offline mode enabled, display the on demand areas
                         OfflineMapMode.OnDemand, OfflineMapMode.Unknown -> {
                             // TODO: Init OnDemand screen...
                             EmptyOnDemandOfflineAreas(onAdd = {

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -114,7 +114,7 @@ public class OfflineMapState(
         _initializationStatus.value = InitializationStatus.Initializing
         // initialize the offline repository
         OfflineRepository.refreshOfflineMapInfos(context)
-        // check if the arcgis map can load
+        // reset to check if map has offline enabled
         isShowingOnlyOfflineModels = false
         // load the map, and ignore network error if device is offline
         arcGISMap.retryLoad().getOrElse { error ->
@@ -159,6 +159,9 @@ public class OfflineMapState(
     }
 
     /**
+     * Loads preplanned map areas from the [portalItem], initializes their [preplannedMapAreaStates],
+     * and updates download status. If no online areas are available or “offline-only” mode is enabled,
+     * falls back [loadOfflinePreplannedMapAreas].
      *
      * @since 200.8.0
      */
@@ -206,8 +209,10 @@ public class OfflineMapState(
     }
 
     /**
-     * Loads the offline preplanned map models with information from the downloaded mobile map
-     * packages for the online map.
+     * Scans the local preplanned directory for downloaded maps and creates [PreplannedMapAreaState]s.
+     * Sets the [OfflineMapMode.Preplanned] when any local areas are found.
+     *
+     * @since 200.8.0
      */
     private suspend fun loadOfflinePreplannedMapAreas(context: Context) {
         val preplannedDirectory = File(
@@ -225,6 +230,13 @@ public class OfflineMapState(
         }
     }
 
+    /**
+     * Attempts to create a [PreplannedMapAreaState] for a given area ID by loading
+     * its [MobileMapPackage] from disk. Returns null if the directory is missing
+     * or the package fails to load; otherwise initializes status and map.
+     *
+     * @since 200.8.0
+     */
     private suspend fun makeOfflinePreplannedMapAreaState(
         context: Context,
         areaItemId: String

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -19,18 +19,27 @@
 package com.arcgismaps.toolkit.offline
 
 import android.content.Context
+import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import com.arcgismaps.LoadStatus
 import com.arcgismaps.mapping.ArcGISMap
+import com.arcgismaps.mapping.MobileMapPackage
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.tasks.offlinemaptask.OfflineMapTask
+import com.arcgismaps.tasks.offlinemaptask.PreplannedMapArea
 import com.arcgismaps.toolkit.offline.preplanned.PreplannedMapAreaState
 import com.arcgismaps.toolkit.offline.preplanned.Status
+import com.arcgismaps.toolkit.offline.ui.NoInternetNoAreas
+import com.arcgismaps.toolkit.offline.workmanager.OfflineURLs
 import kotlinx.coroutines.CancellationException
+import java.io.File
 
 /**
  * Represents the state of the offline map.
@@ -81,6 +90,22 @@ public class OfflineMapState(
     public val initializationStatus: State<InitializationStatus> = _initializationStatus
 
     /**
+     * A Boolean value indicating if only offline models are being shown.
+     *
+     * @since 200.8.0
+     */
+    internal var isShowingOnlyOfflineModels by mutableStateOf(false)
+        private set
+
+    /**
+     * A Boolean value indicating whether the web map is offline disabled.
+     *
+     * @since 200.8.0
+     */
+    internal var mapIsOfflineDisabled by mutableStateOf(false)
+        private set
+
+    /**
      * Initializes the state object by loading the map, creating and loading the offline map task.
      *
      * @return the [Result] indicating if the initialization was successful or not
@@ -91,48 +116,132 @@ public class OfflineMapState(
             return Result.success(Unit)
         }
         _initializationStatus.value = InitializationStatus.Initializing
-        arcGISMap.load().getOrElse {
-            _initializationStatus.value = InitializationStatus.FailedToInitialize(it)
-            throw it
+        // initialize the offline repository
+        _offlineRepository = OfflineRepository(context)
+        // check if the arcgis map can load
+        isShowingOnlyOfflineModels = false
+        // load the map, and ignore network error if device is offline
+        arcGISMap.load().getOrElse { error ->
+            // check if the error is due to network connection
+            if (error.message?.contains("Unable to resolve host") == true) {
+                // enable offline only mode
+                isShowingOnlyOfflineModels = true
+            } else {
+                // unexpected error, report failed status
+                _initializationStatus.value = InitializationStatus.FailedToInitialize(error)
+                throw error
+            }
         }
 
-        _offlineRepository = OfflineRepository(context)
         offlineMapTask = OfflineMapTask(arcGISMap)
         portalItem = (arcGISMap.item as? PortalItem)
             ?: throw IllegalStateException("Item not found")
 
-        offlineMapTask.load().getOrElse {
-            _initializationStatus.value = InitializationStatus.FailedToInitialize(it)
-            throw it
+        // load the task, and ignore network error if device is offline
+        offlineMapTask.load().getOrElse { error ->
+            // check if the error is not due to network connection
+            if (error.message?.contains("Unable to resolve host") == false) {
+                // unexpected error, report failed status
+                _initializationStatus.value = InitializationStatus.FailedToInitialize(error)
+                throw error
+            }
         }
-        val preplannedMapAreas = offlineMapTask.getPreplannedMapAreas().getOrNull()
-        preplannedMapAreas?.let { preplannedMapArea ->
-            _mode = OfflineMapMode.Preplanned
-            preplannedMapArea
-                .sortedBy { it.portalItem.title }
-                .forEach { mapArea ->
-                    val preplannedMapAreaState = PreplannedMapAreaState(
-                        preplannedMapArea = mapArea,
-                        offlineMapTask = offlineMapTask,
-                        portalItem = portalItem,
-                        offlineRepository = _offlineRepository,
-                        onSelectionChanged = onSelectionChanged
-                    )
-                    preplannedMapAreaState.initialize()
-                    val preplannedPath = _offlineRepository.isPrePlannedAreaDownloaded(
-                        portalItemID = portalItem.itemId,
-                        preplannedMapAreaID = mapArea.portalItem.itemId
-                    )
-                    if (preplannedPath != null) {
-                        preplannedMapAreaState.updateStatus(Status.Downloaded)
-                        preplannedMapAreaState.createAndLoadMMPKAndOfflineMap(
-                            mobileMapPackagePath = preplannedPath
-                        )
-                    }
-                    _preplannedMapAreaStates.add(preplannedMapAreaState)
-                }
+
+        // determine if offline is disabled for the map
+        mapIsOfflineDisabled =
+            (arcGISMap.loadStatus.value == LoadStatus.Loaded) && (arcGISMap.offlineSettings == null)
+
+        // load the preplanned map area states
+        loadPreplannedMapAreas(context)
+
+        // check if preplanned for loaded
+        if (_mode != OfflineMapMode.Preplanned || _mode == OfflineMapMode.Unknown) {
+            // TODO: Load OnDemandMapAresState
+            if (_mode == OfflineMapMode.Unknown)
+                _mode = OfflineMapMode.OnDemand
         }
         _initializationStatus.value = InitializationStatus.Initialized
+    }
+
+    /**
+     *
+     * @since 200.8.0
+     */
+    private suspend fun loadPreplannedMapAreas(context: Context) {
+        _mode = OfflineMapMode.Preplanned
+        val preplannedMapAreas = mutableListOf<PreplannedMapArea>()
+        try {
+            preplannedMapAreas.addAll(
+                elements = offlineMapTask.getPreplannedMapAreas().getOrNull() ?: emptyList()
+            )
+        } catch (e: Exception) {
+            preplannedMapAreas.clear()
+        }
+        if (isShowingOnlyOfflineModels || preplannedMapAreas.isEmpty()) {
+            loadOfflinePreplannedMapAreas(context = context)
+        } else {
+            preplannedMapAreas.let { preplannedMapArea ->
+                preplannedMapArea
+                    .sortedBy { it.portalItem.title }
+                    .forEach { mapArea ->
+                        val preplannedMapAreaState = PreplannedMapAreaState(
+                            preplannedMapArea = mapArea,
+                            offlineMapTask = offlineMapTask,
+                            portalItem = portalItem,
+                            offlineRepository = _offlineRepository,
+                            onSelectionChanged = onSelectionChanged
+                        )
+                        preplannedMapAreaState.initialize()
+                        val preplannedPath = _offlineRepository.isPrePlannedAreaDownloaded(
+                            portalItemID = portalItem.itemId,
+                            preplannedMapAreaID = mapArea.portalItem.itemId
+                        )
+                        if (preplannedPath != null) {
+                            preplannedMapAreaState.updateStatus(Status.Downloaded)
+                            preplannedMapAreaState.createAndLoadMMPKAndOfflineMap(
+                                mobileMapPackagePath = preplannedPath
+                            )
+                        }
+                        _preplannedMapAreaStates.add(preplannedMapAreaState)
+                    }
+            }
+        }
+    }
+
+    /**
+     * Loads the offline preplanned map models with information from the downloaded mobile map
+     * packages for the online map.
+     */
+    private fun loadOfflinePreplannedMapAreas(context: Context) {
+        val preplannedDirectory = File(
+            OfflineURLs.prePlannedDirectoryPath(context, portalItem.itemId)
+        )
+        val preplannedMapAreaItemIds = preplannedDirectory.listFiles()?.map { it.name.toString() }
+            ?: emptyList()
+        preplannedMapAreaItemIds.forEach { itemId ->
+            // TODO
+        }
+
+
+    }
+
+    private suspend fun makeOfflinePreplannedMapAreaState(
+        context: Context,
+        areaItemId: String
+    ): PreplannedMapAreaState? {
+        val areaDir = File(
+            OfflineURLs.prePlannedDirectoryPath(
+                context = context,
+                portalItemID = portalItem.itemId,
+                preplannedMapAreaID = areaItemId
+            )
+        )
+
+        if (!areaDir.exists() || !areaDir.isDirectory) return null
+        val mmpk = MobileMapPackage(areaDir.absolutePath)
+        val loadResult = mmpk.load().getOrNull() ?: return null
+        val item = mmpk.item ?: return null
+        return null
     }
 
     /**
@@ -142,6 +251,15 @@ public class OfflineMapState(
      */
     public fun resetSelectedMapArea() {
         _preplannedMapAreaStates.forEach { it.setSelectedToOpen(false) }
+    }
+
+    /**
+     * Support to refresh & re-initialize the offline map area state.
+     *
+     * @since 200.8.0
+     */
+    internal fun resetInitialize() {
+        _initializationStatus.value = InitializationStatus.NotInitialized
     }
 }
 

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -117,7 +117,7 @@ public class OfflineMapState(
         // check if the arcgis map can load
         isShowingOnlyOfflineModels = false
         // load the map, and ignore network error if device is offline
-        arcGISMap.load().getOrElse { error ->
+        arcGISMap.retryLoad().getOrElse { error ->
             // check if the error is due to network connection
             if (error.message?.contains("Unable to resolve host") == true) {
                 // enable offline only mode
@@ -133,7 +133,7 @@ public class OfflineMapState(
             ?: throw IllegalStateException("Item not found")
 
         // load the task, and ignore network error if device is offline
-        offlineMapTask.load().getOrElse { error ->
+        offlineMapTask.retryLoad().getOrElse { error ->
             // check if the error is not due to network connection
             if (error.message?.contains("Unable to resolve host") == false) {
                 // unexpected error, report failed status
@@ -164,6 +164,7 @@ public class OfflineMapState(
      */
     private suspend fun loadPreplannedMapAreas(context: Context) {
         _mode = OfflineMapMode.Preplanned
+        _preplannedMapAreaStates.clear()
         val preplannedMapAreas = mutableListOf<PreplannedMapArea>()
         try {
             preplannedMapAreas.addAll(

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -163,7 +163,6 @@ public class OfflineMapState(
      * @since 200.8.0
      */
     private suspend fun loadPreplannedMapAreas(context: Context) {
-        _mode = OfflineMapMode.Preplanned
         _preplannedMapAreaStates.clear()
         val preplannedMapAreas = mutableListOf<PreplannedMapArea>()
         try {
@@ -176,6 +175,7 @@ public class OfflineMapState(
         if (isShowingOnlyOfflineModels || preplannedMapAreas.isEmpty()) {
             loadOfflinePreplannedMapAreas(context = context)
         } else {
+            _mode = OfflineMapMode.Preplanned
             preplannedMapAreas.let { preplannedMapArea ->
                 preplannedMapArea
                     .sortedBy { it.portalItem.title }
@@ -215,6 +215,10 @@ public class OfflineMapState(
         )
         val preplannedMapAreaItemIds = preplannedDirectory.listFiles()?.map { it.name.toString() }
             ?: emptyList()
+
+        if (preplannedMapAreaItemIds.isNotEmpty())
+            _mode = OfflineMapMode.Preplanned
+
         preplannedMapAreaItemIds.forEach { itemId ->
             makeOfflinePreplannedMapAreaState(context, itemId)
                 ?.let { _preplannedMapAreaStates.add(it) }

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -269,8 +269,9 @@ public class OfflineMapState(
             preplannedMapAreaState.createAndLoadMMPKAndOfflineMap(
                 mobileMapPackagePath = preplannedPath
             )
-        }
-        return preplannedMapAreaState
+            return preplannedMapAreaState
+        } else
+            return null
     }
 
     /**

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -119,7 +119,7 @@ public class OfflineMapState(
         // load the map, and ignore network error if device is offline
         arcGISMap.retryLoad().getOrElse { error ->
             // check if the error is due to network connection
-            if (error.message?.contains("Unable to resolve host") == false) {
+            if (error.message?.contains("Unable to resolve host") == true) {
                 // enable offline only mode
                 isShowingOnlyOfflineModels = true
             } else {

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -119,7 +119,7 @@ public class OfflineMapState(
         // load the map, and ignore network error if device is offline
         arcGISMap.retryLoad().getOrElse { error ->
             // check if the error is due to network connection
-            if (error.message?.contains("Unable to resolve host") == true) {
+            if (error.message?.contains("Unable to resolve host") == false) {
                 // enable offline only mode
                 isShowingOnlyOfflineModels = true
             } else {

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -22,15 +22,22 @@ import android.content.Context
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import com.arcgismaps.LoadStatus
 import com.arcgismaps.mapping.ArcGISMap
+import com.arcgismaps.mapping.MobileMapPackage
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.tasks.offlinemaptask.OfflineMapTask
+import com.arcgismaps.tasks.offlinemaptask.PreplannedMapArea
 import com.arcgismaps.toolkit.offline.preplanned.PreplannedMapAreaState
 import com.arcgismaps.toolkit.offline.preplanned.Status
+import com.arcgismaps.toolkit.offline.workmanager.OfflineURLs
 import kotlinx.coroutines.CancellationException
+import java.io.File
 
 /**
  * Represents the state of the offline map.
@@ -79,6 +86,22 @@ public class OfflineMapState(
     public val initializationStatus: State<InitializationStatus> = _initializationStatus
 
     /**
+     * A Boolean value indicating if only offline models are being shown.
+     *
+     * @since 200.8.0
+     */
+    internal var isShowingOnlyOfflineModels by mutableStateOf(false)
+        private set
+
+    /**
+     * A Boolean value indicating whether the web map is offline disabled.
+     *
+     * @since 200.8.0
+     */
+    internal var mapIsOfflineDisabled by mutableStateOf(false)
+        private set
+
+    /**
      * Initializes the state object by loading the map, creating and loading the offline map task.
      *
      * @return the [Result] indicating if the initialization was successful or not
@@ -89,49 +112,148 @@ public class OfflineMapState(
             return Result.success(Unit)
         }
         _initializationStatus.value = InitializationStatus.Initializing
-        arcGISMap.load().getOrElse {
-            _initializationStatus.value = InitializationStatus.FailedToInitialize(it)
-            throw it
-        }
-
+        // initialize the offline repository
         OfflineRepository.refreshOfflineMapInfos(context)
+        // check if the arcgis map can load
+        isShowingOnlyOfflineModels = false
+        // load the map, and ignore network error if device is offline
+        arcGISMap.load().getOrElse { error ->
+            // check if the error is due to network connection
+            if (error.message?.contains("Unable to resolve host") == true) {
+                // enable offline only mode
+                isShowingOnlyOfflineModels = true
+            } else {
+                // unexpected error, report failed status
+                _initializationStatus.value = InitializationStatus.FailedToInitialize(error)
+                throw error
+            }
+        }
         offlineMapTask = OfflineMapTask(arcGISMap)
         portalItem = (arcGISMap.item as? PortalItem)
             ?: throw IllegalStateException("Item not found")
 
-        offlineMapTask.load().getOrElse {
-            _initializationStatus.value = InitializationStatus.FailedToInitialize(it)
-            throw it
+        // load the task, and ignore network error if device is offline
+        offlineMapTask.load().getOrElse { error ->
+            // check if the error is not due to network connection
+            if (error.message?.contains("Unable to resolve host") == false) {
+                // unexpected error, report failed status
+                _initializationStatus.value = InitializationStatus.FailedToInitialize(error)
+                throw error
+            }
         }
-        val preplannedMapAreas = offlineMapTask.getPreplannedMapAreas().getOrNull()
-        preplannedMapAreas?.let { preplannedMapArea ->
-            _mode = OfflineMapMode.Preplanned
-            preplannedMapArea
-                .sortedBy { it.portalItem.title }
-                .forEach { mapArea ->
-                    val preplannedMapAreaState = PreplannedMapAreaState(
-                        context = context,
-                        preplannedMapArea = mapArea,
-                        offlineMapTask = offlineMapTask,
-                        portalItem = portalItem,
-                        onSelectionChanged = onSelectionChanged
-                    )
-                    preplannedMapAreaState.initialize()
-                    val preplannedPath = OfflineRepository.isPrePlannedAreaDownloaded(
-                        context = context,
-                        portalItemID = portalItem.itemId,
-                        preplannedMapAreaID = mapArea.portalItem.itemId
-                    )
-                    if (preplannedPath != null) {
-                        preplannedMapAreaState.updateStatus(Status.Downloaded)
-                        preplannedMapAreaState.createAndLoadMMPKAndOfflineMap(
-                            mobileMapPackagePath = preplannedPath
-                        )
-                    }
-                    _preplannedMapAreaStates.add(preplannedMapAreaState)
-                }
+
+        // determine if offline is disabled for the map
+        mapIsOfflineDisabled =
+            (arcGISMap.loadStatus.value == LoadStatus.Loaded) && (arcGISMap.offlineSettings == null)
+
+        // load the preplanned map area states
+        loadPreplannedMapAreas(context)
+
+        // check if preplanned for loaded
+        if (_mode != OfflineMapMode.Preplanned || _mode == OfflineMapMode.Unknown) {
+            // TODO: Load OnDemandMapAresState
+            if (_mode == OfflineMapMode.Unknown)
+                _mode = OfflineMapMode.OnDemand
         }
         _initializationStatus.value = InitializationStatus.Initialized
+    }
+
+    /**
+     *
+     * @since 200.8.0
+     */
+    private suspend fun loadPreplannedMapAreas(context: Context) {
+        _mode = OfflineMapMode.Preplanned
+        val preplannedMapAreas = mutableListOf<PreplannedMapArea>()
+        try {
+            preplannedMapAreas.addAll(
+                elements = offlineMapTask.getPreplannedMapAreas().getOrNull() ?: emptyList()
+            )
+        } catch (e: Exception) {
+            preplannedMapAreas.clear()
+        }
+        if (isShowingOnlyOfflineModels || preplannedMapAreas.isEmpty()) {
+            loadOfflinePreplannedMapAreas(context = context)
+        } else {
+            preplannedMapAreas.let { preplannedMapArea ->
+                preplannedMapArea
+                    .sortedBy { it.portalItem.title }
+                    .forEach { mapArea ->
+                        val preplannedMapAreaState = PreplannedMapAreaState(
+                            context = context,
+                            preplannedMapArea = mapArea,
+                            offlineMapTask = offlineMapTask,
+                            item = portalItem,
+                            onSelectionChanged = onSelectionChanged
+                        )
+                        preplannedMapAreaState.initialize()
+                        val preplannedPath = OfflineRepository.isPrePlannedAreaDownloaded(
+                            context = context,
+                            portalItemID = portalItem.itemId,
+                            preplannedMapAreaID = mapArea.portalItem.itemId
+                        )
+                        if (preplannedPath != null) {
+                            preplannedMapAreaState.updateStatus(Status.Downloaded)
+                            preplannedMapAreaState.createAndLoadMMPKAndOfflineMap(
+                                mobileMapPackagePath = preplannedPath
+                            )
+                        }
+                        _preplannedMapAreaStates.add(preplannedMapAreaState)
+                    }
+            }
+        }
+    }
+
+    /**
+     * Loads the offline preplanned map models with information from the downloaded mobile map
+     * packages for the online map.
+     */
+    private suspend fun loadOfflinePreplannedMapAreas(context: Context) {
+        val preplannedDirectory = File(
+            OfflineURLs.prePlannedDirectoryPath(context, portalItem.itemId)
+        )
+        val preplannedMapAreaItemIds = preplannedDirectory.listFiles()?.map { it.name.toString() }
+            ?: emptyList()
+        preplannedMapAreaItemIds.forEach { itemId ->
+            makeOfflinePreplannedMapAreaState(context, itemId)
+                ?.let { _preplannedMapAreaStates.add(it) }
+        }
+    }
+
+    private suspend fun makeOfflinePreplannedMapAreaState(
+        context: Context,
+        areaItemId: String
+    ): PreplannedMapAreaState? {
+        val areaDir = File(
+            OfflineURLs.prePlannedDirectoryPath(
+                context = context,
+                portalItemID = portalItem.itemId,
+                preplannedMapAreaID = areaItemId
+            )
+        )
+        if (!areaDir.exists() || !areaDir.isDirectory) return null
+        val mmpk = MobileMapPackage(areaDir.absolutePath).apply {
+            load().getOrElse { return null }
+        }
+        val item = mmpk.item ?: return null
+
+        val preplannedMapAreaState = PreplannedMapAreaState(
+            context = context,
+            item = item,
+            onSelectionChanged = onSelectionChanged
+        )
+        val preplannedPath = OfflineRepository.isPrePlannedAreaDownloaded(
+            context = context,
+            portalItemID = portalItem.itemId,
+            preplannedMapAreaID = areaItemId
+        )
+        if (preplannedPath != null) {
+            preplannedMapAreaState.updateStatus(Status.Downloaded)
+            preplannedMapAreaState.createAndLoadMMPKAndOfflineMap(
+                mobileMapPackagePath = preplannedPath
+            )
+        }
+        return preplannedMapAreaState
     }
 
     /**
@@ -141,6 +263,15 @@ public class OfflineMapState(
      */
     public fun resetSelectedMapArea() {
         _preplannedMapAreaStates.forEach { it.setSelectedToOpen(false) }
+    }
+
+    /**
+     * Support to refresh & re-initialize the offline map area state.
+     *
+     * @since 200.8.0
+     */
+    internal fun resetInitialize() {
+        _initializationStatus.value = InitializationStatus.NotInitialized
     }
 }
 

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreas.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreas.kt
@@ -100,7 +100,7 @@ internal fun PreplannedMapAreas(
             sheetState = sheetState,
             scope = scope,
             onDismiss = { showSheet = false },
-            thumbnail = selectedPreplannedMapAreaState.thumbnail?.image?.bitmap?.asImageBitmap(),
+            thumbnail = selectedPreplannedMapAreaState.thumbnail?.asImageBitmap(),
             title = selectedPreplannedMapAreaState.title,
             description = selectedPreplannedMapAreaState.description,
             size = selectedPreplannedMapAreaState.directorySize,
@@ -143,7 +143,7 @@ internal fun PreplannedMapAreas(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     // Display the thumbnail image if available, otherwise show a placeholder icon
-                    val thumbnail = state.thumbnail?.image?.bitmap?.asImageBitmap()
+                    val thumbnail = state.thumbnail?.asImageBitmap()
                     Box(
                         modifier = Modifier
                             .padding(vertical = 8.dp)

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreas.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreas.kt
@@ -100,9 +100,9 @@ internal fun PreplannedMapAreas(
             sheetState = sheetState,
             scope = scope,
             onDismiss = { showSheet = false },
-            thumbnail = selectedPreplannedMapAreaState.preplannedMapArea.portalItem.thumbnail?.image?.bitmap?.asImageBitmap(), /* your default image */
-            title = selectedPreplannedMapAreaState.preplannedMapArea.portalItem.title,
-            description = selectedPreplannedMapAreaState.preplannedMapArea.portalItem.description,
+            thumbnail = selectedPreplannedMapAreaState.thumbnail?.image?.bitmap?.asImageBitmap(),
+            title = selectedPreplannedMapAreaState.title,
+            description = selectedPreplannedMapAreaState.description,
             size = selectedPreplannedMapAreaState.directorySize,
             isAvailableToDownload = selectedPreplannedMapAreaState.status.allowsDownload,
             onStartDownload = {
@@ -143,7 +143,7 @@ internal fun PreplannedMapAreas(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     // Display the thumbnail image if available, otherwise show a placeholder icon
-                    val thumbnail = state.preplannedMapArea.portalItem.thumbnail?.image?.bitmap?.asImageBitmap()
+                    val thumbnail = state.thumbnail?.image?.bitmap?.asImageBitmap()
                     Box(
                         modifier = Modifier
                             .padding(vertical = 8.dp)
@@ -171,7 +171,7 @@ internal fun PreplannedMapAreas(
                     Column(modifier = Modifier.weight(1f)) {
                         // Display the title with a maximum of one line
                         Text(
-                            text = state.preplannedMapArea.portalItem.title,
+                            text = state.title,
                             style = MaterialTheme.typography.titleSmall,
                             modifier = Modifier.padding(top = 6.dp),
                             maxLines = 1, // Restrict to one line
@@ -179,7 +179,7 @@ internal fun PreplannedMapAreas(
                         )
                         // Display the description with a maximum of two lines
                         Text(
-                            text = state.preplannedMapArea.portalItem.description,
+                            text = state.description,
                             style = MaterialTheme.typography.bodySmall,
                             maxLines = 2, // Restrict to two lines
                             overflow = TextOverflow.Ellipsis // Add ellipses if the text overflows
@@ -211,11 +211,13 @@ internal fun PreplannedMapAreas(
                                 }
                             }
                         }
+
                         state.status == Status.Downloading -> {
                             CancelDownloadButtonWithProgressIndicator(state.downloadProgress.value) {
                                 state.cancelDownload()
                             }
                         }
+
                         state.status.isDownloaded -> {
                             OpenButton(!state.isSelectedToOpen) {
                                 // Unselect all, then select this one

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
@@ -91,7 +91,7 @@ internal class PreplannedMapAreaState(
     internal val description = item.description
 
     private var _thumbnail by mutableStateOf<Bitmap?>(null)
-    internal val thumbnail: Bitmap? get() = _thumbnail
+    internal val thumbnail: Bitmap? get() = _thumbnail ?: item.thumbnail?.image?.bitmap
 
     /**
      * Loads and initializes the associated preplanned map area.

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
@@ -176,7 +176,7 @@ internal class PreplannedMapAreaState(
      * Defines a directory path where map data will be stored and creates a download job using these configurations.
      *
      * @param preplannedMapArea The target [PreplannedMapArea] to be downloaded offline.
-     *
+     * @param offlineMapTask The target [OfflineMapTask] to create the params & the job.
      * @return An instance of [DownloadPreplannedOfflineMapJob] configured with download parameters.
      *
      * @since 200.8.0

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
@@ -18,6 +18,7 @@
 
 package com.arcgismaps.toolkit.offline.preplanned
 
+import android.graphics.Bitmap
 import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
@@ -29,6 +30,7 @@ import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.MobileMapPackage
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.tasks.offlinemaptask.DownloadPreplannedOfflineMapJob
+import com.arcgismaps.tasks.offlinemaptask.DownloadPreplannedOfflineMapParameters
 import com.arcgismaps.tasks.offlinemaptask.OfflineMapTask
 import com.arcgismaps.tasks.offlinemaptask.PreplannedMapArea
 import com.arcgismaps.tasks.offlinemaptask.PreplannedPackagingStatus
@@ -38,10 +40,12 @@ import com.arcgismaps.toolkit.offline.runCatchingCancellable
 import com.arcgismaps.toolkit.offline.workmanager.LOG_TAG
 import com.arcgismaps.toolkit.offline.OfflineRepository
 import com.arcgismaps.toolkit.offline.workmanager.logWorkInfo
+import com.arcgismaps.toolkit.offline.workmanager.preplannedMapAreas
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.util.UUID
 
@@ -57,6 +61,15 @@ internal class PreplannedMapAreaState(
     private val offlineRepository: OfflineRepository,
     private val onSelectionChanged: (ArcGISMap) -> Unit
 ) {
+
+    internal suspend fun makeParameters(offlineMapTask: OfflineMapTask): DownloadPreplannedOfflineMapParameters? {
+        val params = offlineMapTask.createDefaultDownloadPreplannedOfflineMapParameters(
+            preplannedMapArea = preplannedMapArea
+        ).getOrNull()
+        params?.let { it.updateMode = PreplannedUpdateMode.NoUpdates }
+        return params
+    }
+
     private lateinit var workerUUID: UUID
 
     private lateinit var mobileMapPackage: MobileMapPackage
@@ -66,7 +79,7 @@ internal class PreplannedMapAreaState(
     private var _isSelectedToOpen by mutableStateOf(false)
     internal val isSelectedToOpen: Boolean
         get() = _isSelectedToOpen
-    
+
     // The status of the preplanned map area.
     private var _status by mutableStateOf<Status>(Status.NotLoaded)
     internal val status: Status

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
@@ -26,7 +26,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.arcgismaps.location.LocationDisplayAutoPanMode
 import com.arcgismaps.mapping.ArcGISMap
+import com.arcgismaps.mapping.Item
 import com.arcgismaps.mapping.MobileMapPackage
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.tasks.offlinemaptask.DownloadPreplannedOfflineMapJob
@@ -53,11 +55,12 @@ import java.util.UUID
  */
 internal class PreplannedMapAreaState(
     private val context: Context,
-    internal val preplannedMapArea: PreplannedMapArea,
-    private val offlineMapTask: OfflineMapTask,
-    private val portalItem: PortalItem,
+    private val item: Item,
+    internal val preplannedMapArea: PreplannedMapArea? = null,
+    private val offlineMapTask: OfflineMapTask? = null,
     private val onSelectionChanged: (ArcGISMap) -> Unit
 ) {
+
     private lateinit var workerUUID: UUID
 
     private lateinit var mobileMapPackage: MobileMapPackage
@@ -83,6 +86,10 @@ internal class PreplannedMapAreaState(
 
     private lateinit var scope: CoroutineScope
 
+    internal val title = item.title
+    internal val description = item.description
+    internal val thumbnail = item.thumbnail
+
     /**
      * Loads and initializes the associated preplanned map area.
      *
@@ -96,8 +103,8 @@ internal class PreplannedMapAreaState(
      * @since 200.8.0
      */
     internal suspend fun initialize() = runCatchingCancellable {
-        preplannedMapArea.load()
-            .onSuccess {
+        preplannedMapArea?.load()
+            ?.onSuccess {
                 _status = try {
                     Status.fromPackagingStatus(preplannedMapArea.packagingStatus)
                 } catch (illegalStateException: IllegalStateException) {
@@ -109,7 +116,9 @@ internal class PreplannedMapAreaState(
                 }
                 // Load the thumbnail
                 preplannedMapArea.portalItem.thumbnail?.load()
-            }
+            } ?: {
+            // preplannedMapArea is null.
+        }
     }
 
     /**
@@ -117,24 +126,30 @@ internal class PreplannedMapAreaState(
      *
      * @since 200.8.0
      */
-    internal fun downloadPreplannedMapArea() = runCatchingCancellable {
-        scope = CoroutineScope(Dispatchers.IO)
-        scope.launch {
-            _status = Status.Downloading
-            val offlineWorkerUUID = startOfflineMapJob(
-                downloadPreplannedOfflineMapJob = createOfflineMapJob(
-                    preplannedMapArea = preplannedMapArea
+    internal fun downloadPreplannedMapArea() =
+        runCatchingCancellable {
+            scope = CoroutineScope(Dispatchers.IO)
+            val area = preplannedMapArea ?: return@runCatchingCancellable
+            val task = offlineMapTask ?: return@runCatchingCancellable
+            val portalItem = item as? PortalItem ?: return@runCatchingCancellable
+
+            scope.launch {
+                _status = Status.Downloading
+                val offlineWorkerUUID = startOfflineMapJob(
+                    downloadPreplannedOfflineMapJob = createOfflineMapJob(
+                        preplannedMapArea = area,
+                        offlineMapTask = task
+                    )
                 )
-            )
-            OfflineRepository.observeStatusForPreplannedWork(
-                context = context,
-                onWorkInfoStateChanged = ::logWorkInfo,
-                preplannedMapAreaState = this@PreplannedMapAreaState,
-                portalItem = portalItem,
-                offlineWorkerUUID = offlineWorkerUUID
-            )
+                OfflineRepository.observeStatusForPreplannedWork(
+                    context = context,
+                    onWorkInfoStateChanged = ::logWorkInfo,
+                    preplannedMapAreaState = this@PreplannedMapAreaState,
+                    portalItem = portalItem,
+                    offlineWorkerUUID = offlineWorkerUUID
+                )
+            }
         }
-    }
 
     /**
      * Cancels the current coroutine scope.
@@ -161,7 +176,8 @@ internal class PreplannedMapAreaState(
      * @since 200.8.0
      */
     private suspend fun createOfflineMapJob(
-        preplannedMapArea: PreplannedMapArea
+        preplannedMapArea: PreplannedMapArea,
+        offlineMapTask: OfflineMapTask
     ): DownloadPreplannedOfflineMapJob {
 
         // Create default download parameters from the offline map task
@@ -176,7 +192,7 @@ internal class PreplannedMapAreaState(
         // Define the path where the map will be saved
         val preplannedMapAreaDownloadDirectory = OfflineRepository.createPendingPreplannedJobPath(
             context = context,
-            portalItemID = portalItem.itemId,
+            portalItemID = item.itemId,
             preplannedMapAreaID = preplannedMapArea.portalItem.itemId
         )
 
@@ -210,7 +226,7 @@ internal class PreplannedMapAreaState(
         workerUUID = OfflineRepository.createPreplannedMapAreaRequestAndQueueDownload(
             context = context,
             jsonJobPath = jsonJobFile.path,
-            preplannedMapAreaTitle = preplannedMapArea.portalItem.title
+            preplannedMapAreaTitle = item.title
         )
 
         return workerUUID
@@ -235,7 +251,7 @@ internal class PreplannedMapAreaState(
             if (shouldRemoveOfflineMapInfo()) {
                 OfflineRepository.removeOfflineMapInfo(
                     context = context,
-                    portalItemID = portalItem.itemId
+                    portalItemID = item.itemId
                 )
             }
             val localScope = CoroutineScope(Dispatchers.IO)

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import com.arcgismaps.location.LocationDisplayAutoPanMode
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.Item
 import com.arcgismaps.mapping.MobileMapPackage
@@ -37,10 +36,10 @@ import com.arcgismaps.tasks.offlinemaptask.OfflineMapTask
 import com.arcgismaps.tasks.offlinemaptask.PreplannedMapArea
 import com.arcgismaps.tasks.offlinemaptask.PreplannedPackagingStatus
 import com.arcgismaps.tasks.offlinemaptask.PreplannedUpdateMode
+import com.arcgismaps.toolkit.offline.OfflineRepository
 import com.arcgismaps.toolkit.offline.internal.utils.getDirectorySize
 import com.arcgismaps.toolkit.offline.runCatchingCancellable
 import com.arcgismaps.toolkit.offline.workmanager.LOG_TAG
-import com.arcgismaps.toolkit.offline.OfflineRepository
 import com.arcgismaps.toolkit.offline.workmanager.logWorkInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/MapAreaDetailsScreen.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/MapAreaDetailsScreen.kt
@@ -15,6 +15,7 @@
  *  limitations under the License.
  *
  */
+
 package com.arcgismaps.toolkit.offline.ui
 
 import androidx.compose.foundation.Image

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/OfflineMapAreasStatusScreen.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/OfflineMapAreasStatusScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.Block
@@ -53,6 +54,7 @@ internal fun ContentUnavailable(
     title: String,
     message: String,
     icon: ImageVector,
+    onlyFooterVisible: Boolean,
     actions: @Composable RowScope.() -> Unit = {}
 ) {
     Column(
@@ -62,10 +64,28 @@ internal fun ContentUnavailable(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Icon(icon, contentDescription = null, modifier = Modifier.size(32.dp))
-        Text(title, style = MaterialTheme.typography.titleLarge, textAlign = TextAlign.Center)
-        Text(message, style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center)
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) { actions() }
+        if (onlyFooterVisible) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(icon, contentDescription = null, modifier = Modifier.size(14.dp))
+                Text(
+                    modifier = Modifier.wrapContentSize(),
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    textAlign = TextAlign.Center
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) { actions() }
+        } else {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(32.dp))
+            Text(title, style = MaterialTheme.typography.titleMedium, textAlign = TextAlign.Center)
+            Text(message, style = MaterialTheme.typography.bodySmall, textAlign = TextAlign.Center)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) { actions() }
+        }
     }
 }
 
@@ -82,52 +102,60 @@ internal fun RefreshButton(onRefresh: () -> Unit) {
 }
 
 @Composable
-internal fun NoInternetNoAreas(onRefresh: () -> Unit) {
+internal fun NoInternetNoAreas(onlyFooterVisible: Boolean = false, onRefresh: () -> Unit) {
     ContentUnavailable(
         title = stringResource(R.string.no_internet_connection_error_message),
         message = stringResource(R.string.no_internet_error_message),
         icon = Icons.Default.WifiOff,
-        actions = { RefreshButton(onRefresh) }
+        actions = { RefreshButton(onRefresh) },
+        onlyFooterVisible = onlyFooterVisible
     )
 }
 
 @Composable
-internal fun EmptyPreplannedOfflineAreas(onRefresh: () -> Unit) {
+internal fun EmptyPreplannedOfflineAreas(
+    onlyFooterVisible: Boolean = false,
+    onRefresh: () -> Unit
+) {
     ContentUnavailable(
         title = stringResource(R.string.no_map_areas),
         message = stringResource(R.string.no_offline_map_areas_error_message),
         icon = Icons.Default.ArrowDownward,
-        actions = { RefreshButton(onRefresh) }
+        actions = { RefreshButton(onRefresh) },
+        onlyFooterVisible = onlyFooterVisible
     )
 }
 
 @Composable
-internal fun PreplannedError(onRefresh: () -> Unit) {
+internal fun PreplannedError(onlyFooterVisible: Boolean = false, onRefresh: () -> Unit) {
     ContentUnavailable(
         title = stringResource(R.string.error_fetching_areas),
         message = stringResource(R.string.error_fetching_areas_message),
         icon = Icons.Default.Error,
-        actions = { RefreshButton(onRefresh) }
+        actions = { RefreshButton(onRefresh) },
+        onlyFooterVisible = onlyFooterVisible
     )
 }
 
 @Composable
-internal fun OfflineDisabled(onRefresh: () -> Unit) {
+internal fun OfflineDisabled(onlyFooterVisible: Boolean = false, onRefresh: () -> Unit) {
     ContentUnavailable(
         title = stringResource(R.string.offline_disabled),
         message = stringResource(R.string.offline_disabled_message),
         icon = Icons.Default.Block,
-        actions = { RefreshButton(onRefresh) }
+        actions = { RefreshButton(onRefresh) },
+        onlyFooterVisible = onlyFooterVisible
     )
 }
 
 @Composable
-internal fun EmptyOnDemandOfflineAreas(onAdd: () -> Unit) {
+internal fun EmptyOnDemandOfflineAreas(onlyFooterVisible: Boolean = false, onAdd: () -> Unit) {
     ContentUnavailable(
         title = stringResource(R.string.no_map_areas),
         message = stringResource(R.string.empty_on_demand_message),
         icon = Icons.Default.ArrowDownward,
-        actions = { Button(onClick = onAdd) { Text(stringResource(R.string.map_areas)) } }
+        actions = { Button(onClick = onAdd) { Text(stringResource(R.string.map_areas)) } },
+        onlyFooterVisible = onlyFooterVisible
     )
 }
 
@@ -137,6 +165,16 @@ private fun NoInternetNoAreasPreview() {
     MaterialTheme {
         Surface {
             NoInternetNoAreas { }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NoInternetNoAreasFooterPreview() {
+    MaterialTheme {
+        Surface {
+            NoInternetNoAreas(onlyFooterVisible = true) { }
         }
     }
 }
@@ -166,7 +204,7 @@ private fun PreplannedErrorPreview() {
 private fun OfflineDisabledPreview() {
     MaterialTheme {
         Surface {
-            OfflineDisabled({})
+            OfflineDisabled { }
         }
     }
 }

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/OfflineMapAreasStatusScreen.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/OfflineMapAreasStatusScreen.kt
@@ -1,0 +1,182 @@
+/*
+ *
+ *  Copyright 2025 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.arcgismaps.toolkit.offline.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.arcgismaps.toolkit.offline.R
+
+@Composable
+internal fun ContentUnavailable(
+    title: String,
+    message: String,
+    icon: ImageVector,
+    actions: @Composable RowScope.() -> Unit = {}
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(icon, contentDescription = null, modifier = Modifier.size(32.dp))
+        Text(title, style = MaterialTheme.typography.titleLarge, textAlign = TextAlign.Center)
+        Text(message, style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) { actions() }
+    }
+}
+
+@Composable
+internal fun RefreshButton(onRefresh: () -> Unit) {
+    Button(onClick = onRefresh) {
+        Icon(
+            Icons.Default.Refresh,
+            contentDescription = "A label for a button to refresh map area content."
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(stringResource(R.string.refresh))
+    }
+}
+
+@Composable
+internal fun NoInternetNoAreas(onRefresh: () -> Unit) {
+    ContentUnavailable(
+        title = stringResource(R.string.no_internet_connection_error_message),
+        message = stringResource(R.string.no_internet_error_message),
+        icon = Icons.Default.WifiOff,
+        actions = { RefreshButton(onRefresh) }
+    )
+}
+
+@Composable
+internal fun EmptyPreplannedOfflineAreas(onRefresh: () -> Unit) {
+    ContentUnavailable(
+        title = stringResource(R.string.no_map_areas),
+        message = stringResource(R.string.no_offline_map_areas_error_message),
+        icon = Icons.Default.ArrowDownward,
+        actions = { RefreshButton(onRefresh) }
+    )
+}
+
+@Composable
+internal fun PreplannedError(onRefresh: () -> Unit) {
+    ContentUnavailable(
+        title = stringResource(R.string.error_fetching_areas),
+        message = stringResource(R.string.error_fetching_areas_message),
+        icon = Icons.Default.Error,
+        actions = { RefreshButton(onRefresh) }
+    )
+}
+
+@Composable
+internal fun OfflineDisabled(onRefresh: () -> Unit) {
+    ContentUnavailable(
+        title = stringResource(R.string.offline_disabled),
+        message = stringResource(R.string.offline_disabled_message),
+        icon = Icons.Default.Block,
+        actions = { RefreshButton(onRefresh) }
+    )
+}
+
+@Composable
+internal fun EmptyOnDemandOfflineAreas(onAdd: () -> Unit) {
+    ContentUnavailable(
+        title = stringResource(R.string.no_map_areas),
+        message = stringResource(R.string.empty_on_demand_message),
+        icon = Icons.Default.ArrowDownward,
+        actions = { Button(onClick = onAdd) { Text(stringResource(R.string.map_areas)) } }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NoInternetNoAreasPreview() {
+    MaterialTheme {
+        Surface {
+            NoInternetNoAreas { }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EmptyPreplannedOfflineAreasPreview() {
+    MaterialTheme {
+        Surface {
+            EmptyPreplannedOfflineAreas { }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreplannedErrorPreview() {
+    MaterialTheme {
+        Surface {
+            PreplannedError { }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun OfflineDisabledPreview() {
+    MaterialTheme {
+        Surface {
+            OfflineDisabled({})
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ContentUnavailablePreview() {
+    MaterialTheme {
+        Surface {
+            EmptyOnDemandOfflineAreas { }
+        }
+    }
+}

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/OfflineMapAreasStatusScreen.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/OfflineMapAreasStatusScreen.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.offline.R
 
 @Composable
-internal fun ContentUnavailable(
+internal fun OfflineMapAreasStatusContent(
     title: String,
     message: String,
     icon: ImageVector,
@@ -68,20 +68,20 @@ internal fun ContentUnavailable(
             Row(
                 modifier = Modifier
                     .fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalArrangement = Arrangement.SpaceAround,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(icon, contentDescription = null, modifier = Modifier.size(14.dp))
                 Text(
                     modifier = Modifier.wrapContentSize(),
                     text = message,
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.labelSmall,
                     textAlign = TextAlign.Center
                 )
             }
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) { actions() }
         } else {
-            Icon(icon, contentDescription = null, modifier = Modifier.size(32.dp))
+            Icon(icon, contentDescription = null, modifier = Modifier.size(28.dp))
             Text(title, style = MaterialTheme.typography.titleMedium, textAlign = TextAlign.Center)
             Text(message, style = MaterialTheme.typography.bodySmall, textAlign = TextAlign.Center)
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) { actions() }
@@ -93,17 +93,18 @@ internal fun ContentUnavailable(
 internal fun RefreshButton(onRefresh: () -> Unit) {
     Button(onClick = onRefresh) {
         Icon(
-            Icons.Default.Refresh,
+            modifier = Modifier.size(16.dp),
+            imageVector = Icons.Default.Refresh,
             contentDescription = "A label for a button to refresh map area content."
         )
         Spacer(Modifier.width(4.dp))
-        Text(stringResource(R.string.refresh))
+        Text(text = stringResource(R.string.refresh), style = MaterialTheme.typography.labelSmall)
     }
 }
 
 @Composable
 internal fun NoInternetNoAreas(onlyFooterVisible: Boolean = false, onRefresh: () -> Unit) {
-    ContentUnavailable(
+    OfflineMapAreasStatusContent(
         title = stringResource(R.string.no_internet_connection_error_message),
         message = stringResource(R.string.no_internet_error_message),
         icon = Icons.Default.WifiOff,
@@ -117,7 +118,7 @@ internal fun EmptyPreplannedOfflineAreas(
     onlyFooterVisible: Boolean = false,
     onRefresh: () -> Unit
 ) {
-    ContentUnavailable(
+    OfflineMapAreasStatusContent(
         title = stringResource(R.string.no_map_areas),
         message = stringResource(R.string.no_offline_map_areas_error_message),
         icon = Icons.Default.ArrowDownward,
@@ -127,10 +128,14 @@ internal fun EmptyPreplannedOfflineAreas(
 }
 
 @Composable
-internal fun PreplannedError(onlyFooterVisible: Boolean = false, onRefresh: () -> Unit) {
-    ContentUnavailable(
+internal fun OfflineMapAreasError(
+    error: Throwable,
+    onlyFooterVisible: Boolean = false,
+    onRefresh: () -> Unit
+) {
+    OfflineMapAreasStatusContent(
         title = stringResource(R.string.error_fetching_areas),
-        message = stringResource(R.string.error_fetching_areas_message),
+        message = stringResource(R.string.error_fetching_areas_message) + "\n\n" + error.message,
         icon = Icons.Default.Error,
         actions = { RefreshButton(onRefresh) },
         onlyFooterVisible = onlyFooterVisible
@@ -139,7 +144,7 @@ internal fun PreplannedError(onlyFooterVisible: Boolean = false, onRefresh: () -
 
 @Composable
 internal fun OfflineDisabled(onlyFooterVisible: Boolean = false, onRefresh: () -> Unit) {
-    ContentUnavailable(
+    OfflineMapAreasStatusContent(
         title = stringResource(R.string.offline_disabled),
         message = stringResource(R.string.offline_disabled_message),
         icon = Icons.Default.Block,
@@ -150,7 +155,7 @@ internal fun OfflineDisabled(onlyFooterVisible: Boolean = false, onRefresh: () -
 
 @Composable
 internal fun EmptyOnDemandOfflineAreas(onlyFooterVisible: Boolean = false, onAdd: () -> Unit) {
-    ContentUnavailable(
+    OfflineMapAreasStatusContent(
         title = stringResource(R.string.no_map_areas),
         message = stringResource(R.string.empty_on_demand_message),
         icon = Icons.Default.ArrowDownward,
@@ -191,10 +196,10 @@ private fun EmptyPreplannedOfflineAreasPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun PreplannedErrorPreview() {
+private fun OfflineMapAreasErrorPreview() {
     MaterialTheme {
         Surface {
-            PreplannedError { }
+            OfflineMapAreasError(error = Throwable("Failed to initialize map areas")) { }
         }
     }
 }
@@ -211,7 +216,7 @@ private fun OfflineDisabledPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun ContentUnavailablePreview() {
+private fun EmptyOnDemandOfflineAreasPreview() {
     MaterialTheme {
         Surface {
             EmptyOnDemandOfflineAreas { }

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/OfflineMapAreasStatusScreen.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/OfflineMapAreasStatusScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Error
@@ -95,7 +96,7 @@ internal fun RefreshButton(onRefresh: () -> Unit) {
         Icon(
             modifier = Modifier.size(16.dp),
             imageVector = Icons.Default.Refresh,
-            contentDescription = "A label for a button to refresh map area content."
+            contentDescription = "Icon to refresh map area content."
         )
         Spacer(Modifier.width(4.dp))
         Text(text = stringResource(R.string.refresh), style = MaterialTheme.typography.labelSmall)
@@ -159,7 +160,20 @@ internal fun EmptyOnDemandOfflineAreas(onlyFooterVisible: Boolean = false, onAdd
         title = stringResource(R.string.no_map_areas),
         message = stringResource(R.string.empty_on_demand_message),
         icon = Icons.Default.ArrowDownward,
-        actions = { Button(onClick = onAdd) { Text(stringResource(R.string.map_areas)) } },
+        actions = {
+            Button(onClick = onAdd) {
+                Icon(
+                    modifier = Modifier.size(16.dp),
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "Icon to add map area"
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = stringResource(R.string.add_map_area),
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        },
         onlyFooterVisible = onlyFooterVisible
     )
 }

--- a/toolkit/offline/src/main/res/values/strings.xml
+++ b/toolkit/offline/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
 
 <resources>
     <string name="map_areas">Map Areas</string>
+    <string name="add_map_area">Add Map Area</string>
     <string name="thumbnail_description">PortalItem Thumbnail</string>
     <string name="download">Download</string>
     <string name="open">Open</string>
@@ -33,4 +34,15 @@
     <string name="download_map_area">Download Map Area</string>
     <string name="remove_download">Remove Download</string>
     <string name="no_image_available">No Image Available</string>
+    <string name="refresh">Refresh</string>
+    <string name="no_internet_connection_error_message">No Internet Connection</string>
+    <string name="no_internet_error_message">No internet connection. Showing downloaded areas only.</string>
+    <string name="no_map_areas_error_message">Could not retrieve map areas for this map.</string>
+    <string name="no_offline_map_areas_error_message">There are no map areas for this map.</string>
+    <string name="error_fetching_areas">Error Fetching Map Areas</string>
+    <string name="error_fetching_areas_message">An error occurred while fetching map areas.</string>
+    <string name="no_map_areas">No Map Areas</string>
+    <string name="empty_on_demand_message">There are no map areas for this map. Tap the button below to get started.</string>
+    <string name="offline_disabled">Offline Disabled</string>
+    <string name="offline_disabled_message">The map is not enabled for offline use.</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#5912](https://devtopia.esri.com/runtime/kotlin/issues/5912)

<!-- link to design, if applicable -->

### Description:

When the view fails to display the map areas due to various reasons and errors, different status views will be shown.


### Summary of changes:

- Added Compose UI for: `NoInternetNoAreas`, `EmptyPreplannedOfflineAreas`, `OfflineMapAreasError`, `OfflineDisabled`, `EmptyOnDemandOfflineAreas` in `OfflineMapAreasStatusScreen.kt`.
- Updated `PreplannedMapAreaState` constructor to accept `item` (for `PortalItem` and `MobileMapPackage.item`) and made `offlineMapTask` & `preplannedMapArea ` optional params at they are only needed for online mode. 
- Added properties (title, description, thumbnail) to `PreplannedMapAreaState` to load from PortalItem/MobileMapPackage.
- Added properties `isShowingOnlyOfflineModels`, `mapIsOfflineDisabled` to `OfflineMapState.kt` for Compose UI failures.
- Added function `loadPreplannedMapAreas` to `OfflineMapState.kt` to load and add online areas to `_preplannedMapAreaStates`.
- Added function `loadOfflinePreplannedMapAreas ` to `OfflineMapState.kt` to load and add offline areas to `_preplannedMapAreaStates`.
- Added function `makeOfflinePreplannedMapAreaState` to `OfflineMapState.kt` to make a PreplannedMapAreaState from the MobileMapPackage.
- Wired up OfflineMapMode Preplanned, OnDemand, Unknown logic.
- Wired up `resetInitialize` logic to refresh UI. 
- Removed `NonRecoveredErrorIndicator`. 
- Updated strings matching swift offline errors. 

### Screenshots

---------

- If not `OfflineMapMode.Preplanned`, display: `EmptyOnDemandOfflineAreas`:

<img src="https://github.com/user-attachments/assets/5b41d274-9fcb-40bc-9529-59e6a0aaf3c4" height=700>

---------

- If provided `ArcGISMap` has `offlineSettings == null`:

<img src="https://github.com/user-attachments/assets/e83e5cf9-a4c5-4712-a09d-3f220bbecb8f" height=700>

---------

- If `FailedToInitialize`, display error:

<img src="https://github.com/user-attachments/assets/f8e07f99-bb47-413c-a69b-48e099f2a007" height=700>

---------

- If `OfflineMapMode` is Preplanned and local mmpks are available and internet connection not available: 

<img src="https://github.com/user-attachments/assets/c6e50a2f-b60c-489d-9f78-dd4191efbc46" height=700>

---------

- If `OfflineMapMode` is Preplanned and local mmpks are not available and internet connection not available:

<img src="https://github.com/user-attachments/assets/17ef03b4-8fa5-4aaa-9d59-47274ec6481b" height=700>

---------

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/747/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  