### PR TITLE
Move flyover translation factor onto the composable

### DIFF
--- a/microapps/ArFlyoverApp/app/src/main/java/com/arcgismaps/toolkit/arflyoverapp/screens/MainScreen.kt
+++ b/microapps/ArFlyoverApp/app/src/main/java/com/arcgismaps/toolkit/arflyoverapp/screens/MainScreen.kt
@@ -110,13 +110,13 @@ fun MainScreen() {
                 230.0,
                 SpatialReference.wgs84()
             ),
-            heading = 160.0,
-            translationFactor = 1000.0
+            heading = 160.0
         )
 
         FlyoverSceneView(
             arcGISScene = arcGISScene,
-            flyoverSceneViewProxy = flyoverSceneViewProxy
+            flyoverSceneViewProxy = flyoverSceneViewProxy,
+            translationFactor = 1000.0
         )
     } else {
         // otherwise display a message and a button that causes the privacy info dialog to be shown

--- a/toolkit/ar/api/ar.api
+++ b/toolkit/ar/api/ar.api
@@ -9,12 +9,12 @@ public final class com/arcgismaps/toolkit/ar/ArCoreResourceExhaustedException : 
 }
 
 public final class com/arcgismaps/toolkit/ar/FlyoverSceneViewKt {
-	public static final fun FlyoverSceneView-H0GAfME (Lcom/arcgismaps/mapping/ArcGISScene;Lcom/arcgismaps/toolkit/ar/FlyoverSceneViewProxy;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/util/List;Lcom/arcgismaps/mapping/view/SceneViewInteractionOptions;Lcom/arcgismaps/mapping/view/ViewLabelProperties;Lcom/arcgismaps/mapping/view/SelectionProperties;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/util/List;Ljava/util/List;Lcom/arcgismaps/mapping/view/AtmosphereEffect;Lcom/arcgismaps/mapping/TimeExtent;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/mapping/view/SpaceEffect;Ljava/time/Instant;Lcom/arcgismaps/mapping/view/LightingMode;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;IIIIII)V
+	public static final fun FlyoverSceneView-W-Wk5Ls (Lcom/arcgismaps/mapping/ArcGISScene;Lcom/arcgismaps/toolkit/ar/FlyoverSceneViewProxy;DLandroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/util/List;Lcom/arcgismaps/mapping/view/SceneViewInteractionOptions;Lcom/arcgismaps/mapping/view/ViewLabelProperties;Lcom/arcgismaps/mapping/view/SelectionProperties;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/util/List;Ljava/util/List;Lcom/arcgismaps/mapping/view/AtmosphereEffect;Lcom/arcgismaps/mapping/TimeExtent;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/mapping/view/SpaceEffect;Ljava/time/Instant;Lcom/arcgismaps/mapping/view/LightingMode;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;IIIIII)V
 }
 
 public final class com/arcgismaps/toolkit/ar/FlyoverSceneViewProxy {
 	public static final field $stable I
-	public fun <init> (Lcom/arcgismaps/geometry/Point;DD)V
+	public fun <init> (Lcom/arcgismaps/geometry/Point;D)V
 	public final fun exportImage-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getFieldOfView ()Ljava/lang/Double;
 	public final fun getFieldOfViewDistortionRatio ()Ljava/lang/Double;
@@ -32,11 +32,10 @@ public final class com/arcgismaps/toolkit/ar/FlyoverSceneViewProxy {
 	public final fun screenToBaseSurface (Lcom/arcgismaps/mapping/view/DoubleXY;)Lcom/arcgismaps/geometry/Point;
 	public final fun screenToLocation-gIAlu-s (Lcom/arcgismaps/mapping/view/DoubleXY;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setLocationAndHeading (Lcom/arcgismaps/geometry/Point;D)V
-	public final fun setTranslationFactor (D)V
 }
 
 public final class com/arcgismaps/toolkit/ar/FlyoverSceneViewProxyKt {
-	public static final fun rememberFlyoverSceneViewProxy (Lcom/arcgismaps/geometry/Point;DDLandroidx/compose/runtime/Composer;I)Lcom/arcgismaps/toolkit/ar/FlyoverSceneViewProxy;
+	public static final fun rememberFlyoverSceneViewProxy (Lcom/arcgismaps/geometry/Point;DLandroidx/compose/runtime/Composer;I)Lcom/arcgismaps/toolkit/ar/FlyoverSceneViewProxy;
 }
 
 public abstract class com/arcgismaps/toolkit/ar/FlyoverSceneViewStatus {

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneView.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneView.kt
@@ -22,6 +22,7 @@ import android.Manifest
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -197,7 +198,9 @@ public fun FlyoverSceneView(
         }
     }
 
-    flyoverSceneViewProxy.setTranslationFactor(translationFactor)
+    SideEffect {
+        flyoverSceneViewProxy.setTranslationFactor(translationFactor)
+    }
 
     Box(modifier = Modifier) {
         // Use rememberUpdatedState so that the lambda used below always sees the latest proxy. Without

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneView.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneView.kt
@@ -71,6 +71,8 @@ import java.time.Instant
  *
  * @param arcGISScene the [ArcGISScene] to be rendered by this FlyoverSceneView.
  * @param flyoverSceneViewProxy the [FlyoverSceneViewProxy] to associate with the FlyoverSceneView.
+ * @param translationFactor the translation factor that defines how much the scene view translates
+ * as the device moves.
  * @param modifier Modifier to be applied to the FlyoverSceneView.
  * @param onInitializationStatusChanged a callback that is invoked when the initialization status of this FlyoverSceneView changes.
  * @param onViewpointChangedForCenterAndScale lambda invoked when the viewpoint changes, passing a viewpoint
@@ -112,6 +114,7 @@ import java.time.Instant
 public fun FlyoverSceneView(
     arcGISScene: ArcGISScene,
     flyoverSceneViewProxy: FlyoverSceneViewProxy,
+    translationFactor: Double,
     modifier: Modifier = Modifier,
     onInitializationStatusChanged: ((FlyoverSceneViewStatus) -> Unit)? = null,
     onViewpointChangedForCenterAndScale: ((Viewpoint) -> Unit)? = null,
@@ -193,6 +196,8 @@ public fun FlyoverSceneView(
             flyoverSceneViewProxy.setSessionWrapper(null)
         }
     }
+
+    flyoverSceneViewProxy.setTranslationFactor(translationFactor)
 
     Box(modifier = Modifier) {
         // Use rememberUpdatedState so that the lambda used below always sees the latest proxy. Without

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneViewProxy.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneViewProxy.kt
@@ -42,7 +42,6 @@ import com.google.ar.core.Config
  *
  * @param location the camera's origin location.
  * @param heading the camera heading.
- * @param translationFactor the translation factor that defines how much the scene view translates
  * as the device moves.
  *
  * @since 200.8.0
@@ -50,14 +49,12 @@ import com.google.ar.core.Config
 @Composable
 public fun rememberFlyoverSceneViewProxy(
     location: Point,
-    heading: Double,
-    translationFactor: Double
+    heading: Double
 ): FlyoverSceneViewProxy {
     return remember {
         FlyoverSceneViewProxy(
             location = location,
-            heading = heading,
-            translationFactor = translationFactor
+            heading = heading
         )
     }
 }
@@ -82,21 +79,17 @@ public class FlyoverSceneViewProxy internal constructor(internal val sceneViewPr
      *
      * @param location the camera's origin location.
      * @param heading the camera heading.
-     * @param translationFactor the translation factor that defines how much the scene view translates
-     * as the device moves.
      *
      * @since 200.8.0
      */
     public constructor(
         location: Point,
-        heading: Double,
-        translationFactor: Double
+        heading: Double
     ) : this(SceneViewProxy()) {
         setLocationAndHeading(
             location = location,
             heading = heading
         )
-        cameraController.setTranslationFactor(translationFactor)
     }
 
     init {
@@ -138,7 +131,7 @@ public class FlyoverSceneViewProxy internal constructor(internal val sceneViewPr
      *
      * @since 200.8.0
      */
-    public fun setTranslationFactor(translationFactor: Double) {
+    internal fun setTranslationFactor(translationFactor: Double) {
         cameraController.setTranslationFactor(translationFactor)
     }
 

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneViewProxy.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneViewProxy.kt
@@ -42,7 +42,6 @@ import com.google.ar.core.Config
  *
  * @param location the camera's origin location.
  * @param heading the camera heading.
- * as the device moves.
  *
  * @since 200.8.0
  */


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/6015

<!-- link to design, if applicable -->

### Description:

Moves `translationFactor` from the proxy to being directly on the composable

### Summary of changes:

- move `translationFactor`
- update api file

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/745/console
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  