### PR TITLE
Add sheetGesturesEnabled

### DIFF
--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/material3/SheetDefaults.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ui/material3/SheetDefaults.kt
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications 2025: Esri Inc. Made functions internal and explicitly specified return types
  */
 
 package com.arcgismaps.toolkit.offline.ui.material3


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/5751

<!-- link to design, if applicable -->

### Description:

ModalBottomSheet response to gestures interferes with panning and zooming on mapview contained in it. We need a way for ModalBottomsheet to not consume gesture events so the user can interact with the mapview

### Summary of changes:

- Add commit to add support for sheetGesturesEnabled https://android-review.googlesource.com/c/platform/frameworks/support/+/3287876/4/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/ModalBottomSheet.kt#262
- Add Modifications to copyright

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/759/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  