### PR TITLE
Colinanderson/flyover hide camera

### DIFF
--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneView.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneView.kt
@@ -218,7 +218,8 @@ public fun FlyoverSceneView(
             },
             onTapWithHitResult = {},
             onFirstPlaneDetected = {},
-            visualizePlanes = false
+            visualizePlanes = false,
+            visualizeCamera = false
         )
 
         SceneView(

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneView.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/FlyoverSceneView.kt
@@ -202,7 +202,7 @@ public fun FlyoverSceneView(
         flyoverSceneViewProxy.setTranslationFactor(translationFactor)
     }
 
-    Box(modifier = Modifier) {
+    Box(modifier = modifier) {
         // Use rememberUpdatedState so that the lambda used below always sees the latest proxy. Without
         // this if we changed the proxy argument updating and rendering would stop.
         val proxy by rememberUpdatedState(flyoverSceneViewProxy)
@@ -220,52 +220,52 @@ public fun FlyoverSceneView(
             onFirstPlaneDetected = {},
             visualizePlanes = false
         )
-    }
 
-    SceneView(
-        arcGISScene = arcGISScene,
-        sceneViewProxy = flyoverSceneViewProxy.sceneViewProxy,
-        cameraController = flyoverSceneViewProxy.cameraController,
-        atmosphereEffect = atmosphereEffect,
-        spaceEffect = spaceEffect,
-        modifier = modifier,
-        onViewpointChangedForCenterAndScale = onViewpointChangedForCenterAndScale,
-        onViewpointChangedForBoundingGeometry = onViewpointChangedForBoundingGeometry,
-        graphicsOverlays = graphicsOverlays,
-        sceneViewInteractionOptions = remember { SceneViewInteractionOptions(isEnabled = false) },
-        viewLabelProperties = viewLabelProperties,
-        selectionProperties = selectionProperties,
-        isAttributionBarVisible = isAttributionBarVisible,
-        onAttributionTextChanged = onAttributionTextChanged,
-        onAttributionBarLayoutChanged = onAttributionBarLayoutChanged,
-        analysisOverlays = analysisOverlays,
-        imageOverlays = imageOverlays,
-        timeExtent = timeExtent,
-        onTimeExtentChanged = onTimeExtentChanged,
-        sunTime = sunTime,
-        sunLighting = sunLighting,
-        ambientLightColor = ambientLightColor,
-        onNavigationChanged = onNavigationChanged,
-        onSpatialReferenceChanged = onSpatialReferenceChanged,
-        onLayerViewStateChanged = onLayerViewStateChanged,
-        onInteractingChanged = onInteractingChanged,
-        onCurrentViewpointCameraChanged = onCurrentViewpointCameraChanged,
-        onRotate = onRotate,
-        onScale = onScale,
-        onUp = onUp,
-        onDown = onDown,
-        onSingleTapConfirmed = onSingleTapConfirmed,
-        onDoubleTap = onDoubleTap,
-        onLongPress = onLongPress,
-        onTwoPointerTap = onTwoPointerTap,
-        onPan = onPan,
-        content = {
-            content?.let { content ->
-                val flyoverSceneViewScope = remember {
-                    FlyoverSceneViewScope(this)
+        SceneView(
+            arcGISScene = arcGISScene,
+            sceneViewProxy = flyoverSceneViewProxy.sceneViewProxy,
+            cameraController = flyoverSceneViewProxy.cameraController,
+            atmosphereEffect = atmosphereEffect,
+            spaceEffect = spaceEffect,
+            modifier = modifier,
+            onViewpointChangedForCenterAndScale = onViewpointChangedForCenterAndScale,
+            onViewpointChangedForBoundingGeometry = onViewpointChangedForBoundingGeometry,
+            graphicsOverlays = graphicsOverlays,
+            sceneViewInteractionOptions = remember { SceneViewInteractionOptions(isEnabled = false) },
+            viewLabelProperties = viewLabelProperties,
+            selectionProperties = selectionProperties,
+            isAttributionBarVisible = isAttributionBarVisible,
+            onAttributionTextChanged = onAttributionTextChanged,
+            onAttributionBarLayoutChanged = onAttributionBarLayoutChanged,
+            analysisOverlays = analysisOverlays,
+            imageOverlays = imageOverlays,
+            timeExtent = timeExtent,
+            onTimeExtentChanged = onTimeExtentChanged,
+            sunTime = sunTime,
+            sunLighting = sunLighting,
+            ambientLightColor = ambientLightColor,
+            onNavigationChanged = onNavigationChanged,
+            onSpatialReferenceChanged = onSpatialReferenceChanged,
+            onLayerViewStateChanged = onLayerViewStateChanged,
+            onInteractingChanged = onInteractingChanged,
+            onCurrentViewpointCameraChanged = onCurrentViewpointCameraChanged,
+            onRotate = onRotate,
+            onScale = onScale,
+            onUp = onUp,
+            onDown = onDown,
+            onSingleTapConfirmed = onSingleTapConfirmed,
+            onDoubleTap = onDoubleTap,
+            onLongPress = onLongPress,
+            onTwoPointerTap = onTwoPointerTap,
+            onPan = onPan,
+            content = {
+                content?.let { content ->
+                    val flyoverSceneViewScope = remember {
+                        FlyoverSceneViewScope(this)
+                    }
+                    content.invoke(flyoverSceneViewScope)
                 }
-                content.invoke(flyoverSceneViewScope)
             }
-        }
-    )
+        )
+    }
 }

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArCameraFeed.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArCameraFeed.kt
@@ -45,6 +45,7 @@ import com.google.ar.core.Session
  * @param onFrame a callback that is invoked every frame.
  * @param onTapWithHitResult a callback that is invoked when the user taps the screen and a hit is detected.
  * @param visualizePlanes whether to visualize detected planes.
+ * @param visualizeCamera whether to visualize the camera feed.
  * @since 200.6.0
  */
 @Composable
@@ -53,7 +54,8 @@ internal fun ArCameraFeed(
     onFrame: (Frame, Int, Session) -> Unit,
     onTapWithHitResult: (hit: HitResult?) -> Unit,
     onFirstPlaneDetected: () -> Unit,
-    visualizePlanes: Boolean = true
+    visualizePlanes: Boolean = true,
+    visualizeCamera: Boolean = true
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
@@ -71,7 +73,10 @@ internal fun ArCameraFeed(
             this.surfaceDrawHandler = SurfaceDrawHandler(surfaceViewWrapper.glSurfaceView, this)
         }
     }.apply {
+        // These properties must be applied outside of the remember block, as they are expected to
+        // change after the CameraFeedRenderer is created
         this.visualizePlanes = visualizePlanes
+        this.visualizeCamera = visualizeCamera
     }
 
     DisposableEffect(Unit) {

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/render/CameraFeedRenderer.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/render/CameraFeedRenderer.kt
@@ -48,7 +48,8 @@ internal class CameraFeedRenderer(
     private val onFrame: (Frame, Int, Session) -> Unit,
     private val onTapWithHitResult: (hit: HitResult?) -> Unit,
     private val onFirstPlaneDetected: () -> Unit,
-    var visualizePlanes: Boolean = true
+    var visualizePlanes: Boolean = true,
+    var visualizeCamera: Boolean = true
 ) :
     SurfaceDrawHandler.Renderer, DefaultLifecycleObserver {
 
@@ -197,7 +198,7 @@ internal class CameraFeedRenderer(
             updateDisplayGeometry(frame)
 
             // -- Draw background
-            if (frame.timestamp != 0L) {
+            if (frame.timestamp != 0L && visualizeCamera) {
                 // Suppress rendering if the camera did not produce the first frame yet. This is to avoid
                 // drawing possible leftover data from previous sessions if the texture is reused.
                 drawBackground(surfaceDrawHandler)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5849

<!-- link to design, if applicable -->

### Description:

Add parameter that controls if the camera feed is rendered or not - defaults to true.

When the parameter is set to true the start up looks like

https://github.com/user-attachments/assets/193e1bbf-024e-41fb-ae5d-aa68426b236f

### Summary of changes:

- add parameter
- fix how the modifier is applied to `FlyoverSceneView` as discussed in scrum. The components of the flyover view are placed in a box and the modifier applied to the box. Before this fix the scene view part would respect any modifiers applied but the camera feed did not... slightly academic now that we don't render the camera.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/777/console
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  