### PR TITLE
Add remember

### DIFF
--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneView.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/TableTopSceneView.kt
@@ -310,7 +310,12 @@ public fun TableTopSceneView(
                 onTwoPointerTap = onTwoPointerTap,
                 onPan = onPan,
                 content = {
-                    content?.invoke(TableTopSceneViewScope(this))
+                    content?.let { content ->
+                        val tableTopSceneViewScope = remember {
+                            TableTopSceneViewScope(this)
+                        }
+                        content.invoke(tableTopSceneViewScope)
+                    }
                 }
             )
         }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/6024

<!-- link to design, if applicable -->

### Description:

Add a remember to TableTopSceneView's scope parameter so it is not recreated on every recomposition and to make it consistent with WorldScaleSceneView and FlyoverSceneView.

### Summary of changes:

- remember the scope

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/799/console
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  