### PR TITLE
use AuthenticatorState to sign out

### DIFF
--- a/toolkit/authentication/src/androidTest/AndroidManifest.xml
+++ b/toolkit/authentication/src/androidTest/AndroidManifest.xml
@@ -46,5 +46,11 @@
                     android:scheme="kotlin-authentication-test-2" />
             </intent-filter>
             </activity>
+        <activity android:name="com.arcgismaps.toolkit.authentication.AuthenticatorStateActivity"
+            android:exported="true">
+            <intent-filter>
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/AuthenticatorStateActivity.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/AuthenticatorStateActivity.kt
@@ -1,0 +1,14 @@
+package com.arcgismaps.toolkit.authentication
+
+import androidx.activity.ComponentActivity
+
+
+/**
+ * This activity provides the AuthenticatorState for ComposeTestRules.
+ * The Activity is recreated and destroyed for each test when it is provided by a TestRule.
+ *
+ * @since 200.8.0
+ */
+class AuthenticatorStateActivity : ComponentActivity() {
+    val authenticatorState = AuthenticatorState()
+}

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthDefaultConfigurationTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthDefaultConfigurationTests.kt
@@ -16,7 +16,6 @@
  */
 package com.arcgismaps.toolkit.authentication
 
-import androidx.activity.ComponentActivity
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -49,7 +48,7 @@ import org.junit.Test
 class OAuthDefaultConfigurationTests {
 
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+    val composeTestRule = createAndroidComposeRule<AuthenticatorStateActivity>()
 
     @Before
     fun signOutBefore() = signOut()
@@ -59,7 +58,7 @@ class OAuthDefaultConfigurationTests {
 
     private fun signOut() {
         runBlocking {
-            ArcGISEnvironment.authenticationManager.signOut()
+            composeTestRule.activity.authenticatorState.signOut()
         }
         // reset the ArcGISHttpClient to remove any custom interceptors
         ArcGISEnvironment.configureArcGISHttpClient()

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthUserLauncherTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthUserLauncherTests.kt
@@ -63,7 +63,7 @@ class OAuthUserLauncherTests {
 
     private fun signOut() {
         runBlocking {
-            ArcGISEnvironment.authenticationManager.signOut()
+            composeTestRule.activity.viewModel.authenticatorState.signOut()
         }
         // reset the ArcGISHttpClient to remove any custom interceptors
         ArcGISEnvironment.configureArcGISHttpClient()

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ServerTrustTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ServerTrustTests.kt
@@ -17,14 +17,12 @@
 package com.arcgismaps.toolkit.authentication
 
 import android.view.KeyEvent
-import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallenge
 import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallengeResponse
 import com.arcgismaps.httpcore.authentication.NetworkAuthenticationType
@@ -48,13 +46,13 @@ import java.security.cert.CertificateException
 class ServerTrustTests {
 
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+    val composeTestRule = createAndroidComposeRule<AuthenticatorStateActivity>()
 
 
     @Before
     fun signOut() {
         runBlocking {
-            ArcGISEnvironment.authenticationManager.signOut()
+            composeTestRule.activity.authenticatorState.signOut()
         }
     }
 
@@ -129,14 +127,13 @@ class ServerTrustTests {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun TestScope.testServerTrustChallengeWithStateRestoration(userInputOnDialog: () -> Unit): Deferred<NetworkAuthenticationChallengeResponse> =
         with(StateRestorationTester(composeTestRule)) {
-            val authenticatorState = AuthenticatorState()
             setContent {
-                DialogAuthenticator(authenticatorState = authenticatorState)
+                DialogAuthenticator(authenticatorState = composeTestRule.activity.authenticatorState)
             }
             // issue the server trust challenge
             val certificateHostName = "https://server-trust-tests.com/"
             val challengeResponse = async {
-                authenticatorState.handleNetworkAuthenticationChallenge(
+                composeTestRule.activity.authenticatorState.handleNetworkAuthenticationChallenge(
                     NetworkAuthenticationChallenge(
                         certificateHostName,
                         NetworkAuthenticationType.ServerTrust,
@@ -152,7 +149,7 @@ class ServerTrustTests {
                 )
             // ensure the dialog prompt is displayed as expected
             advanceUntilIdle()
-            assert(authenticatorState.pendingServerTrustChallenge.value != null)
+            assert(composeTestRule.activity.authenticatorState.pendingServerTrustChallenge.value != null)
             composeTestRule.onNodeWithText(serverTrustMessage).assertIsDisplayed()
 
             // simulate a configuration change
@@ -163,7 +160,7 @@ class ServerTrustTests {
 
             advanceUntilIdle()
             // ensure the dialog has disappeared
-            assert(authenticatorState.pendingServerTrustChallenge.value == null)
+            assert(composeTestRule.activity.authenticatorState.pendingServerTrustChallenge.value == null)
             composeTestRule.onNodeWithText(serverTrustMessage).assertDoesNotExist()
 
             // return the response deferred

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/UsernamePasswordTests.kt
@@ -53,10 +53,8 @@ import org.junit.rules.TestRule
  */
 class UsernamePasswordTests {
 
-    private val authenticatorState = AuthenticatorState()
-
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+    val composeTestRule = createAndroidComposeRule<AuthenticatorStateActivity>()
 
     @Before
     fun before() = signOut()
@@ -66,7 +64,7 @@ class UsernamePasswordTests {
 
     private fun signOut() {
         runBlocking {
-            ArcGISEnvironment.authenticationManager.signOut()
+            composeTestRule.activity.authenticatorState.signOut()
         }
         ArcGISEnvironment.configureArcGISHttpClient { }
     }
@@ -270,7 +268,10 @@ class UsernamePasswordTests {
         val hostname = "arcgis.com"
         every { usernamePasswordChallengeMock.hostname } returns hostname
         every { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) } just Runs
-        every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
+        every {
+            @Suppress("DEPRECATION")
+            usernamePasswordChallengeMock.additionalMessage
+        } answers { MutableStateFlow("") }
         every { usernamePasswordChallengeMock.cause } returns null
 
         composeTestRule.setContent {
@@ -300,11 +301,15 @@ class UsernamePasswordTests {
         val mockCause = mockk<ArcGISAuthenticationException>()
         val usernamePasswordChallengeMock = mockk<UsernamePasswordChallenge>()
         every { usernamePasswordChallengeMock.hostname } returns "arcgis.com"
-        every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
+        every {
+            @Suppress("DEPRECATION")
+            usernamePasswordChallengeMock.additionalMessage
+        } answers { MutableStateFlow("") }
         every { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) } just Runs
         every { usernamePasswordChallengeMock.cause } returns mockCause
 
         composeTestRule.setContent {
+            @Suppress("DEPRECATION")
             UsernamePasswordAuthenticator(usernamePasswordChallengeMock)
         }
 
@@ -331,7 +336,10 @@ class UsernamePasswordTests {
 
         val usernamePasswordChallengeMock = mockk<UsernamePasswordChallenge>()
         every { usernamePasswordChallengeMock.hostname } returns "arcgis.com"
-        every { usernamePasswordChallengeMock.additionalMessage } answers { MutableStateFlow("") }
+        every {
+            @Suppress("DEPRECATION")
+            usernamePasswordChallengeMock.additionalMessage
+        } answers { MutableStateFlow("") }
         every { usernamePasswordChallengeMock.continueWithCredentials(any(), any()) } just Runs
         every { usernamePasswordChallengeMock.cause } returns IllegalStateException("Test")
 
@@ -382,7 +390,7 @@ class UsernamePasswordTests {
     fun TestScope.testUsernamePasswordChallengeWithStateRestoration(userInputOnDialog: () -> Unit): Deferred<NetworkAuthenticationChallengeResponse> {
         with(StateRestorationTester(composeTestRule)) {
             setContent {
-                DialogAuthenticator(authenticatorState = authenticatorState)
+                DialogAuthenticator(authenticatorState = composeTestRule.activity.authenticatorState)
             }
 
             val hostname = "arcgis.com"
@@ -393,7 +401,7 @@ class UsernamePasswordTests {
             )
             // issue the challenge
             val challengeResponse = async {
-                authenticatorState.handleNetworkAuthenticationChallenge(challenge)
+                composeTestRule.activity.authenticatorState.handleNetworkAuthenticationChallenge(challenge)
             }
             // ensure the dialog prompt is displayed as expected
             advanceUntilIdle()
@@ -401,7 +409,7 @@ class UsernamePasswordTests {
                 R.string.username_password_login_message,
                 hostname
             )
-            assert(authenticatorState.pendingUsernamePasswordChallenge.value != null)
+            assert(composeTestRule.activity.authenticatorState.pendingUsernamePasswordChallenge.value != null)
             composeTestRule.onNodeWithText(usernamePasswordMessage).assertIsDisplayed()
 
             // simulate a configuration change
@@ -412,7 +420,7 @@ class UsernamePasswordTests {
 
             // ensure the dialog has disappeared
             advanceUntilIdle()
-            assert(authenticatorState.pendingUsernamePasswordChallenge.value == null)
+            assert(composeTestRule.activity.authenticatorState.pendingUsernamePasswordChallenge.value == null)
             composeTestRule.onNodeWithText(usernamePasswordMessage).assertDoesNotExist()
 
             // return the response deferred
@@ -438,13 +446,13 @@ class UsernamePasswordTests {
     fun arcGISTokenAuthentication() = runTest {
         with(StateRestorationTester(composeTestRule)) {
             setContent {
-                DialogAuthenticator(authenticatorState = authenticatorState)
+                DialogAuthenticator(authenticatorState = composeTestRule.activity.authenticatorState)
             }
             // issue the challenge
             val hostname = "arcgis.com"
             val challenge = makeMockArcGISAuthenticationChallenge()
             val challengeResponse = async {
-                authenticatorState.handleArcGISAuthenticationChallenge(challenge)
+                composeTestRule.activity.authenticatorState.handleArcGISAuthenticationChallenge(challenge)
             }
             // ensure the dialog prompt is displayed as expected
             advanceUntilIdle()
@@ -453,7 +461,7 @@ class UsernamePasswordTests {
                 R.string.username_password_login_message,
                 hostname
             )
-            assert(authenticatorState.pendingUsernamePasswordChallenge.value != null)
+            assert(composeTestRule.activity.authenticatorState.pendingUsernamePasswordChallenge.value != null)
             composeTestRule.onNodeWithText(usernamePasswordMessage).assertIsDisplayed()
 
             // simulate a configuration change
@@ -471,7 +479,7 @@ class UsernamePasswordTests {
             }
 
             // ensure the dialog has disappeared after last attempt
-            assert(authenticatorState.pendingUsernamePasswordChallenge.value == null)
+            assert(composeTestRule.activity.authenticatorState.pendingUsernamePasswordChallenge.value == null)
             composeTestRule.onNodeWithText(usernamePasswordMessage).assertDoesNotExist()
 
             assert(challengeResponse.await() is ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError)
@@ -497,13 +505,13 @@ class UsernamePasswordTests {
 
             // issue another challenge
             val challengeResponse2 = async {
-                authenticatorState.handleArcGISAuthenticationChallenge(challenge)
+                composeTestRule.activity.authenticatorState.handleArcGISAuthenticationChallenge(challenge)
             }
 
             // ensure the dialog prompt is displayed as expected
             advanceUntilIdle()
 
-            assert(authenticatorState.pendingUsernamePasswordChallenge.value != null)
+            assert(composeTestRule.activity.authenticatorState.pendingUsernamePasswordChallenge.value != null)
             composeTestRule.onNodeWithText(usernamePasswordMessage).assertIsDisplayed()
 
             // enter a username and password
@@ -515,7 +523,7 @@ class UsernamePasswordTests {
             assert(response2 is ArcGISAuthenticationChallengeResponse.ContinueWithCredential)
 
             // assert the dialog has been dismissed
-            assert(authenticatorState.pendingUsernamePasswordChallenge.value == null)
+            assert(composeTestRule.activity.authenticatorState.pendingUsernamePasswordChallenge.value == null)
             composeTestRule.onNodeWithText(usernamePasswordMessage).assertDoesNotExist()
         }
     }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/6080

<!-- link to design, if applicable -->

### Description:

PR to replace usage of AuthenticationManager.signOut() with AuthenticatorState.signOut()
A new Activity was created to use in tests so that I could add the AuthenticatorState to the ComposeTestRule's Activity, and have it cleaned up between tests.

FeatureForms usage will be addressed in a PR that targets its feature branch.



### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/804/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  