### PR TITLE
Add doc about API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ API_KEY=YOUR_ACCESS_TOKEN
 
 ### ArcGIS identity
 
-An ArcGIS named user account that is a member of an organization in ArcGIS Online or ArcGIS Enterprise.
+An ArcGIS named user account that is a member of an organization in ArcGIS Online or ArcGIS
+Enterprise.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ The template and TemplateApp modules are for bootstrapping new modules.
 
 Please see the [package structure](doc/general/developer_setup.md#package-structure) documentation for more details.
 
+## Accessing Esri location services
+
+Some tookit components may require access to Esri location services, including basemaps, routing,
+and geocoding, which requires authentication using either an API Key or an ArcGIS identity:
+
+### API key
+
+A long-lived access token that gives your application access to ArcGIS location services. Go to
+the [Create an API key](https://links.esri.com/create-an-api-key) tutorial to obtain a new API key
+access token. Ensure that the following privileges are enabled:
+
+* **Location services** > **Basemaps**
+* **Location services** > **Geocoding**
+* **Location services** > **Routing**
+
+The components in this repository have been structured to use an access token, set once.
+Set your access token in the `local.properties` in the same folder as the
+`secrets.defaults.properties` as shown below.
+
+```gradle
+API_KEY=YOUR_ACCESS_TOKEN
+```
+
+### ArcGIS identity
+
+An ArcGIS named user account that is a member of an organization in ArcGIS Online or ArcGIS Enterprise.
+
 ## Issues
 
 Find a bug or want to request a new feature enhancement? Please let us know by [submitting an issue](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/issues/new).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Please see the [package structure](doc/general/developer_setup.md#package-struct
 ## Accessing Esri location services
 
 Some toolkit components may require access to Esri location services, including basemaps, routing,
-and geocoding, which requires authentication using either an API Key or an ArcGIS identity:
+and geocoding, which requires authentication using either an API Key or an ArcGIS identity. The
+toolkit code is set up to easily use an API key.
 
 ### API key
 
@@ -93,7 +94,9 @@ API_KEY=YOUR_ACCESS_TOKEN
 ### ArcGIS identity
 
 An ArcGIS named user account that is a member of an organization in ArcGIS Online or ArcGIS
-Enterprise.
+Enterprise can be used as an alternative to API keys. To use this method will require code changes
+to be made. See [User authentication](https://developers.arcgis.com/kotlin/security-and-authentication/#user-authentication)
+for more information.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Please see the [package structure](doc/general/developer_setup.md#package-struct
 
 ## Accessing Esri location services
 
-Some tookit components may require access to Esri location services, including basemaps, routing,
+Some toolkit components may require access to Esri location services, including basemaps, routing,
 and geocoding, which requires authentication using either an API Key or an ArcGIS identity:
 
 ### API key

--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ API_KEY=YOUR_ACCESS_TOKEN
 ### ArcGIS identity
 
 An ArcGIS named user account that is a member of an organization in ArcGIS Online or ArcGIS
-Enterprise can be used as an alternative to API keys. To use this method will require code changes
-to be made. See [User authentication](https://developers.arcgis.com/kotlin/security-and-authentication/#user-authentication)
+Enterprise can be used as an alternative to API keys. Most toolkit micro apps don't make use of
+named user authentication.
+See [User authentication](https://developers.arcgis.com/kotlin/security-and-authentication/#user-authentication)
 for more information.
 
 ## Issues


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/5824

<!-- link to design, if applicable -->

### Description:

Adds doc about API key/ArcGIS identity for accessing Esri location services. This is heavily based on the samples [doc](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/tree/main?tab=readme-ov-file#api-key) which also mentions ArcGIS identity but doesn't explain much about it.

### Summary of changes:

- adds doc

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  