### PR TITLE
Offline map info - deletion bug fix

### DIFF
--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.arcgismaps.LoadStatus
 import com.arcgismaps.mapping.ArcGISMap
+import com.arcgismaps.mapping.LocalItem
 import com.arcgismaps.mapping.MobileMapPackage
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.tasks.offlinemaptask.OfflineMapTask
@@ -291,7 +292,9 @@ public class OfflineMapState(
         val mmpk = MobileMapPackage(areaDir.absolutePath).apply {
             load().getOrElse { return null }
         }
-        val item = mmpk.item ?: return null
+        val item = (mmpk.item as? LocalItem)?.apply {
+            itemId = portalItem.itemId
+        } ?: return null
 
         val preplannedMapAreaState = PreplannedMapAreaState(
             context = context,
@@ -336,7 +339,9 @@ public class OfflineMapState(
         val mmpk = MobileMapPackage(areaDir.absolutePath).apply {
             load().getOrElse { return null }
         }
-        val item = mmpk.item ?: return null
+        val item = (mmpk.item as? LocalItem)?.apply {
+            itemId = portalItem.itemId
+        } ?: return null
 
         val onDemandMapAreasState = OnDemandMapAreasState(
             context = context,


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#6117](https://devtopia.esri.com/runtime/kotlin/issues/6117)

<!-- link to design, if applicable -->

### Description:

PR to fix the issue of a valid OfflineMapInfo item persists with no areas. 

Feel free to test using the [demo app branch](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/tree/shubham/full-oma-experience).

### Summary of changes:

With the changes made in this PR when component is launched in offline mode, we have a valid `portalItem` which is required for the `removeOfflineMapInfo` when we remove downloaded map area for preplanned or on-demand state. This worked for online mode previously as we have a valid `portalItem`, and this PR provides one for offline mode:

```kotlin
internal fun removeDownloadedMapArea(shouldRemoveOfflineMapInfo: () -> Boolean) {
    if (OfflineRepository.deleteContentsForDirectory(mobileMapPackage.path)) {
        Log.d(TAG, "Deleted preplanned map area: ${mobileMapPackage.path}")
        // Reset the status to reflect the deletion
        _status = PreplannedStatus.NotLoaded
        if (shouldRemoveOfflineMapInfo()) {
            OfflineRepository.removeOfflineMapInfo(
                context = context,
                portalItemID = item.itemId
            )
        }
        val localScope = CoroutineScope(Dispatchers.IO)
        localScope.launch {
            initialize()
            localScope.cancel()
        }
    } else {
        Log.e(TAG, "Failed to delete preplanned map area: ${mobileMapPackage.path}")
    }
}
``` 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/810/