### PR TITLE
`FeatureForm`: Update UN Association Display Spec

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/UtilityAssociationsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/UtilityAssociationsFormElementTests.kt
@@ -209,7 +209,7 @@ class UtilityAssociationsFormElementTests {
         // Verify the associations are displayed
         listView = composeTestRule.onNode(hasScrollAction())
         val firstElement = listView.onChildWithText("Circuit Breaker").assertIsDisplayed()
-        firstElement.assert(hasText("Containment Visible : false"))
+        firstElement.assert(hasText("Content"))
     }
 
     /**

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/UtilityAssociationsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/UtilityAssociationsFormElementTests.kt
@@ -148,8 +148,8 @@ class UtilityAssociationsFormElementTests {
         val items = listView.onChildren().filter(hasText("Fuse"))
         items.assertCountEquals(2)
         // Verify the terminals are displayed
-        items[0].assert(hasText("Terminal : Single Terminal"))
-        items[1].assert(hasText("Terminal : Single Terminal"))
+        items[0].assert(hasText("Single Terminal"))
+        items[1].assert(hasText("Single Terminal"))
     }
 
     /**
@@ -270,7 +270,7 @@ class UtilityAssociationsFormElementTests {
         listView = composeTestRule.onNode(hasScrollAction())
 
         val firstElement = listView.onChildWithText("Substation").assertIsDisplayed()
-        firstElement.assert(hasText("Containment Visible : false").not())
+        firstElement.assert(hasText("Content").not())
     }
 
     /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureFormState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureFormState.kt
@@ -207,7 +207,8 @@ public class FeatureFormState private constructor(
         // Check if the active feature form is different from the current form.
         if (_activeFeatureForm.value != formStateData.featureForm) {
             _activeFeatureForm.value = formStateData.featureForm
-            _activeFeatureForm.value.feature.refresh()
+            // refresh the feature to ensure the latest data is loaded.
+            formStateData.featureForm.feature.refresh()
             if (formStateData.initialEvaluation.value.not()) {
                 formStateData.evaluateExpressions()
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureFormState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureFormState.kt
@@ -207,6 +207,7 @@ public class FeatureFormState private constructor(
         // Check if the active feature form is different from the current form.
         if (_activeFeatureForm.value != formStateData.featureForm) {
             _activeFeatureForm.value = formStateData.featureForm
+            _activeFeatureForm.value.feature.refresh()
             if (formStateData.initialEvaluation.value.not()) {
                 formStateData.evaluateExpressions()
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -487,11 +487,13 @@ internal fun AttachmentElementState.getNewAttachmentNameForContentType(
 }
 
 /**
- * Exception indicating that the attachment size exceeds the maximum limit.
+ * Exception indicating that the attachment size exceeds the limit.
  *
- * @param limit The maximum attachment size limit in bytes.
+ * @param limit The attachment size limit in bytes.
  */
-internal class AttachmentSizeLimitExceededException(val limit : Long) : Exception("Attachment size exceeds the maximum limit of $limit MB")
+internal class AttachmentSizeLimitExceededException(val limit: Long) : Exception(
+    "Attachment size exceeds the limit of ${limit/1_000_000} MB"
+)
 
 /**
  * Exception indicating that the attachment size is 0.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociations.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociations.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.Guid
@@ -214,9 +215,9 @@ private fun AssociationItem(
         is UtilityAssociationType.Containment -> {
             if (associatedFeature.globalId == association.toElement.globalId) {
                 supportingText = if (association.isContainmentVisible) {
-                    "Visible Content"
+                    stringResource(R.string.visible_content)
                 } else {
-                    "Content"
+                    stringResource(R.string.content)
                 }
             }
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociations.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociations.kt
@@ -20,12 +20,16 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
 import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -36,14 +40,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Composition
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.Guid
@@ -54,7 +55,6 @@ import com.arcgismaps.utilitynetworks.UtilityAssociationGroupResult
 import com.arcgismaps.utilitynetworks.UtilityAssociationType
 import com.arcgismaps.utilitynetworks.UtilityAssociationsFilterResult
 import com.arcgismaps.utilitynetworks.UtilityElement
-import com.arcgismaps.utilitynetworks.UtilityNetworkSourceType
 
 /**
  * Displays the provided [UtilityAssociationsFilterResult]. The filter result is displayed as a
@@ -167,13 +167,15 @@ internal fun UtilityAssociations(
 /**
  * Displays the provided [UtilityAssociation] and its associated feature.
  *
- * If the association is of type JunctionEdgeObjectConnectivityFromSide, JunctionEdgeObjectConnectivityToSide
- * or JunctionEdgeObjectConnectivityMidspan and the target feature is an edge, the fractionAlongEdge
- * is displayed. Otherwise, the terminal is displayed.
+ * The spec for displaying the association is based on the following rules:
  *
- * For a Connectivity association, the terminal is displayed.
+ * - If the association is of type JunctionEdgeObjectConnectivityMidspan, then only the fractionAlongEdge
+ * is displayed.
  *
- * For a Containment association, the isContainmentVisible property is displayed if the associated
+ * - If the association is of type JunctionEdgeObjectConnectivityFromSide, JunctionEdgeObjectConnectivityToSide
+ * or Connectivity then fractionAlongEdge and the terminal (if present) is displayed.
+ *
+ * - For a Containment association, the isContainmentVisible property is displayed if the associated
  * feature is the toElement.
  *
  */
@@ -188,90 +190,95 @@ private fun AssociationItem(
     modifier: Modifier = Modifier
 ) {
     val target = association.getTargetElement(associatedFeature)
-    val icon = association.getIcon(associatedFeature.globalId)
-    val (terminal, fractionAlongEdge) = when (association.associationType) {
-        is UtilityAssociationType.Connectivity -> {
-            Pair(target.terminal, null)
-        }
-
-        is UtilityAssociationType.JunctionEdgeObjectConnectivityFromSide,
-        UtilityAssociationType.JunctionEdgeObjectConnectivityToSide,
-        UtilityAssociationType.JunctionEdgeObjectConnectivityMidspan -> {
-            if (target.networkSource.sourceType == UtilityNetworkSourceType.Edge) {
-                Pair(null, association.fractionAlongEdge)
-            } else {
-                Pair(target.terminal, null)
+    val icon = association.getIcon()
+    // Text to display at the end of the row.
+    var trailingText = ""
+    // Text to display below the title.
+    var supportingText = ""
+    when (association.associationType) {
+        is UtilityAssociationType.JunctionEdgeObjectConnectivityMidspan -> {
+            trailingText = "${(association.fractionAlongEdge * 100).toInt()}%"
+            target.terminal?.let { terminal ->
+                supportingText = terminal.name
             }
         }
 
-        else -> {
-            Pair(null, null)
-        }
-    }
-    val trailingText = when {
-        terminal != null -> {
-            stringResource(R.string.terminal_with_value, terminal.name)
-        }
-
-        fractionAlongEdge != null -> {
-            "$fractionAlongEdge %"
+        is UtilityAssociationType.Connectivity,
+        UtilityAssociationType.JunctionEdgeObjectConnectivityFromSide,
+        UtilityAssociationType.JunctionEdgeObjectConnectivityToSide -> {
+            target.terminal?.let { terminal ->
+                supportingText = terminal.name
+            }
         }
 
-        association.associationType is UtilityAssociationType.Containment &&
-            associatedFeature.globalId == association.toElement.globalId -> {
-            stringResource(R.string.containment_visible_value, association.isContainmentVisible)
+        is UtilityAssociationType.Containment -> {
+            if (associatedFeature.globalId == association.toElement.globalId) {
+                supportingText = if (association.isContainmentVisible) {
+                    "Visible Content"
+                } else {
+                    "Content"
+                }
+            }
         }
 
-        else -> ""
+        else -> {}
     }
     val contentColor = if (enabled) {
         LocalContentColor.current
     } else {
         MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
     }
-    Column(modifier = modifier.clickable(enabled = enabled, onClick = onClick)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            if (icon != null) {
-                Icon(
-                    painter = icon,
-                    contentDescription = "feature association icon",
-                    modifier = Modifier.padding(
-                        end = 12.dp
-                    )
+    Row(
+        modifier = modifier
+            .clickable(enabled = enabled, onClick = onClick)
+            .height(56.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        if (icon != null) {
+            Icon(
+                painter = icon,
+                contentDescription = "feature association icon",
+                modifier = Modifier.padding(
+                    end = 12.dp
                 )
-            }
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.Start
-            ) {
+            )
+        }
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.Start
+        ) {
+            Text(
+                text = title,
+                modifier = Modifier.padding(
+                    top = if (supportingText.isNotEmpty()) 6.dp else 0.dp,
+                ),
+                style = MaterialTheme.typography.bodyLarge,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                color = contentColor
+            )
+            if (supportingText.isNotEmpty()) {
                 Text(
-                    text = title,
-                    modifier = Modifier.padding(
-                        top = if (trailingText.isNotEmpty()) 6.dp else 0.dp,
-                    ),
-                    style = MaterialTheme.typography.bodyLarge,
+                    text = supportingText,
+                    modifier = Modifier
+                        .padding(
+                            bottom = 6.dp
+                        ),
+                    style = MaterialTheme.typography.bodyMedium,
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
                     color = contentColor
                 )
-                if (trailingText.isNotEmpty()) {
-                    Text(
-                        text = trailingText,
-                        modifier = Modifier
-                            .padding(
-                                bottom = 6.dp
-                            ),
-                        style = MaterialTheme.typography.bodyMedium,
-                        overflow = TextOverflow.Ellipsis,
-                        maxLines = 1,
-                        color = contentColor
-                    )
-                }
+            }
+        }
+        if (trailingText.isNotEmpty()) {
+            Card(modifier = Modifier.wrapContentSize()) {
+                Text(text = trailingText, modifier = Modifier.padding(8.dp))
             }
         }
     }
@@ -295,22 +302,26 @@ internal val ArcGISFeature.globalId: Guid
     get() = attributes["globalid"] as Guid
 
 /**
- * Returns an icon for the association based on the association type and the GUID of the target element.
+ * Returns an icon for the association based on the association type.
  */
 @Composable
-internal fun UtilityAssociation.getIcon(targetElementGuid: Guid): Painter? {
+internal fun UtilityAssociation.getIcon(): Painter? {
     return when (this.associationType) {
+
+        is UtilityAssociationType.Connectivity -> {
+            painterResource(R.drawable.connection_to_connection)
+        }
+
+        is UtilityAssociationType.JunctionEdgeObjectConnectivityFromSide -> {
+            painterResource(R.drawable.connection_end_left)
+        }
+
         is UtilityAssociationType.JunctionEdgeObjectConnectivityMidspan -> {
             painterResource(R.drawable.connection_mid)
         }
 
-        is UtilityAssociationType.Connectivity, UtilityAssociationType.JunctionEdgeObjectConnectivityFromSide,
-        UtilityAssociationType.JunctionEdgeObjectConnectivityToSide -> {
-            if (targetElementGuid == fromElement.globalId) {
-                painterResource(R.drawable.connection_end_left)
-            } else {
-                painterResource(R.drawable.connection_end_right)
-            }
+        is UtilityAssociationType.JunctionEdgeObjectConnectivityToSide -> {
+            painterResource(R.drawable.connection_end_right)
         }
 
         else -> null

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociations.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociations.kt
@@ -191,7 +191,6 @@ private fun AssociationItem(
     modifier: Modifier = Modifier
 ) {
     val target = association.getTargetElement(associatedFeature)
-    val icon = association.getIcon()
     // Text to display at the end of the row.
     var trailingText = ""
     // Text to display below the title.
@@ -237,7 +236,7 @@ private fun AssociationItem(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        if (icon != null) {
+        association.getIcon()?.let { icon ->
             Icon(
                 painter = icon,
                 contentDescription = "feature association icon",

--- a/toolkit/featureforms/src/main/res/drawable/connection_to_connection.xml
+++ b/toolkit/featureforms/src/main/res/drawable/connection_to_connection.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M27.5,13.1a3.39,3.39 0,0 0,-3.35 2.9H8.85a3.39,3.39 0,0 0,-3.35 -2.9,3.4 3.4,0 0,0 0,6.8A3.39,3.39 0,0 0,8.85 17h15.3a3.39,3.39 0,0 0,3.35 2.9,3.4 3.4,0 1,0 0,-6.8m-22,5.8c-1.323,0 -2.4,-1.077 -2.4,-2.4s1.077,-2.4 2.4,-2.4 2.4,1.077 2.4,2.4 -1.077,2.4 -2.4,2.4m22,0c-1.323,0 -2.4,-1.077 -2.4,-2.4s1.077,-2.4 2.4,-2.4 2.4,1.077 2.4,2.4 -1.077,2.4 -2.4,2.4"/>
+</vector>

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -162,7 +162,6 @@
     <string name="terminal">Terminal</string>
     <string name="terminal_with_value">Terminal : %1$s</string>
     <string name="containment_visible">Containment Visible</string>
-    <string name="containment_visible_value">Containment Visible : %1$s</string>
     <string name="fraction_along_edge">Fraction Along Edge</string>
     <string name="from_element">From Element</string>
     <string name="to_element">To Element</string>
@@ -172,6 +171,8 @@
     <string name="remove">Remove</string>
     <string name="association_settings">Association Settings</string>
     <string name="percent_along_edge">%1$d %%</string>
+    <string name="visible_content">Visible Content</string>
+    <string name="content">Content</string>
     <plurals name="you_have_errors_that_must_be_fixed_before_saving">
         <item quantity="zero">You have %1$d errors that must be fixed before saving.</item>
         <item quantity="one">You have %1$d error that must be fixed before saving.</item>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[kotlin/6148](https://devtopia.esri.com/runtime/kotlin/issues/6148)

<!-- link to design, if applicable -->

### Description:

This PR updates the toolkit to follow the latest spec for displaying UNA properties and behavior.

### Summary of changes:

- The properties for a displayed association have been updated according to the spec [here](https://devtopia.esri.com/runtime/kotlin/issues/6148).
- `Feature.refresh()` is now called when navigating forward/backward to a feature to trigger any attribute rule changes. See [apollo/1168](https://devtopia.esri.com/runtime/apollo/issues/1168).
- Fixed a size conversion issue in the `AttachmentSizeLimitExceededException` class.

Test data available in the linked issue.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/843/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes (navigation tests are failing due to unrelated service issues)
  - [ ] No
  