### PR TITLE
test oauth with user provided Activity for challeneges using BrowserA…

### DIFF
--- a/toolkit/authentication/src/androidTest/AndroidManifest.xml
+++ b/toolkit/authentication/src/androidTest/AndroidManifest.xml
@@ -45,7 +45,25 @@
                     android:host="auth"
                     android:scheme="kotlin-authentication-test-2" />
             </intent-filter>
-            </activity>
+        </activity>
+        <activity android:name="com.arcgismaps.toolkit.authentication.BrowserUserLauncherTestActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:taskAffinity="">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="auth"
+                    android:scheme="kotlin-authentication-test-browser" />
+            </intent-filter>
+        </activity>
         <activity android:name="com.arcgismaps.toolkit.authentication.AuthenticatorStateActivity"
             android:exported="true">
             <intent-filter>

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Esri
+ *  Copyright 2025 Esri
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -46,14 +46,17 @@ import org.junit.Rule
 import org.junit.Test
 
 /**
- * Tests the [Authenticator] against OAuth challenges when the Custom Chrome Tab is launched from a user activity
+ * Tests the [Authenticator] against OAuth challenges when the Custom Chrome Tab is launched from a
+ * user activity using the general purpose Authenticator composable, which supports both OAuth and
+ * IAP sign ins via a trailing lambda which provides a [BrowserAuthenticationChallenge] as a
+ * parameter.
  *
- * @since 200.5.0
+ * @since 200.8.0
  */
-class OAuthUserLauncherTests {
+class BrowserUserLauncherTests {
 
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<OAuthUserLauncherTestActivity>()
+    val composeTestRule = createAndroidComposeRule<BrowserUserLauncherTestActivity>()
 
     @Before
     fun signOutBefore() = signOut()
@@ -72,13 +75,15 @@ class OAuthUserLauncherTests {
 
     /**
      * Given an [AuthenticatorState] configured with an [OAuthUserConfiguration] for ArcGIS Online,
-     * When an [ArcGISAuthenticationChallenge] is received and the OAuth browser redirects with a successful response,
-     * Then the [ArcGISAuthenticationChallengeResponse] should be [ArcGISAuthenticationChallengeResponse.ContinueWithCredential].
+     * When an [ArcGISAuthenticationChallenge] is received and the OAuth browser redirects with a
+     * successful response,
+     * Then the [ArcGISAuthenticationChallengeResponse] should be
+     * [ArcGISAuthenticationChallengeResponse.ContinueWithCredential].
      *
-     * Note: This function automatically redirects to the app with a successful response without user input,
-     * and fakes the token validation response.
+     * Note: This function automatically redirects to the app with a successful response without
+     * user input, and fakes the token validation response.
      *
-     * @since 200.5.0
+     * @since 200.8.0
      */
     @Test
     fun successfulSignIn() = runTest {
@@ -92,18 +97,23 @@ class OAuthUserLauncherTests {
             // When the OAuth sign in screen displays, we simulate successful sign in by launching an
             // intent with the expected redirect URL, which otherwise would be sent from the Portal
             // server, but would require valid credentials
-            InstrumentationRegistry.getInstrumentation().context.startActivity(createSuccessfulRedirectIntent("kotlin-authentication-test-2://auth"))
+            InstrumentationRegistry.getInstrumentation().context.startActivity(
+                createSuccessfulRedirectIntent("kotlin-authentication-test-browser://auth")
+            )
         }.await().getOrNull()
         assert(response is ArcGISAuthenticationChallengeResponse.ContinueWithCredential)
-        assert((response as ArcGISAuthenticationChallengeResponse.ContinueWithCredential).credential is OAuthUserCredential)
+        assert(
+            (response as ArcGISAuthenticationChallengeResponse.ContinueWithCredential).credential is OAuthUserCredential
+        )
     }
 
     /**
      * Given an [AuthenticatorState] configured with an [OAuthUserConfiguration] for ArcGIS Online,
      * When an [ArcGISAuthenticationChallenge] is received and the user cancels the sign in process,
-     * Then the [ArcGISAuthenticationChallengeResponse] should be [ArcGISAuthenticationChallengeResponse.Cancel].
+     * Then the [ArcGISAuthenticationChallengeResponse] should be
+     * [ArcGISAuthenticationChallengeResponse.Cancel].
      *
-     * @since 200.5.0
+     * @since 200.8.0
      */
     @Test
     fun cancelSignIn() = runTest {
@@ -116,9 +126,10 @@ class OAuthUserLauncherTests {
     /**
      * Given an [AuthenticatorState] configured with an [OAuthUserConfiguration] for ArcGIS Online,
      * When an [ArcGISAuthenticationChallenge] is received and the user presses the back button,
-     * Then the [ArcGISAuthenticationChallengeResponse] should be [ArcGISAuthenticationChallengeResponse.Cancel].
+     * Then the [ArcGISAuthenticationChallengeResponse] should be
+     * [ArcGISAuthenticationChallengeResponse.Cancel].
      *
-     * @since 200.5.0
+     * @since 200.8.0
      */
     @Test
     fun pressBack() = runTest {
@@ -131,10 +142,10 @@ class OAuthUserLauncherTests {
     /**
      * Places an [Authenticator] in the composition and issues an OAuth challenge.
      * Once the browser is launched, [userInputOnDialog] will be called to simulate user input.
-     * Also, the device will be rotated to ensure that the Authenticator can handle configuration changes
-     * before calling [userInputOnDialog].
+     * Also, the device will be rotated to ensure that the Authenticator can handle configuration
+     * changes before calling [userInputOnDialog].
      *
-     * @since 200.5.0
+     * @since 200.8.0
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun TestScope.testOAuthChallengeWithStateRestoration(
@@ -179,19 +190,20 @@ class OAuthUserLauncherTests {
 }
 
 /**
- * This activity is used to test the Authenticator when the Custom Chrome Tab is launched from a user activity
+ * This activity is used to test the Authenticator when the Custom Chrome Tab is launched from a
+ * user activity. The Activity's content contains  the [Authenticator] composable for which the
+ * trailing lambda provides a [BrowserAuthenticationChallenge] parameter.
  *
- * @since 200.5.0
+ * @since 200.8.0
  */
-@Suppress("DEPRECATION")
-class OAuthUserLauncherTestActivity : ComponentActivity() {
-    val viewModel: OAuthUserLauncherTestViewModel by viewModels()
+class BrowserUserLauncherTestActivity : ComponentActivity() {
+    val viewModel: BrowserUserLauncherTestViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             Authenticator(
                 authenticatorState = viewModel.authenticatorState,
-                onPendingOAuthUserSignIn = {
+                onPendingBrowserAuthenticationChallenge = {
                     launchCustomTabs(it)
                 }
             )
@@ -200,22 +212,21 @@ class OAuthUserLauncherTestActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        viewModel.authenticatorState.completeOAuthSignIn(intent)
+        viewModel.authenticatorState.completeBrowserAuthenticationChallenge(intent)
     }
 
     override fun onResume() {
         super.onResume()
-        viewModel.authenticatorState.completeOAuthSignIn(intent)
+        viewModel.authenticatorState.completeBrowserAuthenticationChallenge(intent)
     }
 }
 
 /**
- * ViewModel for the [OAuthUserLauncherTestActivity] that contains the [AuthenticatorState] for testing
+ * ViewModel for the [BrowserUserLauncherTestActivity] that contains the [AuthenticatorState] for testing
  *
- * @since 200.5.0
- *
+ * @since 200.8.0
  */
-class OAuthUserLauncherTestViewModel : ViewModel() {
+class BrowserUserLauncherTestViewModel : ViewModel() {
     val authenticatorState = AuthenticatorState().apply {
         oAuthUserConfiguration = OAuthUserConfiguration(
             "https://arcgis.com/",
@@ -223,7 +234,7 @@ class OAuthUserLauncherTestViewModel : ViewModel() {
             // create your own client ID. For more info see:
             // https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/register-your-application/
             "SmYakFwlYRYWEJAR",
-            "kotlin-authentication-test-2://auth"
+            "kotlin-authentication-test-browser://auth"
         )
     }
 }


### PR DESCRIPTION
…uthenticationChallenge

<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/6153

<!-- link to design, if applicable -->

### Description:

adds test of new Authenticator composable

### Summary of changes:

- new test class and Activity so we can continue having a single compose test rule per test class, which makes things simple
- new redirectUrl registered on AGOL with existing client id. so the device doesn't ask which Activity to use for Intent resolution
- mostly identical tests to existing OAuthUserLauncherTests

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/844/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  