### PR TITLE
Colinanderson/issue 4702

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ androidxComposeCompiler = "1.5.12"
 androidxCore = "1.16.0"
 androidxEspresso = "3.6.1"
 androidxHiltNavigationCompose = "1.2.0"
-androidxLifecycle = "2.8.7"
 androidxMaterialIcons = "1.7.8"
 androidxTestExt = "1.2.1"
 androidXTestRunner = "1.6.2"
@@ -60,7 +59,6 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest"}
 androidx-compose-ui-util = { group = "androidx.compose.ui", name = "ui-util"}
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHiltNavigationCompose" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose"}
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose"}
 androidx-material-icons = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "androidxMaterialIcons"}

--- a/microapps/ArFlyoverApp/app/build.gradle.kts
+++ b/microapps/ArFlyoverApp/app/build.gradle.kts
@@ -86,7 +86,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/ArTabletopApp/app/build.gradle.kts
+++ b/microapps/ArTabletopApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/microapps/ArWorldScaleApp/app/build.gradle.kts
+++ b/microapps/ArWorldScaleApp/app/build.gradle.kts
@@ -86,7 +86,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/AuthenticationApp/app/build.gradle.kts
+++ b/microapps/AuthenticationApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/BasemapGalleryApp/app/build.gradle.kts
+++ b/microapps/BasemapGalleryApp/app/build.gradle.kts
@@ -85,7 +85,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/CompassApp/app/build.gradle.kts
+++ b/microapps/CompassApp/app/build.gradle.kts
@@ -83,7 +83,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -98,7 +98,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.navigation)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/microapps/FloorFilterApp/app/build.gradle.kts
+++ b/microapps/FloorFilterApp/app/build.gradle.kts
@@ -66,7 +66,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/LegendApp/app/build.gradle.kts
+++ b/microapps/LegendApp/app/build.gradle.kts
@@ -85,7 +85,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/MapViewCalloutApp/app/build.gradle.kts
+++ b/microapps/MapViewCalloutApp/app/build.gradle.kts
@@ -83,7 +83,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.compose.navigation)

--- a/microapps/MapViewGeometryEditorApp/app/build.gradle.kts
+++ b/microapps/MapViewGeometryEditorApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(platform(libs.androidx.compose.bom))

--- a/microapps/MapViewIdentifyApp/app/build.gradle.kts
+++ b/microapps/MapViewIdentifyApp/app/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
+
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(platform(libs.androidx.compose.bom))

--- a/microapps/MapViewIdentifyApp/app/build.gradle.kts
+++ b/microapps/MapViewIdentifyApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(platform(libs.androidx.compose.bom))

--- a/microapps/MapViewInsetsApp/app/build.gradle.kts
+++ b/microapps/MapViewInsetsApp/app/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
+
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(platform(libs.androidx.compose.bom))

--- a/microapps/MapViewInsetsApp/app/build.gradle.kts
+++ b/microapps/MapViewInsetsApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(platform(libs.androidx.compose.bom))

--- a/microapps/MapViewLocationDisplayApp/app/build.gradle.kts
+++ b/microapps/MapViewLocationDisplayApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(platform(libs.androidx.compose.bom))

--- a/microapps/MapViewSetViewpointApp/app/build.gradle.kts
+++ b/microapps/MapViewSetViewpointApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(platform(libs.androidx.compose.bom))

--- a/microapps/MicroappsLib/build.gradle.kts
+++ b/microapps/MicroappsLib/build.gradle.kts
@@ -62,7 +62,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     debugImplementation(libs.bundles.debug)

--- a/microapps/OfflineMapAreasApp/app/build.gradle.kts
+++ b/microapps/OfflineMapAreasApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/OverviewMapApp/app/build.gradle.kts
+++ b/microapps/OverviewMapApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/PopupApp/app/build.gradle.kts
+++ b/microapps/PopupApp/app/build.gradle.kts
@@ -89,7 +89,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/ScalebarApp/app/build.gradle.kts
+++ b/microapps/ScalebarApp/app/build.gradle.kts
@@ -85,7 +85,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/SceneViewAnalysisOverlayApp/app/build.gradle.kts
+++ b/microapps/SceneViewAnalysisOverlayApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/SceneViewCalloutApp/app/build.gradle.kts
+++ b/microapps/SceneViewCalloutApp/app/build.gradle.kts
@@ -83,7 +83,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/SceneViewCameraControllerApp/app/build.gradle.kts
+++ b/microapps/SceneViewCameraControllerApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/SceneViewLightingOptionsApp/app/build.gradle.kts
+++ b/microapps/SceneViewLightingOptionsApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/SceneViewSetViewpointApp/app/build.gradle.kts
+++ b/microapps/SceneViewSetViewpointApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(platform(libs.androidx.compose.bom))

--- a/microapps/TemplateApp/app/build.gradle.kts
+++ b/microapps/TemplateApp/app/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.bundles.unitTest)

--- a/microapps/UtilityNetworkTraceApp/app/build.gradle.kts
+++ b/microapps/UtilityNetworkTraceApp/app/build.gradle.kts
@@ -85,7 +85,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     debugImplementation(libs.bundles.debug)

--- a/toolkit/ar/build.gradle.kts
+++ b/toolkit/ar/build.gradle.kts
@@ -108,7 +108,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.play.services.location)
     testImplementation(libs.bundles.unitTest)

--- a/toolkit/ar/src/androidTest/java/com/arcgismaps/toolkit/ar/VPSAvailabilityTests.kt
+++ b/toolkit/ar/src/androidTest/java/com/arcgismaps/toolkit/ar/VPSAvailabilityTests.kt
@@ -58,7 +58,7 @@ class VPSAvailabilityTests {
      *
      * @since 200.8.0
      */
-    @Ignore("Requires ARCore installation + API key")
+    //@Ignore("Requires ARCore installation + API key")
     @Test
     fun testVPSAvailability() = runTest {
         // check ARCore is installed

--- a/toolkit/ar/src/androidTest/java/com/arcgismaps/toolkit/ar/VPSAvailabilityTests.kt
+++ b/toolkit/ar/src/androidTest/java/com/arcgismaps/toolkit/ar/VPSAvailabilityTests.kt
@@ -58,7 +58,7 @@ class VPSAvailabilityTests {
      *
      * @since 200.8.0
      */
-    //@Ignore("Requires ARCore installation + API key")
+    @Ignore("Requires ARCore installation + API key")
     @Test
     fun testVPSAvailability() = runTest {
         // check ARCore is installed

--- a/toolkit/basemapgallery/build.gradle.kts
+++ b/toolkit/basemapgallery/build.gradle.kts
@@ -90,7 +90,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     testImplementation(libs.bundles.unitTest)
     androidTestImplementation(libs.bundles.composeTest)

--- a/toolkit/compass/build.gradle.kts
+++ b/toolkit/compass/build.gradle.kts
@@ -83,7 +83,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     testImplementation(libs.bundles.unitTest)
     androidTestImplementation(libs.bundles.composeTest)

--- a/toolkit/composable-map/build.gradle.kts
+++ b/toolkit/composable-map/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     testImplementation(libs.bundles.unitTest)
     androidTestImplementation(libs.bundles.composeTest)

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -132,7 +132,6 @@ dependencies {
     implementation(libs.bundles.composeCore)
     implementation(libs.androidx.compose.ui.util)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.material.icons)
     implementation(libs.bundles.camerax)

--- a/toolkit/geoview-compose/build.gradle.kts
+++ b/toolkit/geoview-compose/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     testImplementation(libs.bundles.unitTest)
     androidTestImplementation(libs.bundles.composeTest)

--- a/toolkit/indoors/build.gradle.kts
+++ b/toolkit/indoors/build.gradle.kts
@@ -79,7 +79,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.material.icons)

--- a/toolkit/legend/build.gradle.kts
+++ b/toolkit/legend/build.gradle.kts
@@ -99,7 +99,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     testImplementation(libs.bundles.unitTest)
     androidTestImplementation(libs.bundles.composeTest)

--- a/toolkit/offline/build.gradle.kts
+++ b/toolkit/offline/build.gradle.kts
@@ -100,7 +100,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.androidx.material.icons)

--- a/toolkit/popup/build.gradle.kts
+++ b/toolkit/popup/build.gradle.kts
@@ -98,7 +98,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.material.icons)
     implementation(libs.androidx.media3.exoplayer)

--- a/toolkit/scalebar/build.gradle.kts
+++ b/toolkit/scalebar/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     testImplementation(libs.bundles.unitTest)
     androidTestImplementation(libs.bundles.composeTest)

--- a/toolkit/template/build.gradle.kts
+++ b/toolkit/template/build.gradle.kts
@@ -77,7 +77,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     testImplementation(libs.bundles.unitTest)
     androidTestImplementation(libs.bundles.composeTest)

--- a/toolkit/utilitynetworks/build.gradle.kts
+++ b/toolkit/utilitynetworks/build.gradle.kts
@@ -115,7 +115,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeCore)
     implementation(libs.bundles.core)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.navigation)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/4702

<!-- link to design, if applicable -->

### Description:

Based on [this](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.0) "lifecycle-runtime-ktx is now empty, with all APIs being moved into lifecycle-runtime."

### Summary of changes:

- remove lifecycle-runtime-ktx dependency

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/200.8.0/job/vtest/job/toolkit/10/consoleFull
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  