### PR TITLE
Make localMap property settable only in OfflineState

### DIFF
--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -118,6 +118,7 @@ public class OfflineMapState {
         get() = _mode
 
     internal lateinit var localMap: ArcGISMap
+        private set
 
     private lateinit var offlineMapTask: OfflineMapTask
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Currently localMap property is modifiable from anywhere in the module. We should encapsulate it to only offlineState 

### Summary of changes:

- Make the setter for localMap private

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/Release/job/200.8.0/job/vtest/view/vTest/job/toolkit/14/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  