### PR TITLE
SceneViewLightingOptionsApp: update sun time dialog

### DIFF
--- a/microapps/SceneViewLightingOptionsApp/app/src/main/java/com/arcgismaps/toolkit/sceneviewlightingoptionsapp/screens/MainScreen.kt
+++ b/microapps/SceneViewLightingOptionsApp/app/src/main/java/com/arcgismaps/toolkit/sceneviewlightingoptionsapp/screens/MainScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
@@ -288,6 +290,7 @@ fun SunTimeOptions(
             modifier = Modifier
                 .width(IntrinsicSize.Min)
                 .height(IntrinsicSize.Min)
+                .verticalScroll(rememberScrollState())
                 .background(
                     shape = MaterialTheme.shapes.extraLarge,
                     color = MaterialTheme.colorScheme.surface


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/6225

<!-- link to design, if applicable -->

### Description:

<img width="2424" height="1080" alt="image" src="https://github.com/user-attachments/assets/7a4496c0-e703-45c5-a3cf-ffa380cfbf1e" />

The sun time dialog in the microapp does not display the TimePicker correctly in landscape mode. After researching the docs and various stack overflow posts, it seems like this is not an isolated issue on our end, or at least, ensuring a TimePicker displays correctly is not trivial. On my own testing I found that using TimeInput instead results in acceptable behavior, and is a small change without affecting the functionality of the microapp, so this PR just changes the dialog to use a TimeInput instead.

### Summary of changes:

- Use `TimeInput` instead of `TimePicker`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/Release/job/200.8.0/job/vtest/job/toolkit/16/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [x] No
  