### PR TITLE
Popup UI reactive enhancements 

### DIFF
--- a/microapps/PopupApp/app/src/main/java/com/arcgismaps/toolkit/popupapp/screens/mapscreen/MainScreen.kt
+++ b/microapps/PopupApp/app/src/main/java/com/arcgismaps/toolkit/popupapp/screens/mapscreen/MainScreen.kt
@@ -21,11 +21,7 @@
 package com.arcgismaps.toolkit.popupapp.screens.mapscreen
 
 import android.widget.Toast
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -68,19 +64,8 @@ fun MainScreen(viewModel: MapViewModel) {
     )
     BottomSheetScaffold(
         sheetContent = {
-            AnimatedVisibility(
-                visible = viewModel.popup != null,
-                enter = slideInVertically { h -> h },
-                exit = slideOutVertically { h -> h },
-                label = "popup",
-                modifier = Modifier.heightIn(min = 0.dp, max = 400.dp)
-            ) {
-                if (viewModel.popup != null) {
-                    Popup(
-                        viewModel.popup!!,
-                        modifier = Modifier.fillMaxSize()
-                    )
-                }
+            if (viewModel.popup != null) {
+                Popup(viewModel.popup!!)
             }
         },
         modifier = Modifier.fillMaxSize(),

--- a/microapps/PopupApp/app/src/main/java/com/arcgismaps/toolkit/popupapp/screens/mapscreen/MainScreen.kt
+++ b/microapps/PopupApp/app/src/main/java/com/arcgismaps/toolkit/popupapp/screens/mapscreen/MainScreen.kt
@@ -21,6 +21,7 @@
 package com.arcgismaps.toolkit.popupapp.screens.mapscreen
 
 import android.widget.Toast
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomSheetScaffold
@@ -65,7 +66,7 @@ fun MainScreen(viewModel: MapViewModel) {
     BottomSheetScaffold(
         sheetContent = {
             if (viewModel.popup != null) {
-                Popup(viewModel.popup!!)
+                Popup(viewModel.popup!!, Modifier.animateContentSize())
             }
         },
         modifier = Modifier.fillMaxSize(),

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
@@ -105,7 +105,6 @@ public fun Popup(popup: Popup, modifier: Modifier = Modifier) {
  */
 private val attachments: MutableList<PopupAttachment> = mutableListOf()
 
-@Suppress("unused_parameter")
 @Composable
 private fun Popup(popupState: PopupState, modifier: Modifier = Modifier) {
     val popup = popupState.popup

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
@@ -142,7 +142,7 @@ private fun Popup(popupState: PopupState, modifier: Modifier = Modifier) {
         evaluated = true
     }
 
-    Popup(popupState, evaluated && fetched, lastUpdatedEntityId)
+    Popup(popupState, evaluated && fetched, lastUpdatedEntityId, modifier)
 }
 
 @Composable

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/Popup.kt
@@ -21,7 +21,6 @@ package com.arcgismaps.toolkit.popup
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -157,7 +156,7 @@ private fun Popup(popupState: PopupState, initialized: Boolean, refreshed: Long,
         }
     }
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
@@ -199,9 +198,7 @@ private fun PopupBody(
     val lazyListState = rememberLazyListState()
     val states = rememberStates(popup, attachments)
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .semantics { contentDescription = "lazy column" },
+        modifier = Modifier.semantics { contentDescription = "lazy column" },
         state = lazyListState
     ) {
         states.forEach { entry ->


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[6358](https://devtopia.esri.com/runtime/kotlin/issues/6358)

<!-- link to design, if applicable -->

### Description:
 
PR to update the Popup's UI to handle user Modifier content sizes dynamically. (`fillMaxSize` & `wrapContentSize` etc). Currently, a `fillMaxSize` Modifier is hard-coded within the `Popup` root Column. 

This PR aims to update the UI to adapt the `Popup` composable to react dynamically towards constraint sizes between Modifier content size changes, and composable content changes.   

### Summary of changes:

- Removed `fillMaxSize` from `Popup`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/863/
  