### PR TITLE
`FeatureForm` : Micro-app datastore updates

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/MainActivity.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/MainActivity.kt
@@ -79,6 +79,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -160,11 +161,10 @@ class MainActivity : ComponentActivity() {
         // create and set a NetworkCredentialStore that persists
         val networkCredentialStore = NetworkCredentialStore.createWithPersistence().getOrThrow()
         ArcGISEnvironment.authenticationManager.networkCredentialStore = networkCredentialStore
-        // get the portal settings url
-        val url = portalSettings.getPortalUrl()
         // check if any credentials are present for this portal
-        val credential =
-            ArcGISEnvironment.authenticationManager.arcGISCredentialStore.getCredential(url)
+        val credential = portalSettings.getPortalUser()?.let { user ->
+            ArcGISEnvironment.authenticationManager.arcGISCredentialStore.getCredential(user.portal.url)
+        }
         appState.value = if (credential == null) {
             // if the portal connection type set it Anonymous, then the user has skipped sign in
             if (portalSettings.getPortalConnection() == Portal.Connection.Anonymous) {

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/MainActivity.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/MainActivity.kt
@@ -79,7 +79,6 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalItemRepository.kt
@@ -19,7 +19,6 @@
 package com.arcgismaps.toolkit.featureformsapp.data
 
 import android.util.Log
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.portal.Portal
 import com.arcgismaps.portal.PortalFolder
@@ -33,6 +32,7 @@ import com.arcgismaps.toolkit.featureformsapp.data.network.ItemRemoteDataSource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.joinAll
@@ -145,12 +145,8 @@ class PortalItemRepository(
     /**
      * Returns the username of the currently signed-in user.
      */
-    fun getUsername(): String? {
-        val credential =
-            ArcGISEnvironment.authenticationManager.arcGISCredentialStore.getCredential(
-                portalSettings.getPortalUrl()
-            )
-        return credential?.username
+    suspend fun getUsername(): String? {
+        return portalSettings.user.firstOrNull()?.username
     }
 
     suspend fun searchItems(query: PortalQueryParameters): Result<PortalQueryResultSet<PortalItem>> {

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalSettings.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalSettings.kt
@@ -17,60 +17,132 @@
 package com.arcgismaps.toolkit.featureformsapp.data
 
 import android.content.Context
-import android.content.SharedPreferences
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.portal.Portal
+import com.arcgismaps.portal.PortalUser
 import com.arcgismaps.toolkit.authentication.signOut
 import com.arcgismaps.toolkit.featureformsapp.R
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+private val Context.portalPreferences: DataStore<Preferences> by preferencesDataStore(name = "portal_settings")
+private val URL_KEY = stringPreferencesKey("url")
+private val PORTAL_USER_KEY = stringPreferencesKey("portal_user")
+private val PORTAL_CONNECTION_KEY = intPreferencesKey("portal_connection")
+
 class PortalSettings(
-    context: Context
+    context: Context,
+    scope: CoroutineScope
 ) {
-    private val preferences: SharedPreferences =
-        context.getSharedPreferences("portal_settings", Context.MODE_PRIVATE)
+    private val preferences = context.portalPreferences
+
+    private val _user: MutableStateFlow<PortalUser?> = MutableStateFlow(null)
+
+    /**
+     * The current portal user, or null if not logged in. Observe this to get updates when the user changes.
+     *
+     * See [getPortalUser] for how to retrieve the user directly.
+     */
+    val user: StateFlow<PortalUser?> = _user.asStateFlow()
 
     val defaultPortalUrl: String = context.getString(R.string.agol_portal_url)
 
-    private val urlKey = "url"
-    private val connectionKey = "connection"
+    init {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            // Load the initial portal user from preferences, if available
+            _user.value = getPortalUser()
+        }
+    }
 
-    fun getPortalConnection() : Portal.Connection {
-        val connection = preferences.getInt(connectionKey, 0)
-        return if (connection == 0) {
+    /**
+     * Retrieves the current portal connection state.
+     */
+    suspend fun getPortalConnection(): Portal.Connection? = withContext(Dispatchers.IO) {
+        val connection = preferences.data.first()[PORTAL_CONNECTION_KEY] ?: return@withContext null
+        return@withContext if (connection == 0) {
             Portal.Connection.Authenticated
         } else {
             Portal.Connection.Anonymous
         }
     }
 
-    suspend fun setPortalConnection(connection: Portal.Connection) = withContext(Dispatchers.IO) {
-        with(preferences.edit()) {
-            val value = if (connection is Portal.Connection.Authenticated) {
-                0
-            } else {
-                1
+    /**
+     * Sets the portal connection state.
+     */
+    suspend fun setPortalConnection(connection: Portal.Connection) =
+        withContext(Dispatchers.IO) {
+            preferences.edit { settings ->
+                settings[PORTAL_CONNECTION_KEY] =
+                    if (connection is Portal.Connection.Authenticated) {
+                        0
+                    } else {
+                        1
+                    }
             }
-            putInt(connectionKey, value)
-            commit()
+        }
+
+    /**
+     * Retrieves the current portal user, or null if not logged in. See [user] for a flow that emits
+     * updates to the user state.
+     */
+    suspend fun getPortalUser(): PortalUser? = withContext(Dispatchers.IO) {
+        preferences.data.firstOrNull()?.let { settings ->
+            val portalUrl = settings[URL_KEY] ?: return@withContext null
+            val connection = settings[PORTAL_CONNECTION_KEY] ?: return@withContext null
+            val userJson = settings[PORTAL_USER_KEY] ?: return@withContext null
+            val portal = Portal(
+                portalUrl,
+                if (connection == 0) {
+                    Portal.Connection.Authenticated
+                } else {
+                    Portal.Connection.Anonymous
+                }
+            )
+            PortalUser.fromJsonOrNull(userJson, portal)
         }
     }
 
-    fun getPortalUrl(): String {
-        return preferences.getString(urlKey, "") ?: ""
-    }
-
-    suspend fun setPortalUrl(url: String) = withContext(Dispatchers.IO) {
-        with(preferences.edit()) {
-            putString(urlKey, url)
-            commit()
+    /**
+     * Sets the current portal user and updates the preferences.
+     */
+    suspend fun setPortalUser(user: PortalUser) = withContext(Dispatchers.IO) {
+        preferences.edit { settings ->
+            settings[PORTAL_USER_KEY] = user.toJson()
+            settings[URL_KEY] = user.portal.url
+            settings[PORTAL_CONNECTION_KEY] =
+                if (user.portal.connection is Portal.Connection.Authenticated) {
+                    0 // Authenticated
+                } else {
+                    1 // Anonymous
+                }
         }
+        _user.value = user
     }
 
+    /**
+     * Signs out the current user and clears the stored portal settings.
+     */
     suspend fun signOut() = withContext(Dispatchers.IO) {
-        setPortalConnection(Portal.Connection.Authenticated)
+        preferences.edit { settings ->
+            settings.remove(URL_KEY)
+            settings.remove(PORTAL_USER_KEY)
+            settings.remove(PORTAL_CONNECTION_KEY)
+        }
+        _user.value = null
         ArcGISEnvironment.authenticationManager.signOut()
     }
 }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/network/ItemRemoteDataSource.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/network/ItemRemoteDataSource.kt
@@ -20,12 +20,16 @@ package com.arcgismaps.toolkit.featureformsapp.data.network
 
 import android.util.Log
 import com.arcgismaps.mapping.PortalItem
-import com.arcgismaps.portal.Portal
 import com.arcgismaps.portal.PortalFolder
 import com.arcgismaps.portal.PortalItemType
 import com.arcgismaps.portal.PortalQueryParameters
 import com.arcgismaps.portal.PortalQueryResultSet
+import com.arcgismaps.portal.PortalUser
+import com.arcgismaps.toolkit.featureformsapp.data.PortalSettings
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
@@ -41,72 +45,67 @@ class UserContent(
  */
 class ItemRemoteDataSource(
     private val dispatcher: CoroutineDispatcher,
-    private val portalUri: String
+    private val portalSettings: PortalSettings,
+    coroutineScope: CoroutineScope
 ) {
+    private var portalUser : PortalUser? = null
 
-    private lateinit var portal: Portal
+    init {
+        coroutineScope.launch {
+            portalSettings.user.collectLatest { user ->
+                portalUser = user
+            }
+        }
+    }
 
     suspend fun fetchContent(): UserContent = withContext(dispatcher) {
-        //create a Portal
-        if (!::portal.isInitialized) {
-            portal = Portal(
-                portalUri,
-                connection = Portal.Connection.Authenticated
+        portalUser?.let { user ->
+            // log an exception and return if the portal user loading fails
+            user.load().onFailure {
+                Log.e("ItemRemoteDataSource", "unable to load the portal user: ${it.message}", it)
+                return@withContext emptyUserContent()
+            }
+            // fetch the users content
+            val portalUserContent =
+                user.fetchContent().getOrElse { return@withContext emptyUserContent() }
+            val items = portalUserContent.items.filter {
+                it.type == PortalItemType.WebMap
+            }
+            return@withContext UserContent(
+                items = items,
+                folders = portalUserContent.folders
             )
-        }
-        // log an exception and return if the portal loading fails
-        portal.load().onFailure {
-            Log.e("ItemRemoteDataSource", "unable to load the Portal: ${it.message}")
-            return@withContext emptyUserContent()
-        }
-        val user = portal.user ?: return@withContext emptyUserContent()
-        // fetch the users content
-        val portalUserContent =
-            user.fetchContent().getOrElse { return@withContext emptyUserContent() }
-        val items = portalUserContent.items.filter {
-            it.type == PortalItemType.WebMap
-        }
-        return@withContext UserContent(
-            items = items,
-            folders = portalUserContent.folders
-        )
+        } ?: return@withContext emptyUserContent()
     }
 
     suspend fun fetchItemsInFolder(folderId: String): List<PortalItem> = withContext(dispatcher) {
-        //initialize the Portal
-        if (!::portal.isInitialized) {
-            portal = Portal(
-                portalUri,
-                connection = Portal.Connection.Authenticated
-            )
-        }
-        // log an exception and return if the portal loading fails
-        portal.load().onFailure {
-            Log.e("ItemRemoteDataSource", "unable to load the Portal: ${it.message}")
-            return@withContext emptyList()
-        }
-        val user = portal.user ?: return@withContext emptyList()
-        // fetch the users content
-        val items = user.fetchContentInFolder(folderId).getOrDefault(emptyList()).filter {
-            it.type == PortalItemType.WebMap
-        }
-        return@withContext items
+        portalUser?.let { user ->
+            // log an exception and return if the portal user loading fails
+            user.load().onFailure {
+                Log.e("ItemRemoteDataSource", "unable to load the portal user: ${it.message}", it)
+                return@withContext emptyList()
+            }
+            // fetch the users content
+            val items = user.fetchContentInFolder(folderId).getOrDefault(emptyList()).filter {
+                it.type == PortalItemType.WebMap
+            }
+            return@withContext items
+        } ?: return@withContext emptyList()
     }
 
-    suspend fun searchContent(query: PortalQueryParameters) : Result<PortalQueryResultSet<PortalItem>> = withContext(dispatcher) {
-        if (::portal.isInitialized.not()) {
-            portal = Portal(
-                portalUri,
-                connection = Portal.Connection.Authenticated
+    suspend fun searchContent(query: PortalQueryParameters): Result<PortalQueryResultSet<PortalItem>> =
+        withContext(dispatcher) {
+            portalUser?.let { user ->
+                // log an exception and return if the portal user loading fails
+                user.load().onFailure {
+                    Log.e("ItemRemoteDataSource", "unable to load the portal user: ${it.message}", it)
+                    return@withContext Result.failure(it)
+                }
+                return@withContext user.portal.findItems(query)
+            } ?: return@withContext Result.failure(
+                IllegalStateException("Portal User is not initialized")
             )
         }
-        // log an exception and return if the portal loading fails
-        portal.load().onFailure {
-            Log.e("ItemRemoteDataSource", "unable to load the Portal: ${it.message}")
-            return@withContext Result.failure(it)
-        }
-        return@withContext portal.findItems(query)
-    }
 
     private fun emptyUserContent(): UserContent {
         return UserContent(

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/di/DataModule.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/di/DataModule.kt
@@ -31,6 +31,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
@@ -60,9 +61,10 @@ class DataModule {
     @ItemRemoteSource
     internal fun provideItemRemoteDataSource(
         @IoDispatcher dispatcher: CoroutineDispatcher,
-        portalSettings: PortalSettings
+        portalSettings: PortalSettings,
+        @ApplicationScope scope: CoroutineScope,
     ): ItemRemoteDataSource {
-        return ItemRemoteDataSource(dispatcher, portalSettings.getPortalUrl())
+        return ItemRemoteDataSource(dispatcher, portalSettings, scope)
     }
 
 
@@ -85,7 +87,8 @@ class DataModule {
     @Provides
     internal fun providePortalSettings(
         @ApplicationContext context: Context,
-    ): PortalSettings = PortalSettings(context = context)
+        @ApplicationScope scope: CoroutineScope
+    ): PortalSettings = PortalSettings(context = context, scope = scope)
 
     @Singleton
     @Provides

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentScreen.kt
@@ -85,7 +85,6 @@ fun PortalContentScreen(
 ) {
     val dataStore = LocalContext.current.datastore
     val uiState by viewModel.uiState.collectAsState()
-    val username = remember { viewModel.getUsername() }
     var showSignOutProgress by rememberSaveable {
         mutableStateOf(false)
     }
@@ -102,13 +101,13 @@ fun PortalContentScreen(
                     }
                 },
                 actions = {
-                    if (username != null) {
+                    if (viewModel.username != null) {
                         IconButton(onClick = onSearchIconClick) {
                             Icon(Icons.Filled.Search, contentDescription = "Refresh")
                         }
                     }
                     User(
-                        username = username,
+                        username = viewModel.username,
                         isLoading = uiState.isLoading,
                         onRefresh = viewModel::refresh,
                         onSignOut = {
@@ -175,9 +174,10 @@ fun PortalContentScreen(
                 showSignOutProgress
             },
             modifier = Modifier.fillMaxSize(),
-            statusText = if (viewModel.getUsername()
-                    .isNullOrEmpty()
-            ) stringResource(R.string.loading) else stringResource(R.string.signing_out)
+            statusText = if (viewModel.username.isNullOrEmpty())
+                stringResource(R.string.loading)
+            else
+                stringResource(R.string.signing_out)
         )
     }
     LaunchedEffect(Unit) {

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentViewModel.kt
@@ -18,6 +18,7 @@
 
 package com.arcgismaps.toolkit.featureformsapp.screens.browse
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arcgismaps.mapping.PortalItem
@@ -50,6 +51,14 @@ class PortalContentViewModel @Inject constructor(
     private val navigator: Navigator
 ) : ViewModel() {
 
+    private val _username = mutableStateOf<String?>(null)
+
+    /**
+     * Username of the currently logged in user.
+     */
+    val username: String?
+        get() = _username.value
+
     // State flow to keep track of current loading state
     private val _isLoading = MutableStateFlow(false)
 
@@ -70,6 +79,7 @@ class PortalContentViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            _username.value = portalItemRepository.getUsername()
             // if the data is empty, refresh it
             // this is used to identify first launch
             if (portalItemRepository.getItemCount(null) == 0) {
@@ -77,11 +87,6 @@ class PortalContentViewModel @Inject constructor(
             }
         }
     }
-
-    /**
-     * Returns the username of the currently signed-in user.
-     */
-    fun getUsername(): String? = portalItemRepository.getUsername()
 
     /**
      * Refreshes the data.

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginViewModel.kt
@@ -86,13 +86,14 @@ class LoginViewModel @Inject constructor(
                         )
                     )
                 else emptyList()
-            portalSettings.setPortalUrl(url)
-            portalSettings.setPortalConnection(Portal.Connection.Authenticated)
             val portal = Portal(url, Portal.Connection.Authenticated)
             portal.load().onFailure {
                 _loginState.value = LoginState.Failed(it.message ?: "")
             }.onSuccess {
-                _loginState.value = LoginState.Success
+                _loginState.value = portal.user?.let { user ->
+                    portalSettings.setPortalUser(user)
+                    LoginState.Success
+                } ?: LoginState.Failed("Failed to load portal user")
             }
         }
     }
@@ -102,7 +103,7 @@ class LoginViewModel @Inject constructor(
      */
     fun skipSignIn() {
         viewModelScope.launch {
-            portalSettings.setPortalUrl(portalSettings.defaultPortalUrl)
+            // Set the connection to anonymous to allow loading public content without authentication
             portalSettings.setPortalConnection(Portal.Connection.Anonymous)
             _loginState.value = LoginState.Success
         }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchViewModel.kt
@@ -96,6 +96,8 @@ class SearchViewModel @Inject constructor(
             types = listOf(PortalItemType.WebMap),
             searchQuery = "title:$searchQuery",
         ).apply {
+            // TO-DO: make this configurable
+            this.searchPublic = false
             limit = 100
         }
         val searchResults = repository.searchItems(queryParams).getOrNull()

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchViewModel.kt
@@ -96,7 +96,7 @@ class SearchViewModel @Inject constructor(
             types = listOf(PortalItemType.WebMap),
             searchQuery = "title:$searchQuery",
         ).apply {
-            // TO-DO: make this configurable
+            // TODO: make this configurable
             this.searchPublic = false
             limit = 100
         }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[kotlin/6400](https://devtopia.esri.com/runtime/kotlin/issues/6400)

<!-- link to design, if applicable -->

### Description:

This PR migrates the use of shared preferences to jetpack datastore and introduces enhancements and fixes along with it.

### Summary of changes:

- Updated the use of `SharedPreferences` to data store within the `PortalSettings` class.
- Every time the portal user changes, the `PortalSettings` class will emit the change through the `user` StateFlow.
- This is then used by the `ItemRemoteDataSource` to always have the latest portal to query against. The earlier behavior was likely buggy as the `Portal` inside `ItemRemoteDataSource` could become stale as a user goes through multiple portals/logins.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  