### PR TITLE
Authenticator: Adds Custom Tabs ephemeral session support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 activityCompose = "1.10.1"
 androidGradlePlugin = "8.9.2"
-androidXBrowser = "1.8.0"
+androidXBrowser = "1.9.0"
 coilBOM = "2.5.0"
 composeBOM = "2025.04.01"
 androidxCamera = "1.4.2"

--- a/toolkit/authentication/README.md
+++ b/toolkit/authentication/README.md
@@ -162,20 +162,9 @@ If you want to launch a Custom Tab from your own app's activity, follow these st
     }
     ```
 
-### Launch OAuth Prompts in Incognito Mode
+### Launch OAuth Prompts in Private Browser Sessions (Ephemeral Mode)
 
-OAuth user sign-in prompts are launched in a Custom Tab. Therefore, any credentials saved in the browser's cache could be used to authenticate a device. For enterprise sign-ins, this behavior may be problematic. Unfortunately, there is no programmatic way to remedy this. However, the `Authenticator` can be configured to launch OAuth prompts in incognito mode (which will not store credentials in the browser cache) like so:
-
-- The device must have Chrome installed.
-- The device's Chrome browser must have the following flags set to true:
-
-```
-chrome://flags/#cct-incognito
-chrome://flags/#cct-incognito-available-to-third-party
-```
-
-- The Chrome browser must be relaunched for those flags to take effect.
-- The `AuthenticatorState.oAuthUserConfiguration` must have the `preferPrivateWebBrowserSession` property set to true:
+To display OAuth sign-in prompts in a private browser session (ephemeral mode), set the `preferPrivateWebBrowserSession` property to `true` in your `OAuthUserConfiguration`. This ensures that the browser does not use any cached credentials, which is important for enterprise security.
 
 ```kotlin
 authenticatorState.oAuthUserConfiguration = OAuthUserConfiguration(

--- a/toolkit/authentication/README.md
+++ b/toolkit/authentication/README.md
@@ -162,7 +162,7 @@ If you want to launch a Custom Tab from your own app's activity, follow these st
     }
     ```
 
-### Launch OAuth Prompts in Private Browser Sessions (Ephemeral Mode)
+### Using Private Browser Sessions (Ephemeral mode) for OAuth Authentication
 
 To display OAuth sign-in prompts in a private browser session (ephemeral mode), set the `preferPrivateWebBrowserSession` property to `true` in your `OAuthUserConfiguration`. This ensures that the browser does not use any cached credentials, which is important for enterprise security.
 

--- a/toolkit/authentication/README.md
+++ b/toolkit/authentication/README.md
@@ -174,6 +174,7 @@ authenticatorState.oAuthUserConfiguration = OAuthUserConfiguration(
         preferPrivateWebBrowserSession = true
     )
 ```
+Note: Private web browsing sessions (ephemeral mode) may not work in Chrome versions lower than 136, and support may vary across non-Chromium-based browsers. For best results, ensure your users have updated to a newer version of Chrome, and be aware that not all browsers may support this feature.
 
 ### Signing out
 

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticationActivity.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticationActivity.kt
@@ -128,8 +128,8 @@ public class AuthenticationActivity internal constructor() : ComponentActivity()
         super.onCreate(savedInstanceState)
         val url = intent.getStringExtra(KEY_INTENT_EXTRA_URL)
         url?.let {
-            val shouldUseIncognito = intent.getBooleanExtra(KEY_INTENT_EXTRA_PRIVATE_BROWSING, false)
-            launchCustomTabs(it, shouldUseIncognito)
+            val preferPrivateWebBrowserSession = intent.getBooleanExtra(KEY_INTENT_EXTRA_PRIVATE_BROWSING, false)
+            launchCustomTabs(it, preferPrivateWebBrowserSession)
         }
     }
 

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Extensions.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Extensions.kt
@@ -57,7 +57,7 @@ public suspend fun AuthenticationManager.signOut() {
  *
  * @since 200.2.0
  */
-@Deprecated (
+@Deprecated(
     message = "since 200.8.0. Use Activity.launchCustomTabs(BrowserAuthenticationChallenge) " +
             "instead as it provides support for IAP sign-in/sign-out.",
     replaceWith = ReplaceWith("Activity.launchCustomTabs(BrowserAuthenticationChallenge)")
@@ -102,9 +102,9 @@ public fun Activity.launchCustomTabs(pendingBrowserAuthenticationChallenge: Brow
  * @since 200.2.0
  */
 internal fun Activity.launchCustomTabs(authorizeUrl: String, useIncognito: Boolean?) {
-    CustomTabsIntent.Builder().build().apply {
+    CustomTabsIntent.Builder().apply {
         if (useIncognito == true) {
-            intent.putExtra("com.google.android.apps.chrome.EXTRA_OPEN_NEW_INCOGNITO_TAB", true)
+            setEphemeralBrowsingEnabled(true)
         }
-    }.launchUrl(this, authorizeUrl.toUri())
+    }.build().launchUrl(this, authorizeUrl.toUri())
 }

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Extensions.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Extensions.kt
@@ -99,7 +99,7 @@ public fun Activity.launchCustomTabs(pendingBrowserAuthenticationChallenge: Brow
  * user credentials.
  * @param preferPrivateWebBrowserSession whether the [CustomTabsIntent] should use a private web browser session, if available.
  *
- * @since 200.2.0
+ * @since 200.8.1
  */
 internal fun Activity.launchCustomTabs(authorizeUrl: String, preferPrivateWebBrowserSession: Boolean?) {
     CustomTabsIntent.Builder().apply {

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Extensions.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/Extensions.kt
@@ -48,7 +48,7 @@ public suspend fun AuthenticationManager.signOut() {
 
 /**
  * Launches the custom tabs activity with the provided authorize URL. The resulting intent will
- * launch using an Incognito tab if the [pendingSignIn]'s [OAuthUserConfiguration.preferPrivateWebBrowserSession]
+ * launch using a private web browser session if the [pendingSignIn]'s [OAuthUserConfiguration.preferPrivateWebBrowserSession]
  * is true.
  *
  * @receiver an [Activity] used to launch the [CustomTabsIntent].
@@ -72,7 +72,7 @@ public fun Activity.launchCustomTabs(pendingSignIn: OAuthUserSignIn?): Unit {
 /**
  * Launches the custom tabs activity with the provided browser authentication challenge.
  *
- * This method determines the appropriate URL and whether to use Incognito mode based on the type of
+ * This method determines the appropriate URL and whether to use a private web browser session based on the type of
  * [BrowserAuthenticationChallenge] provided. It supports OAuth user sign-in, IAP sign-in, and IAP sign-out challenges.
  *
  * @receiver an [Activity] used to launch the [CustomTabsIntent].
@@ -82,13 +82,13 @@ public fun Activity.launchCustomTabs(pendingSignIn: OAuthUserSignIn?): Unit {
  * @since 200.8.0
  */
 public fun Activity.launchCustomTabs(pendingBrowserAuthenticationChallenge: BrowserAuthenticationChallenge) {
-    val (url, useIncognito) = when (pendingBrowserAuthenticationChallenge) {
+    val (url, preferPrivateWebBrowserSession) = when (pendingBrowserAuthenticationChallenge) {
         is BrowserAuthenticationChallenge.OAuthUserSignIn ->
             pendingBrowserAuthenticationChallenge.oAuthUserSignIn.authorizeUrl to pendingBrowserAuthenticationChallenge.oAuthUserSignIn.oAuthUserConfiguration.preferPrivateWebBrowserSession
         is BrowserAuthenticationChallenge.IapSignIn -> pendingBrowserAuthenticationChallenge.iapSignIn.authorizeUrl to false
         is BrowserAuthenticationChallenge.IapSignOut -> pendingBrowserAuthenticationChallenge.iapSignOut.signOutUrl to false
     }
-    launchCustomTabs(url, useIncognito)
+    launchCustomTabs(url, preferPrivateWebBrowserSession)
 }
 
 
@@ -97,13 +97,13 @@ public fun Activity.launchCustomTabs(pendingBrowserAuthenticationChallenge: Brow
  *
  * @param authorizeUrl the authorize URL used by the custom tabs browser to prompt for OAuth
  * user credentials.
- * @param useIncognito whether the [CustomTabsIntent] should use Incognito mode, if available.
+ * @param preferPrivateWebBrowserSession whether the [CustomTabsIntent] should use a private web browser session, if available.
  *
  * @since 200.2.0
  */
-internal fun Activity.launchCustomTabs(authorizeUrl: String, useIncognito: Boolean?) {
+internal fun Activity.launchCustomTabs(authorizeUrl: String, preferPrivateWebBrowserSession: Boolean?) {
     CustomTabsIntent.Builder().apply {
-        if (useIncognito == true) {
+        if (preferPrivateWebBrowserSession == true) {
             setEphemeralBrowsingEnabled(true)
         }
     }.build().launchUrl(this, authorizeUrl.toUri())

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthAuthenticator.kt
@@ -30,7 +30,7 @@ import com.arcgismaps.httpcore.authentication.OAuthUserSignIn
 private const val DEFAULT_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
 
 /**
- * Launches a Custom Chrome Tab using the url in [oAuthPendingSignIn] and calls [onActivityResult] on completion.
+ * Launches a Custom Tab using the url in [oAuthPendingSignIn] and calls [onActivityResult] on completion.
  *
  * @see AuthenticationActivity
  * @param oAuthPendingSignIn the [OAuthUserSignIn] pending completion.

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthUserSignInActivity.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthUserSignInActivity.kt
@@ -106,9 +106,9 @@ public class OAuthUserSignInActivity : ComponentActivity() {
         if (intent.hasExtra(KEY_INTENT_EXTRA_PROMPT_SIGN_IN)) {
             // authorize URL should be a valid string since we are adding it in the ActivityResultContract
             val authorizeUrl = intent.getStringExtra(KEY_INTENT_EXTRA_AUTHORIZE_URL)
-            val useIncognito = intent.getBooleanExtra(KEY_INTENT_EXTRA_PRIVATE_BROWSING, false)
+            val preferPrivateWebBrowserSession = intent.getBooleanExtra(KEY_INTENT_EXTRA_PRIVATE_BROWSING, false)
             authorizeUrl?.let {
-                launchCustomTabs(it, useIncognito)
+                launchCustomTabs(it, preferPrivateWebBrowserSession)
             }
         }
     }

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
@@ -39,6 +39,7 @@ import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallenge
 import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallengeResponse
 import com.arcgismaps.httpcore.authentication.NetworkAuthenticationType
 import com.arcgismaps.httpcore.authentication.NetworkCredential
+import com.arcgismaps.httpcore.authentication.OAuthUserConfiguration
 import com.arcgismaps.httpcore.authentication.OAuthUserSignIn
 import com.arcgismaps.httpcore.authentication.PasswordCredential
 import kotlinx.coroutines.CoroutineScope
@@ -268,7 +269,7 @@ private class OAuthWebViewClient(
     /**
      * Completes the WebView OAuth challenge by either passing back a [redirectUrl] or an [exception].
      *
-     * If [com.arcgismaps.httpcore.authentication.OAuthUserConfiguration.preferPrivateWebBrowserSession] is set to true, this method will clear the [webView]'s
+     * If [OAuthUserConfiguration.preferPrivateWebBrowserSession] is set to true, this method will clear the [webView]'s
      * session.
      *
      * @since 200.3.0

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
@@ -267,7 +267,8 @@ private class OAuthWebViewClient(
 
     /**
      * Completes the WebView OAuth challenge by either passing back a [redirectUrl] or an [exception].
-     * if [OAuthUserConfiguration.preferPrivateWebBrowserSession] is set to true, this method will clear the [webView]'s
+     *
+     * If [com.arcgismaps.httpcore.authentication.OAuthUserConfiguration.preferPrivateWebBrowserSession] is set to true, this method will clear the [webView]'s
      * session.
      *
      * @since 200.3.0


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/6350
### Summary of changes:
- Adds flag to enable Ephemeral browser sessions 
- Rewords doc and parameters to uniformly call it private web session
- Updates README

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/899
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  