### PR TITLE
Pause ar session before closing it

### DIFF
--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
@@ -30,6 +30,7 @@ import com.google.ar.core.Config
 import com.google.ar.core.Config.PlaneFindingMode
 import com.google.ar.core.Session
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
@@ -54,12 +55,19 @@ internal class ArSessionWrapper(
     private var shouldInitializeDisplay = true
 
     override fun onDestroy(owner: LifecycleOwner) {
+        var sessionRef: Session? = null
         withLock { session, _ ->
             this.session = null
-            session?.pause()
-            owner.lifecycleScope.launch(Dispatchers.Default) {
-                session?.close()
-            }
+            sessionRef = session
+        }
+        // Call pause() before close(), even if running on the same thread.
+        // This ensures proper cleanup before closing the session.
+        sessionRef?.pause()
+        // Close the session on a background thread as recommended in the official docs:
+        // https://developers.google.com/ar/reference/java/com/google/ar/core/Session#close()
+        // Using NonCancellable so the close operation runs even if the coroutine scope is cancelled.
+        owner.lifecycleScope.launch(Dispatchers.Default + NonCancellable) {
+            sessionRef?.close()
         }
     }
 

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
@@ -53,6 +53,7 @@ internal class ArSessionWrapper(
     override fun onDestroy(owner: LifecycleOwner) {
         withLock { session, _ ->
             this.session = null
+            session?.pause()
             session?.close()
         }
     }

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
@@ -146,7 +146,7 @@ internal fun rememberArSessionWrapper(
     applicationContext: Context,
     onError: (Throwable) -> Unit = {},
     useGeospatial: Boolean = false,
-    planeFindingMode: Config.PlaneFindingMode
+    planeFindingMode: PlaneFindingMode
 ): ArSessionWrapper {
     val lifecycleOwner = LocalLifecycleOwner.current
     val arSessionWrapper = remember {

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/ArSessionWrapper.kt
@@ -25,9 +25,12 @@ import androidx.compose.runtime.remember
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.google.ar.core.Config
 import com.google.ar.core.Config.PlaneFindingMode
 import com.google.ar.core.Session
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 
@@ -54,7 +57,9 @@ internal class ArSessionWrapper(
         withLock { session, _ ->
             this.session = null
             session?.pause()
-            session?.close()
+            owner.lifecycleScope.launch(Dispatchers.Default) {
+                session?.close()
+            }
         }
     }
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Pause ar session before closing it. This approash is recommended by [oficcial documentation](https://developers.google.com/ar/reference/java/com/google/ar/core/Session#close-).

### Summary of changes:

- add `session?.pause()` before `session?.close()`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  