### PR TITLE
`FeatureForm`: Add navigate back when last association is deleted via swipe

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociations.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociations.kt
@@ -145,8 +145,11 @@ internal fun UtilityAssociationFilter(
  * Displays the provided list of associations that are part of the [UtilityAssociationGroupResult].
  *
  * @param groupResult The [UtilityAssociationGroupResult] to display.
+ * @param isNavigationEnabled Whether navigation to the associated feature is enabled.
  * @param onItemClick A callback that is called when an association is clicked.
  * @param onDetailsClick A callback that is called when the details icon is clicked.
+ * @param onDelete A callback that is called when an association is deleted. The callback provides
+ * a boolean indicating whether the group is empty after deletion.
  * @param modifier The [Modifier] to apply to this layout.
  */
 @Composable
@@ -155,6 +158,7 @@ internal fun UtilityAssociations(
     isNavigationEnabled: Boolean,
     onItemClick: (Int) -> Unit,
     onDetailsClick: (Int) -> Unit,
+    onDelete: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val lazyListState = rememberLazyListState()
@@ -184,6 +188,7 @@ internal fun UtilityAssociations(
                         },
                         onDelete = {
                             groupResult.delete(info.association)
+                            onDelete(groupResult.associationResults.isEmpty())
                         },
                         modifier = Modifier.animateItem()
                     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UNAssociationsScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UNAssociationsScreen.kt
@@ -128,6 +128,12 @@ internal fun UNAssociationsScreen(
             // show the details sheet
             showDetails = true
         },
+        onDelete = { isGroupEmpty ->
+            if (isGroupEmpty) {
+                // If the group is empty after deletion, navigate back to the filter view
+                onBack()
+            }
+        },
         modifier = modifier
             .padding(16.dp)
             .fillMaxSize()


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

<!-- Related to issue: # -->

<!-- link to design, if applicable -->

### Description:

Fixes a bug where if the last association in a group was deleted via a swipe gesture, the view should have navigated back. This was only working when the association was deleted via the details page.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/933/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  