### PR TITLE
SceneView: Camera controller patch

### DIFF
--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/SceneView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/SceneView.kt
@@ -320,7 +320,6 @@ public fun SceneView(
                 it.selectionProperties = selectionProperties
                 it.grid = grid
                 it.setTimeExtent(timeExtent)
-                it.cameraController = cameraController
                 it.atmosphereEffect = atmosphereEffect
                 it.spaceEffect = spaceEffect
                 it.sunTime = sunTime
@@ -345,6 +344,7 @@ public fun SceneView(
                         addAll(imageOverlays)
                     }
                 }
+                it.cameraController = cameraController
             })
 
         val sceneViewScope = remember { SceneViewScope(sceneView) }

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/SceneView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/SceneView.kt
@@ -344,6 +344,10 @@ public fun SceneView(
                         addAll(imageOverlays)
                     }
                 }
+                // Set the camera controller last, to ensure other dependend SceneView properties are already set.
+                // For example, OrbitGeoElementCameraController requires its associated GeoElement to be in a graphics overlay
+                // set on the SceneView at this point.
+                // https://devtopia.esri.com/runtime/kotlin/issues/6623
                 it.cameraController = cameraController
             })
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#6623](https://devtopia.esri.com/runtime/kotlin/issues/6623)

<!-- link to design, if applicable -->

### Description:
PR to patch SceneView to ensure camera controller is used with the active graphics overlay.


### Summary of changes:

- Internally reorder the `update` block to set the `cameraController` **after** all overlays has been applied. 


### Testing crash using micoapp:

- Run the `scene-view-camera-controller-app` using the [branch](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/compare/v.next...shubham/camera-controller-repro-bug): `shubham/camera-controller-repro-bug`, and rotate device after launch. 

```console
java.lang.IllegalStateException: Illegal state. Target Graphic must be in an active Graphics Overlay.
```


### Pre-merge Checklist

- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/964/