### PR TITLE
enable edgeToEdge support

### DIFF
--- a/microapps/PopupApp/app/src/main/java/com/arcgismaps/toolkit/popupapp/MainActivity.kt
+++ b/microapps/PopupApp/app/src/main/java/com/arcgismaps/toolkit/popupapp/MainActivity.kt
@@ -23,6 +23,7 @@ package com.arcgismaps.toolkit.popupapp
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallenge
@@ -34,6 +35,7 @@ import com.arcgismaps.toolkit.popupapp.ui.theme.PopupAppTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         ArcGISEnvironment.authenticationManager.arcGISAuthenticationChallengeHandler =
             TestArcGISAuthenticationChallengeHandler(

--- a/microapps/PopupApp/app/src/main/java/com/arcgismaps/toolkit/popupapp/screens/mapscreen/MainScreen.kt
+++ b/microapps/PopupApp/app/src/main/java/com/arcgismaps/toolkit/popupapp/screens/mapscreen/MainScreen.kt
@@ -24,9 +24,13 @@ import android.widget.Toast
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetValue
@@ -37,6 +41,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.data.Feature
@@ -74,17 +80,36 @@ fun MainScreen(viewModel: MapViewModel = viewModel()) {
         }
     }
 
+    val navBarHeight = with(LocalDensity.current) {
+        WindowInsets.navigationBars.getBottom(this).toDp()
+    }
+    // ensure a minimum bottom inset of 48.dp when there is no navigation bar
+    // this ensures that the peek height is always at least 96.dp
+    val bottomInset = maxOf(navBarHeight, 48.dp)
+
+    val statusBarHeightDp = with(LocalDensity.current) {
+        WindowInsets.statusBars.getTop(this).toDp()
+    }
+
+    val maxPopupHeight = with(LocalDensity.current) {
+        LocalWindowInfo.current.containerSize.height.toDp() - (statusBarHeightDp + bottomInset)
+    }
+
     BottomSheetScaffold(
         sheetContent = {
             val state = viewModel.popupState
             if (state != null) {
                 Popup(
                     state,
-                    Modifier.animateContentSize(),
-                    onDismiss = { scope.launch {
-                        resetSelection(viewModel)
-                        scaffoldState.bottomSheetState.hide()
-                    } }
+                    Modifier
+                        .animateContentSize()
+                        .heightIn(max = maxPopupHeight),
+                    onDismiss = {
+                        scope.launch {
+                            resetSelection(viewModel)
+                            scaffoldState.bottomSheetState.hide()
+                        }
+                    }
                 )
             }
         },
@@ -92,6 +117,7 @@ fun MainScreen(viewModel: MapViewModel = viewModel()) {
             .fillMaxSize()
             .padding(WindowInsets.safeDrawing.asPaddingValues()),
         scaffoldState = scaffoldState,
+        sheetPeekHeight = bottomInset.times(2),
         sheetSwipeEnabled = true,
         topBar = null
     ) { padding ->
@@ -100,7 +126,7 @@ fun MainScreen(viewModel: MapViewModel = viewModel()) {
             arcGISMap = viewModel.map,
             mapViewProxy = viewModel.proxy,
             modifier = Modifier
-                .padding(padding)
+                .consumeWindowInsets(padding)
                 .fillMaxSize(),
             onSingleTapConfirmed = {
                 resetSelection(viewModel)


### PR DESCRIPTION
add max height for popup

<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/6633

<!-- link to design, if applicable -->

### Description:

Update popup micro app so the bottomsheet does not overlap the status bar when fully expanded on Android 16

### Summary of changes:

- Enable edgetoEdge support for Android api < 16
- Calculate popup max height by taking in account the status bar and navigation bar height and set it over the popup. I did this since there is no direct way like in `Scaffold` to set `contentWindowInsets = WindowInsets.safeDrawing` in `BottomSheetScaffold`.  

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/974/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  