### PR TITLE
Remove use of mutable Item.id

### DIFF
--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -342,9 +342,7 @@ public class OfflineMapState {
         val mmpk = MobileMapPackage(areaDir.absolutePath).apply {
             load().getOrElse { return null }
         }
-        val item = (mmpk.item as? LocalItem)?.apply {
-            itemId = portalItem.itemId
-        } ?: return null
+        val item = (mmpk.item as? LocalItem) ?: return null
 
         val preplannedMapAreaState = PreplannedMapAreaState(
             context = context,
@@ -389,9 +387,7 @@ public class OfflineMapState {
         val mmpk = MobileMapPackage(areaDir.absolutePath).apply {
             load().getOrElse { return null }
         }
-        val item = (mmpk.item as? LocalItem)?.apply {
-            itemId = portalItem.itemId
-        } ?: return null
+        val item = (mmpk.item as? LocalItem) ?: return null
 
         val onDemandMapAreasState = OnDemandMapAreasState(
             context = context,


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/6671

<!-- link to design, if applicable -->

### Description:

Removes the use of mutable item.id to fix the broken build

### Summary of changes:

- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/987/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  