### PR TITLE
Add PortalItem.itemId to OnDemandMapAreaState and PreplannedMapAreasS…

### DIFF
--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -250,6 +250,7 @@ public class OfflineMapState {
                             preplannedMapArea = mapArea,
                             offlineMapTask = offlineMapTask,
                             item = portalItem,
+                            portalItemID = portalItem.itemId,
                             onSelectionChanged = onSelectionChanged
                         )
                         preplannedMapAreaState.initialize()
@@ -347,6 +348,7 @@ public class OfflineMapState {
         val preplannedMapAreaState = PreplannedMapAreaState(
             context = context,
             item = item,
+            portalItemID = portalItem.itemId,
             onSelectionChanged = onSelectionChanged
         )
         val preplannedPath = OfflineRepository.isPrePlannedAreaDownloaded(
@@ -392,6 +394,7 @@ public class OfflineMapState {
         val onDemandMapAreasState = OnDemandMapAreasState(
             context = context,
             item = item,
+            portalItemID = portalItem.itemId,
             onSelectionChanged = onSelectionChanged
         )
         val onDemandPath = OfflineRepository.isOnDemandAreaDownloaded(
@@ -422,6 +425,7 @@ public class OfflineMapState {
         val onDemandMapAreasState = OnDemandMapAreasState(
             context = context,
             item = portalItem,
+            portalItemID = portalItem.itemId,
             configuration = configuration,
             offlineMapTask = offlineMapTask,
             onSelectionChanged = onSelectionChanged
@@ -496,6 +500,7 @@ public class OfflineMapState {
                     val restoredState = OnDemandMapAreasState(
                         context = context,
                         item = portalItem,
+                        portalItemID = portalItem.itemId,
                         onSelectionChanged = onSelectionChanged
                     ).apply { restoreOfflineMapJobState(workerUuid, mapAreaMetadata) }
                     // add the in-progress job states after loading on-demand map areas

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ondemand/OnDemandMapAreasState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/ondemand/OnDemandMapAreasState.kt
@@ -72,6 +72,7 @@ internal data class OnDemandMapAreaConfiguration(
 internal class OnDemandMapAreasState(
     private val context: Context,
     private val item: Item,
+    private val portalItemID: String,
     internal val configuration: OnDemandMapAreaConfiguration? = null,
     private val offlineMapTask: OfflineMapTask? = null,
     private val onSelectionChanged: (ArcGISMap) -> Unit
@@ -192,7 +193,7 @@ internal class OnDemandMapAreasState(
         // Define the path where the map will be saved
         val onDemandMapAreaDownloadDirectory = OfflineRepository.createPendingOnDemandJobPath(
             context = context,
-            portalItemID = item.itemId,
+            portalItemID = portalItemID,
             onDemandMapAreaID = onDemandMapAreaID
         )
 
@@ -229,7 +230,7 @@ internal class OnDemandMapAreasState(
 
         workerUUID = OfflineRepository.createOnDemandMapAreaRequestAndQueueDownload(
             context = context,
-            portalItemId = item.itemId,
+            portalItemId = portalItemID,
             mapAreaItemId = onDemandMapAreaId,
             jsonJobPath = jsonJobFile.path,
             onDemandMapAreaTitle = configuration?.title ?: item.title
@@ -257,7 +258,7 @@ internal class OnDemandMapAreasState(
             if (shouldRemoveOfflineMapInfo()) {
                 OfflineRepository.removeOfflineMapInfo(
                     context = context,
-                    portalItemID = item.itemId
+                    portalItemID = portalItemID
                 )
             }
         } else {
@@ -279,7 +280,7 @@ internal class OnDemandMapAreasState(
         if (shouldRemoveOfflineMapInfo()) {
             OfflineRepository.removeOfflineMapInfo(
                 context = context,
-                portalItemID = item.itemId
+                portalItemID = portalItemID
             )
         }
     }

--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/preplanned/PreplannedMapAreasState.kt
@@ -58,6 +58,7 @@ import java.util.UUID
 internal class PreplannedMapAreaState(
     private val context: Context,
     private val item: Item,
+    private val portalItemID: String,
     internal val preplannedMapArea: PreplannedMapArea? = null,
     private val offlineMapTask: OfflineMapTask? = null,
     private val onSelectionChanged: (ArcGISMap) -> Unit
@@ -205,7 +206,7 @@ internal class PreplannedMapAreaState(
         // Define the path where the map will be saved
         val preplannedMapAreaDownloadDirectory = OfflineRepository.createPendingPreplannedJobPath(
             context = context,
-            portalItemID = item.itemId,
+            portalItemID = portalItemID,
             preplannedMapAreaID = preplannedMapArea.portalItem.itemId
         )
 
@@ -241,7 +242,7 @@ internal class PreplannedMapAreaState(
         )
         workerUUID = OfflineRepository.createPreplannedMapAreaRequestAndQueueDownload(
             context = context,
-            portalItemId = item.itemId,
+            portalItemId = portalItemID,
             mapAreaItemId = preplannedMapAreaId,
             jsonJobPath = jsonJobFile.path,
             preplannedMapAreaTitle = item.title
@@ -269,7 +270,7 @@ internal class PreplannedMapAreaState(
             if (shouldRemoveOfflineMapInfo()) {
                 OfflineRepository.removeOfflineMapInfo(
                     context = context,
-                    portalItemID = item.itemId
+                    portalItemID = portalItemID
                 )
             }
             val localScope = CoroutineScope(Dispatchers.IO)


### PR DESCRIPTION
…tate as a property

<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/6671

<!-- link to design, if applicable -->

### Description:

Previously the portalItemId was being set as the itemId of the MMPK which was created when the OMA component was launched when the device was offline. For online we were passing the portalItem from OfflineMapState to both OnDemandMapAreaState and PreplannedMapAreasState, the portalItem had all the needed properties and for offline we were setting the same and passing them down. Now with the update in the API we cannot set the portalItem's id on the MMPK's item. This is breaking the offline deletion workflow where the component will not delete the info file for the portal item in offline mode.

### Summary of changes:

- Pass the portalItem down to OnDemandMapAreaState and PreplannedMapAreaState and use it where ever `Item.ItemId` was used previously.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/989/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  