### PR TITLE
`FeatureForm` : Updates to AddAssociationFromSourceViewModel.kt

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -197,7 +197,7 @@ internal class AddAssociationFromSourceViewModel(
                 val assetType = pair.second
                 // If no source, asset type is selected or the asset type is not valid for the source,
                 // clear the candidates and return an error state
-                if (source == null || assetType == null || (assetType in source.assetTypes).not()) {
+                if (source == null || assetType == null) {
                     _featureCandidatesUiState.value = FeatureCandidatesUiState(
                         isLoading = false,
                         error = IllegalStateException(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -195,8 +195,7 @@ internal class AddAssociationFromSourceViewModel(
             }.distinctUntilChanged().collect { pair ->
                 val source = pair.first
                 val assetType = pair.second
-                // If no source, asset type is selected or the asset type is not valid for the source,
-                // clear the candidates and return an error state
+                // If no source, asset type is selected return an error state
                 if (source == null || assetType == null) {
                     _featureCandidatesUiState.value = FeatureCandidatesUiState(
                         isLoading = false,


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Due to the [issue](https://devtopia.esri.com/runtime/kotlin/issues/6699) with wrapper cache, the saved asset type cannot be reliably checked against the list. This is resulting in constant errors when clicking to view an asset type. This PR removes that check. 

### Summary of changes:

- The check may not be that important as the subsequent `queryFeatures` will throw an error if the asset type does not exist in the source.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  