### PR TITLE
Add fix for popup crash

### DIFF
--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
@@ -45,6 +45,10 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.UUID
 
+internal object PopupConstants {
+    const val USER_AGENT = "ArcGIS Maps SDK for Kotlin Toolkit"
+}
+
 /**
  * Represents the state of an [MediaPopupElement]
  */
@@ -215,12 +219,18 @@ internal class PopupMediaState(
                 ) {
                     val request = ImageRequest.Builder(context)
                         .data(srcUrl)
-                        .addHeader("User-Agent", "ArcGIS Maps SDK for Kotlin Toolkit")
+                        .addHeader("User-Agent", PopupConstants.USER_AGENT)
                         .crossfade(true)
                         .build()
                     (context.imageLoader.execute(request).drawable as? BitmapDrawable)?.bitmap
                         ?: ContextCompat.getDrawable(context, R.drawable.no_image_32)?.toBitmap()
-                        ?: throw IllegalStateException("couldn't load image at $srcUrl or placeholder drawable")
+                        ?: throw IllegalStateException(
+                            if (srcUrl.isNullOrEmpty()) {
+                                "couldn't load image: sourceUrl is missing or empty, and placeholder drawable could not be loaded"
+                            } else {
+                                "couldn't load image at $srcUrl, and placeholder drawable could not be loaded"
+                            }
+                        )
                 }
             ).apply {
                 if (refreshInterval > 0) {

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import coil.imageLoader
 import coil.request.ImageRequest
 import com.arcgismaps.mapping.ChartImageParameters
@@ -32,6 +34,7 @@ import com.arcgismaps.mapping.popup.Popup
 import com.arcgismaps.mapping.popup.PopupMedia
 import com.arcgismaps.mapping.popup.PopupMediaType
 import com.arcgismaps.realtime.DynamicEntity
+import com.arcgismaps.toolkit.popup.R
 import com.arcgismaps.toolkit.popup.internal.element.state.PopupElementState
 import com.arcgismaps.toolkit.popup.internal.util.MediaImageProvider
 import kotlinx.coroutines.CoroutineScope
@@ -120,9 +123,9 @@ internal class MediaElementState(
 internal class PopupMediaState(
     val title: String,
     val caption: String,
-    @Suppress("unused") private val refreshInterval: Long,
+    private val refreshInterval: Long,
     @Suppress("unused") private val linkUrl: String,
-    private val sourceUrl: String,
+    @Suppress("unused") private val sourceUrl: String,
     val type: PopupMediaType,
     uri: String,
     scope: CoroutineScope,
@@ -201,7 +204,7 @@ internal class PopupMediaState(
             context: Context
         ): PopupMediaState {
             val srcUrl = media.value?.sourceUrl
-                ?: throw IllegalArgumentException("null sourceUrl for popup media")
+                ?: ""
             return PopupMediaState(
                 media,
                 scope,
@@ -212,10 +215,12 @@ internal class PopupMediaState(
                 ) {
                     val request = ImageRequest.Builder(context)
                         .data(srcUrl)
+                        .addHeader("User-Agent", "ArcGIS Maps SDK for Kotlin Toolkit")
                         .crossfade(true)
                         .build()
                     (context.imageLoader.execute(request).drawable as? BitmapDrawable)?.bitmap
-                        ?: throw IllegalStateException("couldn't load image at $srcUrl")
+                        ?: ContextCompat.getDrawable(context, R.drawable.no_image_32)?.toBitmap()
+                        ?: throw IllegalStateException("couldn't load image at $srcUrl or placeholder drawable")
                 }
             ).apply {
                 if (refreshInterval > 0) {

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
@@ -46,7 +46,7 @@ import java.io.File
 import java.util.UUID
 
 internal object PopupConstants {
-    const val USER_AGENT = "ArcGIS Maps SDK for Kotlin Toolkit"
+    const val USER_AGENT = "ArcGISMaps-Kotlin"
 }
 
 /**
@@ -207,8 +207,7 @@ internal class PopupMediaState(
             imageFolder: String,
             context: Context
         ): PopupMediaState {
-            val srcUrl = media.value?.sourceUrl
-                ?: ""
+            val srcUrl: String? = media.value?.sourceUrl ?: ""
             return PopupMediaState(
                 media,
                 scope,

--- a/toolkit/popup/src/main/res/drawable/no_image_32.xml
+++ b/toolkit/popup/src/main/res/drawable/no_image_32.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="32"
+    android:viewportHeight="32"
+    android:width="32dp"
+    android:height="32dp">
+    <path
+        android:pathData="M8.828 6l-1 -1H29v21.172l-1 -1V22.58l-4.494 -4.067 -1.144 1.02 -0.713 -0.713 1.428 -1.276a0.65 0.65 0 0 1 0.926 0.033L28 21.247V6zM4 26v-1.474l4.401 -3.5 1.198 0.567 5.007 -4.159 -0.71 -0.71 -4.446 3.693 -0.826 -0.391a0.64 0.64 0 0 0 -0.72 0.117L4 23.248V6.828l-1 -1V27h21.172l-1 -1zm18 -14a2 2 0 1 1 -2 -2 2 2 0 0 1 2 2m-1 0a1 1 0 1 0 -1 1 1 1 0 0 0 1 -1m8.646 18.354l0.707 -0.707 -28 -28 -0.707 0.707z"
+        android:fillColor="#000000" />
+</vector>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/6482

<!-- link to design, if applicable -->

### Description:

The popup component currently crashes when you tap on a feature on the map to load its popup. The MediaElementState currently throws an exception when the Image downloaded is null, leading to the crash. The configuration on the server changed recently where it has stopped returning images if there is no user agent in the header of the request.

Swift is using `ArcGISEnvironment.urlSession.data(from: url)` to download their images which probably applies the `user-agent` to the requests.

### Summary of changes:

- Add user agent string to the header of the image request
- Add default image drawable to use if the image returned from the server is null
- update annotation

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/995/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  