### PR TITLE
add invocation for details screen

### DIFF
--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/utilityassociationselement/UtilityAssociationGroupResult.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/utilityassociationselement/UtilityAssociationGroupResult.kt
@@ -26,15 +26,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Card
 import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -212,8 +211,6 @@ private fun AssociationItem(
     modifier: Modifier = Modifier
 ) {
     val target = association.getTargetElement(associatedFeature)
-    // Text to display at the end of the row.
-    var trailingText = ""
     // Text to display below the title.
     var supportingText = ""
     when (association.associationType) {
@@ -293,10 +290,9 @@ private fun AssociationItem(
                 )
             }
         }
-        if (trailingText.isNotEmpty()) {
-            Card(modifier = Modifier.wrapContentSize()) {
-                Text(text = trailingText, modifier = Modifier.padding(8.dp))
-            }
+        // Details button
+        IconButton(onClick = onDetailsClick) {
+            Icon(Icons.Default.MoreHoriz, contentDescription = "details")
         }
     }
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/6711

<!-- link to design, if applicable -->

### Description:

The details screen is not invoked from associated features. Add call to invoke it.

### Summary of changes:

- Add invocation for details screen

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/996/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  