### PR TITLE
Invoke onSelectionChanged(null) after the component is initialized

### DIFF
--- a/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
+++ b/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/OfflineMapState.kt
@@ -216,9 +216,9 @@ public class OfflineMapState {
             if (_mode == OfflineMapMode.Unknown)
                 _mode = OfflineMapMode.OnDemand
         }
+        _initializationStatus.value = InitializationStatus.Initialized
         // reset the selected map on initialize
         onSelectionChanged(null)
-        _initializationStatus.value = InitializationStatus.Initialized
     }
 
     /**


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/6730

<!-- link to design, if applicable -->

### Description:

The component can fail to initialize when there is an exception thrown in onSelectionChanged lambda

### Summary of changes:

- Invoke onSelectionChanged after the component is initialized

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1000/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  