### PR TITLE
`FeatureForm` : Introduce API to show UNA candidates on map

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -115,7 +115,6 @@ import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.StandardBottom
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberStandardBottomSheetState
 import com.arcgismaps.toolkit.featureformsapp.screens.login.verticalScrollbar
 import com.arcgismaps.toolkit.geoviewcompose.MapView
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable
@@ -217,9 +216,9 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                 FeatureFormSheet(
                     state = rememberedForm,
                     isNavigationEnabled = mapViewModel.navigationEnabled,
-                    onFeatureLocateRequest = { feature ->
+                    onShowOnMapRequest = { feature ->
                         scope.launch {
-                            mapViewModel.locateFeature(feature)
+                            mapViewModel.highlightFeature(feature)
                         }
                     },
                     onDismiss = {
@@ -406,7 +405,7 @@ fun FeatureItem(
 fun FeatureFormSheet(
     state: FeatureFormState,
     isNavigationEnabled: Boolean,
-    onFeatureLocateRequest: (ArcGISFeature) -> Unit,
+    onShowOnMapRequest: (ArcGISFeature) -> Unit,
     onDismiss: () -> Unit,
     onEditingEvent: (FeatureFormEditingEvent) -> Unit,
     modifier: Modifier = Modifier
@@ -451,7 +450,7 @@ fun FeatureFormSheet(
                         }
                     }.invokeOnCompletion {
                         // invoke the locate request after minimizing the sheet
-                        onFeatureLocateRequest(feature)
+                        onShowOnMapRequest(feature)
                     }
                 },
                 onDismiss = onDismiss,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -97,6 +97,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.window.core.layout.WindowSizeClass
+import androidx.window.core.layout.computeWindowSizeClass
 import androidx.window.layout.WindowMetricsCalculator
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.layers.ArcGISSublayer
@@ -114,6 +115,7 @@ import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.StandardBottom
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.rememberStandardBottomSheetState
 import com.arcgismaps.toolkit.featureformsapp.screens.login.verticalScrollbar
 import com.arcgismaps.toolkit.geoviewcompose.MapView
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable
@@ -215,6 +217,11 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                 FeatureFormSheet(
                     state = rememberedForm,
                     isNavigationEnabled = mapViewModel.navigationEnabled,
+                    onFeatureLocateRequest = { feature ->
+                        scope.launch {
+                            mapViewModel.locateFeature(feature)
+                        }
+                    },
                     onDismiss = {
                         mapViewModel.setDefaultState()
                     },
@@ -399,16 +406,22 @@ fun FeatureItem(
 fun FeatureFormSheet(
     state: FeatureFormState,
     isNavigationEnabled: Boolean,
+    onFeatureLocateRequest: (ArcGISFeature) -> Unit,
     onDismiss: () -> Unit,
     onEditingEvent: (FeatureFormEditingEvent) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val windowSize = getWindowSize(LocalContext.current)
+    // determine if the device is in compact width
+    val isCompact = windowSize.isWidthAtLeastBreakpoint(
+        WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
+    ).not()
     val bottomSheetState = rememberStandardBottomSheetState(
         initialValue = SheetValue.PartiallyExpanded,
         confirmValueChange = { it != SheetValue.Hidden },
         skipHiddenState = false
     )
+    val scope = rememberCoroutineScope()
     SheetLayout(
         windowSizeClass = windowSize,
         sheetOffsetY = { bottomSheetState.requireOffset() },
@@ -430,6 +443,17 @@ fun FeatureFormSheet(
                 featureFormState = state,
                 modifier = Modifier.fillMaxSize(),
                 isNavigationEnabled = isNavigationEnabled,
+                onFeatureLocateRequest = { feature ->
+                    scope.launch {
+                        if (isCompact) {
+                            // minimize the sheet on compact devices
+                            bottomSheetState.animateTo(SheetValue.Minimized)
+                        }
+                    }.invokeOnCompletion {
+                        // invoke the locate request after minimizing the sheet
+                        onFeatureLocateRequest(feature)
+                    }
+                },
                 onDismiss = onDismiss,
                 onEditingEvent = onEditingEvent
             )
@@ -443,7 +467,7 @@ fun TopFormBar(
     title: String,
     isEditing: Boolean,
     isNavigationEnabled: Boolean,
-    onToggleNavigation : () -> Unit = {},
+    onToggleNavigation: () -> Unit = {},
     onBackPressed: () -> Unit = {}
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -548,13 +572,16 @@ fun ErrorDialog(
         properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = true)
     )
 }
-@Suppress("DEPRECATION")
+
 fun getWindowSize(context: Context): WindowSizeClass {
     val metrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context)
     val width = metrics.bounds.width()
     val height = metrics.bounds.height()
     val density = context.resources.displayMetrics.density
-    return WindowSizeClass.compute(width / density, height / density)
+    return WindowSizeClass.Companion.BREAKPOINTS_V1.computeWindowSizeClass(
+        widthDp = width / density,
+        heightDp = height / density
+    )
 }
 
 /**

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -443,7 +443,7 @@ fun FeatureFormSheet(
                 featureFormState = state,
                 modifier = Modifier.fillMaxSize(),
                 isNavigationEnabled = isNavigationEnabled,
-                onFeatureLocateRequest = { feature ->
+                onShowOnMapRequest = { feature ->
                     scope.launch {
                         if (isCompact) {
                             // minimize the sheet on compact devices

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -51,6 +51,7 @@ import com.arcgismaps.toolkit.geoviewcompose.MapViewProxy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -170,7 +171,7 @@ class MapViewModel @Inject constructor(
      * The current location of the identify task. This is used to indicate if there is an
      * identify task in progress for the given location.
      */
-    val identifyTaskLocation : State<Point?>
+    val identifyTaskLocation: State<Point?>
         get() = _identifyTaskLocation
 
     /**
@@ -206,7 +207,7 @@ class MapViewModel @Inject constructor(
                 map.clearSelection()
                 // if there is an active feature form then select the feature
                 if (featureForm != null) {
-                    featureForm.selectFeature()
+                    featureForm.feature.selectFeature()
                     featureForm.feature.geometry?.let { geometry ->
                         // set the viewpoint to the feature geometry
                         proxy.setViewpointAnimated(
@@ -226,6 +227,7 @@ class MapViewModel @Inject constructor(
      * Sets the UI state to not editing.
      */
     fun setDefaultState() {
+        map.clearSelection()
         clearErrors()
         _uiState.value = UIState.NotEditing
     }
@@ -423,6 +425,30 @@ class MapViewModel @Inject constructor(
     }
 
     /**
+     * Locates the given [feature] on the map by setting the viewpoint to the feature geometry
+     * and flashing the feature.
+     *
+     * @param feature the feature to locate
+     */
+    suspend fun locateFeature(feature: ArcGISFeature) {
+        feature.geometry?.let { geometry ->
+            // set the viewpoint to the feature geometry
+            proxy.setViewpointAnimated(
+                viewpoint = Viewpoint(geometry)
+            ).onSuccess {
+                feature.layer?.maxScale?.let {
+                    // clamp the scale to be at least 0.1 to avoid zooming in too close
+                    val scale = if (it > 0) it else 0.1
+                    // set the viewpoint scale to the layer's max scale
+                    proxy.setViewpointScale(scale)
+                }
+                // flash the feature to highlight it
+                feature.flashFeature()
+            }
+        }
+    }
+
+    /**
      * Applies the edits in the [featureForm]'s table to the service and sets the UI state to error
      * if there are any errors.
      *
@@ -532,14 +558,35 @@ fun ArcGISMap.clearSelection() {
 }
 
 /**
- * Selects the [FeatureForm.feature] on its corresponding layer.
+ * Returns the [FeatureLayer] associated with this [ArcGISFeature], or null if the feature's
+ * table is not associated with a [FeatureLayer].
  */
-fun FeatureForm.selectFeature() {
-    val table = feature.featureTable as? ArcGISFeatureTable ?: return
-    val layer = when (table.layer) {
-        is SubtypeFeatureLayer -> table.layer as SubtypeFeatureLayer
-        is FeatureLayer -> table.layer as FeatureLayer
-        else -> return
+val ArcGISFeature.layer: FeatureLayer?
+    get() {
+        val table = featureTable as? ArcGISFeatureTable ?: return null
+        return when (table.layer) {
+            is SubtypeFeatureLayer -> table.layer as SubtypeFeatureLayer
+            is FeatureLayer -> table.layer as FeatureLayer
+            else -> null
+        }
     }
-    layer.selectFeature(feature)
+
+/**
+ * Selects this feature in its associated layer, if any.
+ */
+fun ArcGISFeature.selectFeature() = layer?.selectFeature(this)
+
+/**
+ * Flashes this feature in its associated layer, if any, by selecting and unselecting it
+ * a given number of [times] with a delay of [delayMs] milliseconds between each selection
+ * and unselection.
+ */
+suspend fun ArcGISFeature.flashFeature(times: Int = 4, delayMs: Long = 500) {
+    val layer = layer ?: return
+    repeat(times) {
+        layer.selectFeature(this)
+        delay(delayMs)
+        layer.unselectFeature(this)
+        delay(delayMs)
+    }
 }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -434,7 +434,7 @@ class MapViewModel @Inject constructor(
      *
      * @param feature the feature to locate
      */
-    suspend fun locateFeature(feature: ArcGISFeature) {
+    suspend fun highlightFeature(feature: ArcGISFeature) {
         feature.geometry?.let { geometry ->
             // set the viewpoint to the feature geometry extent
             proxy.setViewpointAnimated(

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -41,6 +41,7 @@ import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.layers.SubtypeFeatureLayer
+import com.arcgismaps.mapping.view.AnimationCurve
 import com.arcgismaps.mapping.view.IdentifyLayerResult
 import com.arcgismaps.mapping.view.ScreenCoordinate
 import com.arcgismaps.mapping.view.SingleTapConfirmedEvent
@@ -56,6 +57,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * A UI state class that indicates the current editing state for a feature form.
@@ -432,16 +434,12 @@ class MapViewModel @Inject constructor(
      */
     suspend fun locateFeature(feature: ArcGISFeature) {
         feature.geometry?.let { geometry ->
-            // set the viewpoint to the feature geometry
+            // set the viewpoint to the feature geometry extent
             proxy.setViewpointAnimated(
-                viewpoint = Viewpoint(geometry)
+                Viewpoint(geometry.extent),
+                1.seconds,
+                AnimationCurve.EaseInOutCubic
             ).onSuccess {
-                feature.layer?.maxScale?.let {
-                    // clamp the scale to be at least 0.1 to avoid zooming in too close
-                    val scale = if (it > 0) it else 0.1
-                    // set the viewpoint scale to the layer's max scale
-                    proxy.setViewpointScale(scale)
-                }
                 // flash the feature to highlight it
                 feature.flashFeature()
             }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -40,6 +40,8 @@ import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.layers.FeatureLayer
+import com.arcgismaps.mapping.layers.GroupLayer
+import com.arcgismaps.mapping.layers.Layer
 import com.arcgismaps.mapping.layers.SubtypeFeatureLayer
 import com.arcgismaps.mapping.view.AnimationCurve
 import com.arcgismaps.mapping.view.IdentifyLayerResult
@@ -545,12 +547,20 @@ val List<FeatureEditResult>.errors: List<Throwable>
  */
 fun ArcGISMap.clearSelection() {
     operationalLayers.forEach { layer ->
-        when (layer) {
-            is FeatureLayer -> {
-                layer.clearSelection()
-            }
+        layer.clearSelection()
+    }
+}
 
-            else -> {}
+/**
+ * Clears any previously selected features in this [Layer] by clearing the selection on all
+ * sub layers if this is a [GroupLayer].
+ */
+fun Layer.clearSelection() {
+    if (this is FeatureLayer) {
+        this.clearSelection()
+    } else if (this is GroupLayer) {
+        this.layers.forEach { subLayer ->
+            subLayer.clearSelection()
         }
     }
 }

--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -31,7 +31,7 @@ public final class com/arcgismaps/toolkit/featureforms/FeatureFormEditingEvent$S
 }
 
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormKt {
-	public static final fun FeatureForm (Lcom/arcgismaps/toolkit/featureforms/FeatureFormState;Landroidx/compose/ui/Modifier;ZZZLcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormColorScheme;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;Landroidx/compose/runtime/Composer;III)V
+	public static final fun FeatureForm (Lcom/arcgismaps/toolkit/featureforms/FeatureFormState;Landroidx/compose/ui/Modifier;ZZZLcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormColorScheme;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormState {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -181,7 +181,7 @@ public sealed class FeatureFormEditingEvent {
  * @param onBarcodeButtonClick A callback that is invoked when the barcode accessory is clicked.
  * The callback is invoked with the [FieldFormElement] that has the barcode accessory. If null, the
  * default barcode scanner is used.
- * @param onFeatureLocateRequest A callback that is invoked when a request to locate a feature is made.
+ * @param onShowOnMapRequest A callback that is invoked when a request to highlight a feature is made.
  * Invoked when the locate icon is tapped on a [UtilityAssociationFeatureCandidate] inside a
  * [UtilityAssociationsFormElement] during new association candidate selection. This can be used to
  * highlight the feature in the map view, helping visually confirm the correct feature to associate.
@@ -206,7 +206,7 @@ public fun FeatureForm(
     isNavigationEnabled : Boolean = true,
     validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.Automatic,
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)? = null,
-    onFeatureLocateRequest : ((ArcGISFeature) -> Unit)? = null,
+    onShowOnMapRequest : ((ArcGISFeature) -> Unit)? = null,
     onDismiss: () -> Unit = {},
     onEditingEvent: (FeatureFormEditingEvent) -> Unit = {},
     colorScheme: FeatureFormColorScheme = FeatureFormDefaults.colorScheme(),
@@ -303,8 +303,8 @@ public fun FeatureForm(
                 onSaveForm = ::saveForm,
                 onDiscardForm = ::discardForm,
                 onBarcodeButtonClick = onBarcodeButtonClick,
-                onFeatureLocateRequest = { feature ->
-                    onFeatureLocateRequest?.invoke(feature)
+                onShowOnMapRequest = { feature ->
+                    onShowOnMapRequest?.invoke(feature)
                 },
                 modifier = Modifier.fillMaxSize()
             )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -44,6 +43,7 @@ import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.DialogNavigator
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
 import com.arcgismaps.mapping.featureforms.BarcodeScannerFormInput
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -53,6 +53,7 @@ import com.arcgismaps.mapping.featureforms.FormInput
 import com.arcgismaps.mapping.featureforms.GroupFormElement
 import com.arcgismaps.mapping.featureforms.TextFormElement
 import com.arcgismaps.mapping.featureforms.UtilityAssociationsFormElement
+import com.arcgismaps.mapping.featureforms.UtilityAssociationFeatureCandidate
 import com.arcgismaps.toolkit.featureforms.internal.components.text.TextFormElement
 import com.arcgismaps.toolkit.featureforms.internal.navigation.FeatureFormNavHost
 import com.arcgismaps.toolkit.featureforms.internal.screens.ContentAwareTopBar
@@ -180,6 +181,11 @@ public sealed class FeatureFormEditingEvent {
  * @param onBarcodeButtonClick A callback that is invoked when the barcode accessory is clicked.
  * The callback is invoked with the [FieldFormElement] that has the barcode accessory. If null, the
  * default barcode scanner is used.
+ * @param onFeatureLocateRequest A callback that is invoked when a request to locate a feature is made.
+ * Invoked when the locate icon is tapped on a [UtilityAssociationFeatureCandidate] inside a
+ * [UtilityAssociationsFormElement] during new association candidate selection. This can be used to
+ * highlight the feature in the map view, helping visually confirm the correct feature to associate.
+ * Note that this in only invoked for spatial features that have a geometry.
  * @param onDismiss A callback that is invoked when the close icon is visible and is clicked.
  * @param onEditingEvent A callback that is invoked when an editing event occurs in the form. This
  * is triggered when the edits are saved or discarded using the save or discard buttons, respectively.
@@ -200,6 +206,7 @@ public fun FeatureForm(
     isNavigationEnabled : Boolean = true,
     validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.Automatic,
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)? = null,
+    onFeatureLocateRequest : ((ArcGISFeature) -> Unit)? = null,
     onDismiss: () -> Unit = {},
     onEditingEvent: (FeatureFormEditingEvent) -> Unit = {},
     colorScheme: FeatureFormColorScheme = FeatureFormDefaults.colorScheme(),
@@ -296,6 +303,9 @@ public fun FeatureForm(
                 onSaveForm = ::saveForm,
                 onDiscardForm = ::discardForm,
                 onBarcodeButtonClick = onBarcodeButtonClick,
+                onFeatureLocateRequest = { feature ->
+                    onFeatureLocateRequest?.invoke(feature)
+                },
                 modifier = Modifier.fillMaxSize()
             )
         },

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/AddFromSourceNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/AddFromSourceNavigation.kt
@@ -28,6 +28,7 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.AddAssociationFromSourceViewModel
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
@@ -105,6 +106,7 @@ internal fun NavGraphBuilder.selectAssetTypeDestination(
 internal fun NavGraphBuilder.selectFeatureDestination(
     onBackPressed: (NavBackStackEntry) -> Unit,
     onFeatureCandidateSelected: (NavBackStackEntry) -> Unit,
+    onFeatureCandidateLocateRequest : (ArcGISFeature) -> Unit,
     onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry,
 ) {
     composable<AddFromSourceNavRoute.SelectAssociatedFeature> { backStackEntry ->
@@ -119,6 +121,7 @@ internal fun NavGraphBuilder.selectFeatureDestination(
             onFeatureCandidateSelected = {
                 onFeatureCandidateSelected(backStackEntry)
             },
+            onFeatureCandidateLocateRequest = onFeatureCandidateLocateRequest,
             modifier = Modifier.fillMaxSize()
         )
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
@@ -42,7 +42,7 @@ internal fun FeatureFormNavHost(
     onSaveForm: suspend (FeatureForm, Boolean) -> Result<Unit>,
     onDiscardForm: suspend (Boolean) -> Unit,
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)?,
-    onFeatureLocateRequest: (ArcGISFeature) -> Unit,
+    onShowOnMapRequest: (ArcGISFeature) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -102,7 +102,7 @@ internal fun FeatureFormNavHost(
                 onFeatureCandidateSelected = { backStackEntry ->
                   navController.navigateToCreateAssociation(backStackEntry)
                 },
-                onFeatureCandidateLocateRequest = onFeatureLocateRequest,
+                onFeatureCandidateLocateRequest = onShowOnMapRequest,
                 onGetParentEntry = {
                     navController.getBackStackEntry(it.destination.parent!!.id)
                 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
@@ -27,6 +27,7 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navigation
+import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
@@ -41,6 +42,7 @@ internal fun FeatureFormNavHost(
     onSaveForm: suspend (FeatureForm, Boolean) -> Result<Unit>,
     onDiscardForm: suspend (Boolean) -> Unit,
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)?,
+    onFeatureLocateRequest: (ArcGISFeature) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -100,6 +102,7 @@ internal fun FeatureFormNavHost(
                 onFeatureCandidateSelected = { backStackEntry ->
                   navController.navigateToCreateAssociation(backStackEntry)
                 },
+                onFeatureCandidateLocateRequest = onFeatureLocateRequest,
                 onGetParentEntry = {
                     navController.getBackStackEntry(it.destination.parent!!.id)
                 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/SelectAssociatedFeatureScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/SelectAssociatedFeatureScreen.kt
@@ -90,6 +90,7 @@ internal fun SelectAssociatedFeatureScreen(
     viewModel: AddAssociationFromSourceViewModel,
     onBackPressed: () -> Unit,
     onFeatureCandidateSelected: () -> Unit,
+    onFeatureCandidateLocateRequest : (ArcGISFeature) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val scope = rememberCoroutineScope()
@@ -97,7 +98,7 @@ internal fun SelectAssociatedFeatureScreen(
     val state by viewModel.filteredFeatureCandidatesUiState.collectAsState()
     val candidates = state.candidates
     val count = candidates.count()
-    val title = if (state.isLoading){
+    val title = if (state.isLoading) {
         stringResource(R.string.loading2)
     } else {
         stringResource(R.string.available_features, count)
@@ -199,19 +200,21 @@ internal fun SelectAssociatedFeatureScreen(
                                             modifier = Modifier.padding(start = 12.dp)
                                         )
                                     },
-                                    trailingContent = {
-                                        IconButton(
-                                            onClick = {
-                                                // TODO: Handle locate feature on map
+                                    trailingContent = if (item.feature.geometry != null) {
+                                        {
+                                            IconButton(
+                                                onClick = {
+                                                    onFeatureCandidateLocateRequest(item.feature)
+                                                }
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Outlined.LocationSearching,
+                                                    contentDescription = "Locate Feature",
+                                                    modifier = Modifier.size(24.dp)
+                                                )
                                             }
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Outlined.LocationSearching,
-                                                contentDescription = "Locate Feature",
-                                                modifier = Modifier.size(24.dp)
-                                            )
                                         }
-                                    },
+                                    } else null,
                                     colors = ListItemDefaults.colors(
                                         containerColor = MaterialTheme.colorScheme.surfaceBright,
                                     )
@@ -234,7 +237,7 @@ internal fun SelectAssociatedFeatureScreen(
 @Composable
 private fun EmptyResultsRow(modifier: Modifier = Modifier) {
     val color = LocalContentColor.current
-    Column (
+    Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/1468](https://devtopia.esri.com/runtime/apollo/issues/1468)

<!-- link to design, if applicable -->

### Description:

Adds a new callback parameter to the `FeatureForm` composable to propagate any locate tap events on feature candidates.

### Summary of changes:

- Exposed new parameter `onFeatureLocateRequest : ((ArcGISFeature) -> Unit)?`. Also looking for suggestions on a better name.
- Wired up this new event internally.
- Updated micro-app to zoom and highlight the feature in response to this event.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1004/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  