### PR TITLE
Fixes OAuth WebView authentication bypassing the Network Authentication Handler set on ArcGISEnvironment 

### DIFF
--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
@@ -260,6 +260,7 @@ private class OAuthWebViewClient(
                     networkAuthenticationType,
                     exception
                 )
+                // Invoke the network challenge handler on AuthenticationManager instead of the one on AuthenticatorState, to allow intercepting clients to get their own challenge handler invoked. 
                 // If the challenge handler is null, null is returned to the caller which will cancel the request with the
                 // exception provided
                 val response = ArcGISEnvironment.authenticationManager.networkAuthenticationChallengeHandler

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
@@ -247,18 +247,24 @@ private class OAuthWebViewClient(
         exception: Exception,
         networkAuthenticationType: NetworkAuthenticationType
     ): NetworkCredential? {
+        // Check if we have a stored credential for this host
         val credentialList =
             ArcGISEnvironment.authenticationManager.networkCredentialStore.getCredentials(host).getOrNull()
         val credential: NetworkCredential? =
             if (!credentialList.isNullOrEmpty()) {
                 credentialList.first()
             } else {
+                // If no stored credential, raise a NetworkAuthenticationChallenge to prompt for one
                 val credentialChallenge = NetworkAuthenticationChallenge(
                     host,
                     networkAuthenticationType,
                     exception
                 )
-                when (val response = authenticatorState.handleNetworkAuthenticationChallenge(credentialChallenge)) {
+                // If the challenge handler is null, null is returned to the caller which will cancel the request with the
+                // exception provided
+                val response = ArcGISEnvironment.authenticationManager.networkAuthenticationChallengeHandler
+                    ?.handleNetworkAuthenticationChallenge(credentialChallenge)
+                when (response) {
                     is NetworkAuthenticationChallengeResponse.ContinueWithCredential -> response.credential
                     else -> null
                 }

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/OAuthWebView.kt
@@ -97,7 +97,7 @@ private class OAuthWebViewClient(
 ) : WebViewClient() {
 
     /**
-     * Takes control of the page loading in the [webView] if the URL in the [request] contains the approval code
+     * Takes control of the page loading in the `WebView` if the URL in the [request] contains the approval code
      * and calls [OAuthUserSignIn.complete] with the redirect URL.
      *
      * @param view the WebView that is initiating this callback.


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/6735

<!-- link to design, if applicable -->

### Summary of changes:
- Fixes bug where the `AuthenticationState.NetworkAuthenticationChallengeHandler` was invoked when handling `NetworkAuthenticationChallenges` when authenticating through `WebView`. 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  - [ ] Performed manual test with SAML/PKI & SAML/Custom forms portals 
  