### PR TITLE
`FeatureForm` : Use correct overload for adding a UN Association

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -411,6 +411,16 @@ internal class AddAssociationFromSourceViewModel(
                         }
                     }
 
+                    // no terminals, but fraction along edge provided
+                    fractionAlongEdge != null -> {
+                        // edge to edge
+                        element.addAssociation(
+                            feature = feature,
+                            filter = filter,
+                            fractionAlongEdge = fractionAlongEdge.toDouble()
+                        )
+                    }
+
                     // edge to edge or junction to junction without terminals
                     else -> {
                         element.addAssociation(


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/1473](https://devtopia.esri.com/runtime/apollo/issues/1473)

<!-- link to design, if applicable -->

### Description:

This PR fixes an issue where creating an connectivity association with only a fraction along edge wasn't handled correctly.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  