### PR TITLE
Guard SuspendableCancellableCoroutine to only be resumed once

### DIFF
--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ClientCertificateAuthenticationTest.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ClientCertificateAuthenticationTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.authentication
+
+import com.arcgismaps.httpcore.authentication.CertificateCredential
+import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallenge
+import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallengeResponse
+import com.arcgismaps.httpcore.authentication.NetworkAuthenticationType
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Tests for certificate authentication handling.
+ *
+ * @since 200.8.1
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ClientCertificateAuthenticationTest {
+
+    /**
+     * Given a certificate challenge,
+     * When both the alias callback and cancel callback are invoked nearly simultaneously,
+     * Then only the first callback to be invoked is processed and the other is ignored.
+     * @since 200.8.1
+     */
+    @Test
+    fun testCertificateChallengeCallbackIsResumedOnlyOnce() = runTest {
+        val authenticatorState = AuthenticatorState()
+        val challenge = NetworkAuthenticationChallenge(
+            hostname = "test.server.com",
+            networkAuthenticationType = NetworkAuthenticationType.ClientCertificate,
+            cause = Exception("Certificate challenge exception")
+        )
+
+        val deferred = async {
+            authenticatorState.handleNetworkAuthenticationChallenge(challenge)
+        }
+
+        advanceUntilIdle()
+        val pending = authenticatorState.pendingClientCertificateChallenge.value
+        assertThat(pending).isNotNull()
+
+        // Simulate both callbacks being called nearly simultaneously
+        pending?.keyChainAliasCallback?.alias("alias-1")
+        pending?.onCancel?.invoke() // This should be ignored by the atomic boolean
+
+        val response = deferred.await()
+        assertThat(response).isInstanceOf(NetworkAuthenticationChallengeResponse.ContinueWithCredential::class.java)
+        val credential = (response as NetworkAuthenticationChallengeResponse.ContinueWithCredential).credential
+        assertThat((credential as CertificateCredential).alias).isEqualTo("alias-1")
+    }
+
+    /**
+     * Given a certificate challenge,
+     * When the cancel callback is invoked before the alias callback,
+     * Then only the cancel callback is processed and the alias callback is ignored.
+     * @since 200.8.1
+     */
+    @Test
+    fun testCertificateChallengeCancelCallbackIsResumedOnlyOnce() = runTest {
+        val authenticatorState = AuthenticatorState()
+        val challenge = NetworkAuthenticationChallenge(
+            hostname = "test.server.com",
+            networkAuthenticationType = NetworkAuthenticationType.ClientCertificate,
+            cause = Exception("Certificate challenge exception")
+        )
+
+        val deferred = async {
+            authenticatorState.handleNetworkAuthenticationChallenge(challenge)
+        }
+
+        advanceUntilIdle()
+        val pending = authenticatorState.pendingClientCertificateChallenge.value
+        assertThat(pending).isNotNull()
+
+        // Simulate cancel callback being called before alias callback
+        pending?.onCancel?.invoke()
+        pending?.keyChainAliasCallback?.alias("alias-1") // This should be ignored
+
+        val response = deferred.await()
+        assertThat(response).isInstanceOf(NetworkAuthenticationChallengeResponse.Cancel::class.java)
+    }
+}

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -40,6 +40,7 @@ import com.arcgismaps.httpcore.authentication.OAuthUserSignIn
 import com.arcgismaps.httpcore.authentication.PasswordCredential
 import com.arcgismaps.httpcore.authentication.ServerTrust
 import com.arcgismaps.httpcore.authentication.TokenCredential
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
@@ -386,24 +387,33 @@ private class AuthenticatorStateImpl(
      */
     private suspend fun awaitCertificateChallengeResponse(): NetworkAuthenticationChallengeResponse {
         val selectedAlias = suspendCancellableCoroutine<String?> { continuation ->
+            val hasResumed = AtomicBoolean(false)
+
+            /**
+             * Local function to resume the continuation only once.
+             * @param value the alias to resume with, or null if cancelling.
+             */
+            fun resumeOnce(value: String?) {
+                if (hasResumed.getAndSet(true)) return
+                _pendingClientCertificateChallenge.value = null
+                continuation.resume(value) { _, _, _ -> }
+            }
+
             val aliasCallback = KeyChainAliasCallback { alias ->
-                _pendingClientCertificateChallenge.value = null
-                continuation.resume(alias) { _, _, _ -> }
+                resumeOnce(alias)
             }
-            _pendingClientCertificateChallenge.value = ClientCertificateChallenge(aliasCallback) {
-                _pendingClientCertificateChallenge.value = null
-                continuation.resume(null) { _, _, _ -> }
-            }
-            continuation.invokeOnCancellation {
-                _pendingClientCertificateChallenge.value = null
-                continuation.resume(null) { _, _, _ -> }
-            }
+
+            _pendingClientCertificateChallenge.value =
+                ClientCertificateChallenge(
+                    aliasCallback,
+                    onCancel = { resumeOnce(null) }
+                )
+
+            continuation.invokeOnCancellation { resumeOnce(null) }
         }
         return if (selectedAlias != null) {
             NetworkAuthenticationChallengeResponse.ContinueWithCredential(
-                CertificateCredential(
-                    selectedAlias
-                )
+                CertificateCredential(selectedAlias)
             )
         } else {
             NetworkAuthenticationChallengeResponse.Cancel


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/6742

<!-- link to design, if applicable -->
### Summary of changes:
- Guards against `resume` being more than once
- Adds test cases  

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1007/ -> ClientCertificateAuthenticationTest are passing ✅ 
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  