### PR TITLE
Authenticator: Fix bug with resuming more than once

### DIFF
--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ClientCertificateChallengeTest.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ClientCertificateChallengeTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.authentication
+
+import com.arcgismaps.httpcore.authentication.CertificateCredential
+import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallenge
+import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallengeResponse
+import com.arcgismaps.httpcore.authentication.NetworkAuthenticationType
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Tests for certificate authentication handling.
+ *
+ * @since 200.8.1
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ClientCertificateChallengeTest {
+
+    /**
+     * Given a certificate challenge,
+     * When both the alias callback and cancel callback are invoked nearly simultaneously,
+     * Then only the first callback to be invoked is processed and the other is ignored.
+     * @since 200.8.1
+     */
+    @Test
+    fun testCertificateChallengeCallbackIsResumedOnlyOnce() = runTest {
+        val authenticatorState = AuthenticatorState()
+        val challenge = NetworkAuthenticationChallenge(
+            hostname = "test.server.com",
+            networkAuthenticationType = NetworkAuthenticationType.ClientCertificate,
+            cause = Exception("Certificate challenge exception")
+        )
+
+        val deferred = async {
+            authenticatorState.handleNetworkAuthenticationChallenge(challenge)
+        }
+
+        advanceUntilIdle()
+        val pending = authenticatorState.pendingClientCertificateChallenge.value
+        assertThat(pending).isNotNull()
+
+        // Simulate both callbacks being called nearly simultaneously
+        pending?.keyChainAliasCallback?.alias("alias-1")
+        pending?.onCancel?.invoke() // This should be ignored by the atomic boolean
+
+        val response = deferred.await()
+        assertThat(response).isInstanceOf(NetworkAuthenticationChallengeResponse.ContinueWithCredential::class.java)
+        val credential = (response as NetworkAuthenticationChallengeResponse.ContinueWithCredential).credential
+        assertThat((credential as CertificateCredential).alias).isEqualTo("alias-1")
+    }
+
+    /**
+     * Given a certificate challenge,
+     * When the cancel callback is invoked before the alias callback,
+     * Then only the cancel callback is processed and the alias callback is ignored.
+     * @since 200.8.1
+     */
+    @Test
+    fun testCertificateChallengeCancelCallbackIsResumedOnlyOnce() = runTest {
+        val authenticatorState = AuthenticatorState()
+        val challenge = NetworkAuthenticationChallenge(
+            hostname = "test.server.com",
+            networkAuthenticationType = NetworkAuthenticationType.ClientCertificate,
+            cause = Exception("Certificate challenge exception")
+        )
+
+        val deferred = async {
+            authenticatorState.handleNetworkAuthenticationChallenge(challenge)
+        }
+
+        advanceUntilIdle()
+        val pending = authenticatorState.pendingClientCertificateChallenge.value
+        assertThat(pending).isNotNull()
+
+        // Simulate cancel callback being called before alias callback
+        pending?.onCancel?.invoke()
+        pending?.keyChainAliasCallback?.alias("alias-1") // This should be ignored
+
+        val response = deferred.await()
+        assertThat(response).isInstanceOf(NetworkAuthenticationChallengeResponse.Cancel::class.java)
+    }
+
+    /**
+     * Given a certificate challenge,
+     * When the parent coroutine is cancelled before responding to the challenge,
+     * Then the challenge handling resumes with cancellation
+     * And the pending challenge is cleared.
+     * @since 200.8.1
+     */
+    @Test
+    fun testClientCertChallengeParentCoroutineCancellationReturnsCancel() = runTest {
+        var caughtException: Throwable? = null
+        val authenticatorState = AuthenticatorState()
+        val challenge = NetworkAuthenticationChallenge(
+            hostname = "test.server.com",
+            networkAuthenticationType = NetworkAuthenticationType.ClientCertificate,
+            cause = Exception("Client Certificate challenge exception")
+        )
+        val job = async {
+            authenticatorState.handleNetworkAuthenticationChallenge(challenge)
+        }
+
+        advanceUntilIdle()
+        val pending = authenticatorState.pendingClientCertificateChallenge.value
+        assertThat(pending).isNotNull()
+        job.cancel() // Cancel the parent coroutine before responding
+        try {
+            job.await()
+        } catch (e: Exception) {
+            // Expected cancellation exception
+            caughtException = e
+        }
+        assertThat(caughtException).isInstanceOf(kotlinx.coroutines.CancellationException::class.java)
+        // Ensure that the pending challenge is cleared
+        assertThat(authenticatorState.pendingClientCertificateChallenge.value).isNull()
+    }
+}

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ClientCertificateChallengeTest.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ClientCertificateChallengeTest.kt
@@ -30,7 +30,7 @@ import org.junit.Test
 /**
  * Tests for certificate authentication handling.
  *
- * @since 200.8.1
+ * @since 300.0.0
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ClientCertificateChallengeTest {
@@ -39,7 +39,7 @@ class ClientCertificateChallengeTest {
      * Given a certificate challenge,
      * When both the alias callback and cancel callback are invoked nearly simultaneously,
      * Then only the first callback to be invoked is processed and the other is ignored.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun testCertificateChallengeCallbackIsResumedOnlyOnce() = runTest {
@@ -72,7 +72,7 @@ class ClientCertificateChallengeTest {
      * Given a certificate challenge,
      * When the cancel callback is invoked before the alias callback,
      * Then only the cancel callback is processed and the alias callback is ignored.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun testCertificateChallengeCancelCallbackIsResumedOnlyOnce() = runTest {
@@ -104,7 +104,7 @@ class ClientCertificateChallengeTest {
      * When the parent coroutine is cancelled before responding to the challenge,
      * Then the challenge handling resumes with cancellation
      * And the pending challenge is cleared.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun testClientCertChallengeParentCoroutineCancellationReturnsCancel() = runTest {

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ServerTrustChallengeTest.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ServerTrustChallengeTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.authentication
+
+import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallenge
+import com.arcgismaps.httpcore.authentication.NetworkAuthenticationChallengeResponse
+import com.arcgismaps.httpcore.authentication.NetworkAuthenticationType
+import com.arcgismaps.httpcore.authentication.ServerTrust
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Tests for server trust challenge handling.
+ *
+ * @since 200.8.1
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerTrustChallengeTest {
+    /**
+     * Given a server trust challenge,
+     * When both the trust and distrust callbacks are invoked nearly simultaneously,
+     * Then only the first callback to be invoked is processed and the other is ignored.
+     * @since 200.8.1
+     */
+    @Test
+    fun testServerTrustChallengeWithTrustFirstIsResumedOnlyOnce() = runTest {
+        val authenticatorState = AuthenticatorState()
+        val challenge = NetworkAuthenticationChallenge(
+            hostname = "test.server.com",
+            networkAuthenticationType = NetworkAuthenticationType.ServerTrust,
+            cause = Exception("Server trust challenge exception")
+        )
+
+        val deferred = async {
+            authenticatorState.handleNetworkAuthenticationChallenge(challenge)
+        }
+
+        advanceUntilIdle()
+        val pending = authenticatorState.pendingServerTrustChallenge.value
+        assertThat(pending).isNotNull()
+
+        // Simulate both callbacks being called nearly simultaneously
+        pending?.trust()
+        pending?.distrust() // This should be ignored
+
+        val response = deferred.await()
+        assertThat(response).isInstanceOf(NetworkAuthenticationChallengeResponse.ContinueWithCredential::class.java)
+        val credential = (response as NetworkAuthenticationChallengeResponse.ContinueWithCredential).credential
+        assertThat(credential).isInstanceOf(ServerTrust::class.java)
+    }
+
+    /**
+     * Given a server trust challenge,
+     * When both the distrust and trust callbacks are invoked nearly simultaneously,
+     * Then only the first callback to be invoked is processed and the other is ignored.
+     * @since 200.8.1
+     */
+    @Test
+    fun testServerTrustChallengeWithDistrustFirstIsResumedOnlyOnce() = runTest {
+        val authenticatorState = AuthenticatorState()
+        val challenge = NetworkAuthenticationChallenge(
+            hostname = "test.server.com",
+            networkAuthenticationType = NetworkAuthenticationType.ServerTrust,
+            cause = Exception("Server trust challenge exception")
+        )
+
+        val deferred = async {
+            authenticatorState.handleNetworkAuthenticationChallenge(challenge)
+        }
+
+        advanceUntilIdle()
+        val pending = authenticatorState.pendingServerTrustChallenge.value
+        assertThat(pending).isNotNull()
+
+        // Simulate distrust callback being called before trust callback
+        pending?.distrust()
+        pending?.trust() // This should be ignored
+
+        val response = deferred.await()
+        assertThat(response).isInstanceOf(NetworkAuthenticationChallengeResponse.Cancel::class.java)
+    }
+
+    /**
+     * Given a server trust challenge,
+     * When the parent coroutine is cancelled before responding,
+     * Then a CancellationException is thrown
+     * And the pending challenge is cleared.
+     * @since 200.8.1
+     */
+    @Test
+    fun testServerTrustChallengeParentCoroutineCancellationReturnsCancel() = runTest {
+        var expectedException: Throwable? = null
+        val authenticatorState = AuthenticatorState()
+        val challenge = NetworkAuthenticationChallenge(
+            hostname = "test.server.com",
+            networkAuthenticationType = NetworkAuthenticationType.ServerTrust,
+            cause = Exception("Server trust challenge exception")
+        )
+        val job = async {
+            authenticatorState.handleNetworkAuthenticationChallenge(challenge)
+        }
+
+        advanceUntilIdle()
+        val pending = authenticatorState.pendingServerTrustChallenge.value
+        assertThat(pending).isNotNull()
+        job.cancel() // Cancel the parent coroutine before responding
+        try {
+            job.await()
+        } catch (e: Exception) {
+            // Expected cancellation exception
+            expectedException = e
+        }
+        assertThat(expectedException).isInstanceOf(kotlinx.coroutines.CancellationException::class.java)
+        // Ensure that the pending challenge is cleared
+        assertThat(authenticatorState.pendingServerTrustChallenge.value).isNull()
+    }
+}

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ServerTrustChallengeTest.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/ServerTrustChallengeTest.kt
@@ -30,7 +30,7 @@ import org.junit.Test
 /**
  * Tests for server trust challenge handling.
  *
- * @since 200.8.1
+ * @since 300.0.0
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ServerTrustChallengeTest {
@@ -38,7 +38,7 @@ class ServerTrustChallengeTest {
      * Given a server trust challenge,
      * When both the trust and distrust callbacks are invoked nearly simultaneously,
      * Then only the first callback to be invoked is processed and the other is ignored.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun testServerTrustChallengeWithTrustFirstIsResumedOnlyOnce() = runTest {
@@ -71,7 +71,7 @@ class ServerTrustChallengeTest {
      * Given a server trust challenge,
      * When both the distrust and trust callbacks are invoked nearly simultaneously,
      * Then only the first callback to be invoked is processed and the other is ignored.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun testServerTrustChallengeWithDistrustFirstIsResumedOnlyOnce() = runTest {
@@ -103,7 +103,7 @@ class ServerTrustChallengeTest {
      * When the parent coroutine is cancelled before responding,
      * Then a CancellationException is thrown
      * And the pending challenge is cleared.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun testServerTrustChallengeParentCoroutineCancellationReturnsCancel() = runTest {

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -396,7 +396,6 @@ private class AuthenticatorStateImpl(
             }
             safeContinuation.invokeOnCancellation {
                 _pendingClientCertificateChallenge.value = null
-                safeContinuation.resumeSafely(null)
             }
         }
 
@@ -435,7 +434,6 @@ private class AuthenticatorStateImpl(
 
             safeContinuation.invokeOnCancellation {
                 _pendingServerTrustChallenge.value = null
-                safeContinuation.resumeSafely(null)
             }
         }
 

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -40,6 +40,7 @@ import com.arcgismaps.httpcore.authentication.OAuthUserSignIn
 import com.arcgismaps.httpcore.authentication.PasswordCredential
 import com.arcgismaps.httpcore.authentication.ServerTrust
 import com.arcgismaps.httpcore.authentication.TokenCredential
+import com.arcgismaps.toolkit.authentication.utils.safeSuspendableCancellable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
@@ -50,7 +51,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.suspendCancellableCoroutine
 
 /**
  * Handles authentication challenges and exposes state for the [Authenticator] to display to the user.
@@ -385,20 +385,21 @@ private class AuthenticatorStateImpl(
      * @since 200.2.0
      */
     private suspend fun awaitCertificateChallengeResponse(): NetworkAuthenticationChallengeResponse {
-        val selectedAlias = suspendCancellableCoroutine<String?> { continuation ->
+        val selectedAlias = safeSuspendableCancellable<String?> { safeContinuation ->
             val aliasCallback = KeyChainAliasCallback { alias ->
                 _pendingClientCertificateChallenge.value = null
-                continuation.resume(alias) { _, _, _ -> }
+                safeContinuation.resumeSafely(alias)
             }
             _pendingClientCertificateChallenge.value = ClientCertificateChallenge(aliasCallback) {
                 _pendingClientCertificateChallenge.value = null
-                continuation.resume(null) { _, _, _ -> }
+                safeContinuation.resumeSafely(null)
             }
-            continuation.invokeOnCancellation {
+            safeContinuation.invokeOnCancellation {
                 _pendingClientCertificateChallenge.value = null
-                continuation.resume(null) { _, _, _ -> }
+                safeContinuation.resumeSafely(null)
             }
         }
+
         return if (selectedAlias != null) {
             NetworkAuthenticationChallengeResponse.ContinueWithCredential(
                 CertificateCredential(
@@ -418,29 +419,30 @@ private class AuthenticatorStateImpl(
      * @return [NetworkAuthenticationChallengeResponse] based on user response.
      * @since 200.2.0
      */
-    private suspend fun awaitServerTrustChallengeResponse(networkAuthenticationChallenge: NetworkAuthenticationChallenge): NetworkAuthenticationChallengeResponse =
-        suspendCancellableCoroutine { continuation ->
-            _pendingServerTrustChallenge.value =
-                ServerTrustChallenge(networkAuthenticationChallenge) { shouldTrustServer ->
+    private suspend fun awaitServerTrustChallengeResponse(
+        networkAuthenticationChallenge: NetworkAuthenticationChallenge
+    ): NetworkAuthenticationChallengeResponse {
+        val response = safeSuspendableCancellable<Boolean?> { safeContinuation ->
+            val serverTrustChallenge = ServerTrustChallenge(
+                networkAuthenticationChallenge, onUserResponseReceived = { shouldTrustServer ->
                     _pendingServerTrustChallenge.value = null
-                    if (shouldTrustServer) continuation.resumeWith(
-                        Result.success(
-                            NetworkAuthenticationChallengeResponse.ContinueWithCredential(
-                                ServerTrust
-                            )
-                        )
-                    )
-                    else continuation.resumeWith(
-                        Result.success(
-                            NetworkAuthenticationChallengeResponse.Cancel
-                        )
-                    )
-                }
-            continuation.invokeOnCancellation {
+                    safeContinuation.resumeSafely(shouldTrustServer)
+                })
+
+            _pendingServerTrustChallenge.value = serverTrustChallenge
+
+            safeContinuation.invokeOnCancellation {
                 _pendingServerTrustChallenge.value = null
-                continuation.resumeWith(Result.success(NetworkAuthenticationChallengeResponse.Cancel))
+                safeContinuation.resumeSafely(null)
             }
         }
+
+        return if (response == true) {
+            NetworkAuthenticationChallengeResponse.ContinueWithCredential(ServerTrust)
+        } else {
+            NetworkAuthenticationChallengeResponse.Cancel
+        }
+    }
 
     /**
      * Emits a [UsernamePasswordChallenge] to [pendingUsernamePasswordChallenge] and returns any responses

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -40,7 +40,7 @@ import com.arcgismaps.httpcore.authentication.OAuthUserSignIn
 import com.arcgismaps.httpcore.authentication.PasswordCredential
 import com.arcgismaps.httpcore.authentication.ServerTrust
 import com.arcgismaps.httpcore.authentication.TokenCredential
-import com.arcgismaps.toolkit.authentication.utils.safeSuspendableCancellable
+import com.arcgismaps.toolkit.authentication.utils.suspendWithSafeContinuation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
@@ -385,7 +385,7 @@ private class AuthenticatorStateImpl(
      * @since 200.2.0
      */
     private suspend fun awaitCertificateChallengeResponse(): NetworkAuthenticationChallengeResponse {
-        val selectedAlias = safeSuspendableCancellable<String?> { safeContinuation ->
+        val selectedAlias = suspendWithSafeContinuation<String?> { safeContinuation ->
             val aliasCallback = KeyChainAliasCallback { alias ->
                 _pendingClientCertificateChallenge.value = null
                 safeContinuation.resumeSafely(alias)
@@ -422,12 +422,14 @@ private class AuthenticatorStateImpl(
     private suspend fun awaitServerTrustChallengeResponse(
         networkAuthenticationChallenge: NetworkAuthenticationChallenge
     ): NetworkAuthenticationChallengeResponse {
-        val response = safeSuspendableCancellable<Boolean?> { safeContinuation ->
+        val shouldTrustServer = suspendWithSafeContinuation<Boolean?> { safeContinuation ->
             val serverTrustChallenge = ServerTrustChallenge(
-                networkAuthenticationChallenge, onUserResponseReceived = { shouldTrustServer ->
+                challenge = networkAuthenticationChallenge,
+                onUserResponseReceived = { response ->
                     _pendingServerTrustChallenge.value = null
-                    safeContinuation.resumeSafely(shouldTrustServer)
-                })
+                    safeContinuation.resumeSafely(response)
+                }
+            )
 
             _pendingServerTrustChallenge.value = serverTrustChallenge
 
@@ -437,7 +439,7 @@ private class AuthenticatorStateImpl(
             }
         }
 
-        return if (response == true) {
+        return if (shouldTrustServer == true) {
             NetworkAuthenticationChallengeResponse.ContinueWithCredential(ServerTrust)
         } else {
             NetworkAuthenticationChallengeResponse.Cancel

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/utils/SafeContinuation.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/utils/SafeContinuation.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.CoroutineContext
 
 /**
- * A continuation that can be safely resumed only once.
+ * A coroutine continuation that can be safely resumed only once.
  *
  * This is useful for callback-style APIs that may invoke completion more than once.
  *
@@ -31,7 +31,7 @@ import kotlin.coroutines.CoroutineContext
 internal class SafeContinuation<T> {
     /**
      *  The underlying cancellable continuation.
-     *  It is initialized when [suspendCancellable] is called, which should be set before
+     *  It is initialized when [suspendCancellableCoroutine] is called, which should be set before
      *  [resumeSafely] or [invokeOnCancellation] is called.
      */
     private lateinit var continuation: CancellableContinuation<T>
@@ -66,7 +66,7 @@ internal class SafeContinuation<T> {
      */
     fun <R : T> resumeSafely(
         value: R,
-        onCancellation: ((cause: Throwable, value: R, context: CoroutineContext) -> Unit) = { _, _, _ -> }
+        onCancellation: ((cause: Throwable, value: R, context: CoroutineContext) -> Unit)? = null
     ) {
         if (hasResumed.compareAndSet(false, true)) {
             continuation.resume(value, onCancellation)
@@ -77,11 +77,11 @@ internal class SafeContinuation<T> {
     /**
      * Registers a handler to be invoked if the continuation is cancelled.
      *
-     * @param block The block to invoke on cancellation.
+     * @param handler The cancellation handler to be invoked with the cancellation cause.
      * @since 200.8.1
      */
-    fun invokeOnCancellation(block: () -> Unit) {
-        continuation.invokeOnCancellation { block() }
+    fun invokeOnCancellation(handler: (Throwable?) -> Unit) {
+        continuation.invokeOnCancellation(handler)
     }
 }
 
@@ -95,7 +95,7 @@ internal class SafeContinuation<T> {
  * @return the successful value.
  * @since 200.8.1
  */
-internal suspend inline fun <T> safeSuspendableCancellable(
+internal suspend inline fun <T> suspendWithSafeContinuation(
     crossinline block: (SafeContinuation<T>) -> Unit
 ): T = SafeContinuation<T>().suspendCancellable {
     block(it)

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/utils/SafeContinuation.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/utils/SafeContinuation.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.authentication.utils
+
+import kotlinx.coroutines.CancellableContinuation
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A continuation that can be safely resumed only once.
+ *
+ * This is useful for callback-style APIs that may invoke completion more than once.
+ *
+ * @since 200.8.1
+ */
+internal class SafeContinuation<T> {
+    /**
+     *  The underlying cancellable continuation.
+     *  It is initialized when [suspendCancellable] is called, which should be set before
+     *  [resumeSafely] or [invokeOnCancellation] is called.
+     */
+    private lateinit var continuation: CancellableContinuation<T>
+
+    /**
+     * Indicates whether this continuation has already been resumed.
+     * This is used to ensure that [resumeSafely] only resumes the continuation once.
+     */
+    private val hasResumed: AtomicBoolean = AtomicBoolean(false)
+
+    /**
+     * Suspends using [suspendCancellableCoroutine] and exposes this [SafeContinuation] for callback-style
+     * APIs that may invoke completion more than once. Guarantees only the first resume will be executed.
+     *
+     * @param block Invoked immediately with this [SafeContinuation] to hook into external callbacks.
+     * @return the successful value.
+     * @since 200.8.1
+     */
+    suspend inline fun suspendCancellable(
+        crossinline block: (SafeContinuation<T>) -> Unit
+    ): T = suspendCancellableCoroutine {
+        continuation = it
+        block(this)
+    }
+
+    /**
+     * Resumes this continuation with the given [value] if it has not already been resumed.
+     *
+     * @param value The value to resume the continuation with.
+     * @param onCancellation Optional lambda to be invoked if the continuation is cancelled after resuming.
+     * @since 200.8.1
+     */
+    fun <R : T> resumeSafely(
+        value: R,
+        onCancellation: ((cause: Throwable, value: R, context: CoroutineContext) -> Unit) = { _, _, _ -> }
+    ) {
+        if (hasResumed.compareAndSet(false, true)) {
+            continuation.resume(value, onCancellation)
+        }
+    }
+
+
+    /**
+     * Registers a handler to be invoked if the continuation is cancelled.
+     *
+     * @param block The block to invoke on cancellation.
+     * @since 200.8.1
+     */
+    fun invokeOnCancellation(block: () -> Unit) {
+        continuation.invokeOnCancellation { block() }
+    }
+}
+
+/**
+ * Suspends using [suspendCancellableCoroutine] and exposes a [SafeContinuation] for callback-style
+ * APIs that may invoke completion more than once. Guarantees only the first resume will be executed.
+ * Use [SafeContinuation.resumeSafely] to resume the continuation or [SafeContinuation.invokeOnCancellation]
+ * to handle cancellation.
+ *
+ * @param block Invoked immediately with a [SafeContinuation] to hook into external callbacks.
+ * @return the successful value.
+ * @since 200.8.1
+ */
+internal suspend inline fun <T> safeSuspendableCancellable(
+    crossinline block: (SafeContinuation<T>) -> Unit
+): T = SafeContinuation<T>().suspendCancellable {
+    block(it)
+}

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/utils/SafeContinuation.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/utils/SafeContinuation.kt
@@ -26,7 +26,7 @@ import kotlin.coroutines.CoroutineContext
  *
  * This is useful for callback-style APIs that may invoke completion more than once.
  *
- * @since 200.8.1
+ * @since 300.0.0
  */
 internal class SafeContinuation<T> {
     /**
@@ -48,7 +48,7 @@ internal class SafeContinuation<T> {
      *
      * @param block Invoked immediately with this [SafeContinuation] to hook into external callbacks.
      * @return the successful value.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     suspend inline fun suspendCancellable(
         crossinline block: (SafeContinuation<T>) -> Unit
@@ -62,7 +62,7 @@ internal class SafeContinuation<T> {
      *
      * @param value The value to resume the continuation with.
      * @param onCancellation Optional lambda to be invoked if the continuation is cancelled after resuming.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     fun <R : T> resumeSafely(
         value: R,
@@ -78,7 +78,7 @@ internal class SafeContinuation<T> {
      * Registers a handler to be invoked if the continuation is cancelled.
      *
      * @param handler The cancellation handler to be invoked with the cancellation cause.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     fun invokeOnCancellation(handler: (Throwable?) -> Unit) {
         continuation.invokeOnCancellation(handler)
@@ -93,7 +93,7 @@ internal class SafeContinuation<T> {
  *
  * @param block Invoked immediately with a [SafeContinuation] to hook into external callbacks.
  * @return the successful value.
- * @since 200.8.1
+ * @since 300.0.0
  */
 internal suspend inline fun <T> suspendWithSafeContinuation(
     crossinline block: (SafeContinuation<T>) -> Unit

--- a/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
+++ b/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
@@ -18,7 +18,7 @@
 
 package com.arcgismaps.toolkit.authentication
 
-import com.arcgismaps.toolkit.authentication.utils.safeSuspendableCancellable
+import com.arcgismaps.toolkit.authentication.utils.suspendWithSafeContinuation
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
@@ -27,6 +27,10 @@ import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicBoolean
 
+/**
+ * Tests for [suspendWithSafeContinuation].
+ * @since 200.8.1
+ */
 class SafeSuspendableCancellableTest {
 
     /**
@@ -38,7 +42,7 @@ class SafeSuspendableCancellableTest {
     @Test
     fun returnsValueOnSuccess() = runTest {
 
-        val result = safeSuspendableCancellable<String> { cont ->
+        val result = suspendWithSafeContinuation<String> { cont ->
             cont.resumeSafely("value")
         }
         assertThat(result).isEqualTo("value")
@@ -55,7 +59,7 @@ class SafeSuspendableCancellableTest {
         val ex = RuntimeException("boom")
         var caught: Throwable? = null
         try {
-            safeSuspendableCancellable<Unit> { _ ->
+            suspendWithSafeContinuation<Unit> { _ ->
                 throw ex
             }
         } catch (t: Throwable) {
@@ -67,34 +71,14 @@ class SafeSuspendableCancellableTest {
 
     /**
      * Given a safeSuspendableCancellable block
-     * When the block attempts to resume after throwing an exception
-     * Then the resume is ignored and the exception is propagated
-     * @since 200.8.1
-     */
-    @Test
-    fun throwExceptionFirstThenReturnValueIsIgnored() = runTest {
-        var safeResult: String? = null
-        val res = runCatching {
-            safeResult = safeSuspendableCancellable<String> { cont ->
-                throw IllegalStateException("This should be called first")
-                cont.resumeSafely("late") // ignored
-            }
-        }
-        assertThat(res.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
-        assertThat(res.exceptionOrNull()?.message).isEqualTo("This should be called first")
-        assertThat(safeResult).isNull()
-
-    }
-
-    /**
-     * Given a safeSuspendableCancellable block
      * When the block attempts to resume multiple times
      * Then only the first resume is effective
+     * And no "Multiple resume" errors occur.
      * @since 200.8.1
      */
     @Test
     fun testIgnoresSubsequentSignals() = runTest {
-        val safeResult = safeSuspendableCancellable<String> { cont ->
+        val safeResult = suspendWithSafeContinuation<String> { cont ->
             cont.resumeSafely("first")
             cont.resumeSafely("ignored") // ignored
             cont.resumeSafely("also ignored") // ignored
@@ -109,12 +93,11 @@ class SafeSuspendableCancellableTest {
      * And the cancellation handler is invoked
      * @since 200.8.1
      */
-    @Ignore("TODO() this test fails")
     @Test
     fun parentCancellationResultsInCancellationOutcome() = runTest {
         val invoked = AtomicBoolean(false)
         val deferred = async {
-            safeSuspendableCancellable<String> { cont ->
+            suspendWithSafeContinuation<String> { cont ->
                 // simulate long operation; do not resume
                 cont.invokeOnCancellation {
                     invoked.set(true)

--- a/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
+++ b/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
@@ -1,0 +1,134 @@
+/*
+ *
+ *  Copyright 2025 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.arcgismaps.toolkit.authentication
+
+import com.arcgismaps.toolkit.authentication.utils.safeSuspendableCancellable
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.Ignore
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
+
+class SafeSuspendableCancellableTest {
+
+    /**
+     * Given a safeSuspendableCancellable block
+     * When the block resumes successfully
+     * Then the value is returned
+     * @since 200.8.1
+     */
+    @Test
+    fun returnsValueOnSuccess() = runTest {
+
+        val result = safeSuspendableCancellable<String> { cont ->
+            cont.resumeSafely("value")
+        }
+        assertThat(result).isEqualTo("value")
+    }
+
+    /**
+     * Given a safeSuspendableCancellable block
+     * When the block throws an exception
+     * Then the exception is propagated
+     * @since 200.8.1
+     */
+    @Test
+    fun throwsOnFailure() = runTest {
+        val ex = RuntimeException("boom")
+        var caught: Throwable? = null
+        try {
+            safeSuspendableCancellable<Unit> { _ ->
+                throw ex
+            }
+        } catch (t: Throwable) {
+            caught = t
+        }
+        assertThat(caught).isInstanceOf(ex::class.java)
+        assertThat(caught?.message).isEqualTo(ex.message)
+    }
+
+    /**
+     * Given a safeSuspendableCancellable block
+     * When the block attempts to resume after throwing an exception
+     * Then the resume is ignored and the exception is propagated
+     * @since 200.8.1
+     */
+    @Test
+    fun ignoresSecondResumeCancelThenSuccess() = runTest {
+        var safeResult: String? = null
+        val res = runCatching {
+            safeResult = safeSuspendableCancellable<String> { cont ->
+                throw IllegalStateException("This should be called first")
+                cont.resumeSafely("late") // ignored
+            }
+        }
+        assertThat(res.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(res.exceptionOrNull()?.message).isEqualTo("This should be called first")
+        assertThat(safeResult).isNull()
+
+    }
+
+    /**
+     * Given a safeSuspendableCancellable block
+     * When the block attempts to resume multiple times
+     * Then only the first resume is effective
+     * @since 200.8.1
+     */
+    @Test
+    fun testIgnoresSubsequentSignals() = runTest {
+        val safeResult = safeSuspendableCancellable<String> { cont ->
+            cont.resumeSafely("first")
+            cont.resumeSafely("ignored") // ignored
+            cont.resumeSafely("also ignored") // ignored
+        }
+        assertThat(safeResult).isEqualTo("first")
+    }
+
+    /**
+     * Given a safeSuspendableCancellable block
+     * When the parent coroutine is cancelled
+     * Then the continuation resumes with cancellation
+     * And the cancellation handler is invoked
+     * @since 200.8.1
+     */
+    @Ignore("TODO() this test fails")
+    @Test
+    fun parentCancellationResultsInCancellationOutcome() = runTest {
+        val invoked = AtomicBoolean(false)
+        val deferred = async {
+            safeSuspendableCancellable<String> { cont ->
+                // simulate long operation; do not resume
+                cont.invokeOnCancellation {
+                    invoked.set(true)
+                }
+            }
+        }
+        deferred.cancel()
+        var caught: Throwable? = null
+        try {
+            deferred.await() // expect cancellation
+        } catch (t: Throwable) {
+            caught = t
+        }
+        assertThat(caught).isInstanceOf(CancellationException::class.java)
+        assertThat(invoked.get()).isTrue()
+    }
+}

--- a/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
+++ b/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
@@ -72,7 +72,7 @@ class SafeSuspendableCancellableTest {
      * @since 200.8.1
      */
     @Test
-    fun ignoresSecondResumeCancelThenSuccess() = runTest {
+    fun throwExceptionFirstThenReturnValueIsIgnored() = runTest {
         var safeResult: String? = null
         val res = runCatching {
             safeResult = safeSuspendableCancellable<String> { cont ->

--- a/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
+++ b/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
@@ -22,6 +22,7 @@ import com.arcgismaps.toolkit.authentication.utils.suspendWithSafeContinuation
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.junit.Ignore
 import org.junit.Test
@@ -98,12 +99,13 @@ class SafeSuspendableCancellableTest {
         val invoked = AtomicBoolean(false)
         val deferred = async {
             suspendWithSafeContinuation<String> { cont ->
-                // simulate long operation; do not resume
+                // simulate cancellation handler
                 cont.invokeOnCancellation {
                     invoked.set(true)
                 }
             }
         }
+        delay(100)
         deferred.cancel()
         var caught: Throwable? = null
         try {

--- a/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
+++ b/toolkit/authentication/src/test/java/com/arcgismaps/toolkit/authentication/SafeSuspendableCancellableTest.kt
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Tests for [suspendWithSafeContinuation].
- * @since 200.8.1
+ * @since 300.0.0
  */
 class SafeSuspendableCancellableTest {
 
@@ -38,7 +38,7 @@ class SafeSuspendableCancellableTest {
      * Given a safeSuspendableCancellable block
      * When the block resumes successfully
      * Then the value is returned
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun returnsValueOnSuccess() = runTest {
@@ -53,7 +53,7 @@ class SafeSuspendableCancellableTest {
      * Given a safeSuspendableCancellable block
      * When the block throws an exception
      * Then the exception is propagated
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun throwsOnFailure() = runTest {
@@ -75,7 +75,7 @@ class SafeSuspendableCancellableTest {
      * When the block attempts to resume multiple times
      * Then only the first resume is effective
      * And no "Multiple resume" errors occur.
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun testIgnoresSubsequentSignals() = runTest {
@@ -92,7 +92,7 @@ class SafeSuspendableCancellableTest {
      * When the parent coroutine is cancelled
      * Then the continuation resumes with cancellation
      * And the cancellation handler is invoked
-     * @since 200.8.1
+     * @since 300.0.0
      */
     @Test
     fun parentCancellationResultsInCancellationOutcome() = runTest {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/6742

<!-- link to design, if applicable -->
Adds a wrapper around `suspendCancellableCoroutine` that assures it only resumes once. 

### Summary of changes:
- Modifies `awaitCertificateChallengeResponse` and `awaitServerTrustChallengeResponse` to use this new wrapper

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1021/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  