### PR TITLE
`FeatureForm` : Introduce new API for navigation events

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -21,6 +21,7 @@ package com.arcgismaps.toolkit.featureformsapp.screens.map
 import android.content.Context
 import android.content.res.Resources
 import android.graphics.Bitmap
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -105,6 +106,7 @@ import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.layers.SubtypeFeatureLayer
 import com.arcgismaps.toolkit.featureforms.FeatureForm
 import com.arcgismaps.toolkit.featureforms.FeatureFormEditingEvent
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureformsapp.R
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.BottomSheetMaxWidth
@@ -230,6 +232,9 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                                 mapViewModel.commitEdits(featureForm = event.featureForm)
                             }
                         }
+                    },
+                    onNavigationEvent = {
+                        Log.e("TAG", "MapScreen Nav Event: $it", )
                     },
                     modifier = Modifier.padding(padding)
                 )
@@ -408,6 +413,7 @@ fun FeatureFormSheet(
     onShowOnMapRequest: (ArcGISFeature) -> Unit,
     onDismiss: () -> Unit,
     onEditingEvent: (FeatureFormEditingEvent) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val windowSize = getWindowSize(LocalContext.current)
@@ -454,7 +460,8 @@ fun FeatureFormSheet(
                     }
                 },
                 onDismiss = onDismiss,
-                onEditingEvent = onEditingEvent
+                onEditingEvent = onEditingEvent,
+                onNavigationEvent = onNavigationEvent
             )
         }
     }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -106,7 +106,7 @@ import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.layers.SubtypeFeatureLayer
 import com.arcgismaps.toolkit.featureforms.FeatureForm
 import com.arcgismaps.toolkit.featureforms.FeatureFormEditingEvent
-import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationRoute
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureformsapp.R
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.BottomSheetMaxWidth
@@ -413,7 +413,7 @@ fun FeatureFormSheet(
     onShowOnMapRequest: (ArcGISFeature) -> Unit,
     onDismiss: () -> Unit,
     onEditingEvent: (FeatureFormEditingEvent) -> Unit,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit = {},
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val windowSize = getWindowSize(LocalContext.current)

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -21,7 +21,6 @@ package com.arcgismaps.toolkit.featureformsapp.screens.map
 import android.content.Context
 import android.content.res.Resources
 import android.graphics.Bitmap
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -106,7 +105,6 @@ import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.layers.SubtypeFeatureLayer
 import com.arcgismaps.toolkit.featureforms.FeatureForm
 import com.arcgismaps.toolkit.featureforms.FeatureFormEditingEvent
-import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationRoute
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureformsapp.R
 import com.arcgismaps.toolkit.featureformsapp.screens.bottomsheet.BottomSheetMaxWidth
@@ -232,9 +230,6 @@ fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () ->
                                 mapViewModel.commitEdits(featureForm = event.featureForm)
                             }
                         }
-                    },
-                    onNavigationEvent = {
-                        Log.e("TAG", "MapScreen Nav Event: $it", )
                     },
                     modifier = Modifier.padding(padding)
                 )
@@ -413,7 +408,6 @@ fun FeatureFormSheet(
     onShowOnMapRequest: (ArcGISFeature) -> Unit,
     onDismiss: () -> Unit,
     onEditingEvent: (FeatureFormEditingEvent) -> Unit,
-    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val windowSize = getWindowSize(LocalContext.current)
@@ -460,8 +454,7 @@ fun FeatureFormSheet(
                     }
                 },
                 onDismiss = onDismiss,
-                onEditingEvent = onEditingEvent,
-                onNavigationEvent = onNavigationEvent
+                onEditingEvent = onEditingEvent
             )
         }
     }

--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -49,7 +49,7 @@ public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRout
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
 	public final fun getFilter ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
-	public final fun getGroupResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;
+	public final fun getResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -77,7 +77,7 @@ public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRout
 	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationsFilterResult;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationsFilterResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun getFilterResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;
+	public final fun getResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -38,6 +38,22 @@ public abstract class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationR
 	public static final field $stable I
 }
 
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationGroupResult : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
+	public final fun component3 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationGroupResult;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationGroupResult;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationGroupResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun getFilter ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
+	public final fun getGroupResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationResult : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
 	public static final field $stable I
 	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;)V
@@ -46,8 +62,22 @@ public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRout
 	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationResult;
 	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationResult;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationResult;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssociationResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;
 	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun getUtilityAssociationResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationsFilterResult : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationsFilterResult;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationsFilterResult;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationsFilterResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun getFilterResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -70,38 +100,10 @@ public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRout
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FeatureForm : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$Form : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
 	public static final field $stable I
-	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FeatureForm;
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$Form;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FilterResult : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
-	public static final field $stable I
-	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;)V
-	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;
-	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FilterResult;
-	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FilterResult;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FilterResult;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun getUtilityAssociationsFilterResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$GroupResult : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
-	public static final field $stable I
-	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;)V
-	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;
-	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$GroupResult;
-	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$GroupResult;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$GroupResult;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun getUtilityAssociationGroupResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -54,16 +54,18 @@ public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRout
 
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
 	public static final field $stable I
-	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;)V
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;)V
 	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun component2 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
-	public final fun component3 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;
-	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation;
-	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation;
+	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
+	public final fun component3 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public final fun component4 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCandidate ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;
 	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
 	public final fun getFeatureSource ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public final fun getFilter ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -106,42 +108,48 @@ public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRout
 
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
 	public static final field $stable I
-	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/utilitynetworks/UtilityAssetType;)V
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/utilitynetworks/UtilityAssetType;)V
 	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun component2 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
-	public final fun component3 ()Lcom/arcgismaps/utilitynetworks/UtilityAssetType;
-	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/utilitynetworks/UtilityAssetType;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate;
-	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/utilitynetworks/UtilityAssetType;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate;
+	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
+	public final fun component3 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public final fun component4 ()Lcom/arcgismaps/utilitynetworks/UtilityAssetType;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/utilitynetworks/UtilityAssetType;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/utilitynetworks/UtilityAssetType;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAssetType ()Lcom/arcgismaps/utilitynetworks/UtilityAssetType;
 	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
 	public final fun getFeatureSource ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public final fun getFilter ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
 	public static final field $stable I
-	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;)V
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;)V
 	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource;
-	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource;
+	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun getFilter ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
 	public static final field $stable I
-	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;)V
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;)V
 	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
-	public final fun component2 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
-	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType;
-	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType;
+	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
+	public final fun component3 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
 	public final fun getFeatureSource ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public final fun getFilter ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilter;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/toolkit/featureforms/api/featureforms.api
+++ b/toolkit/featureforms/api/featureforms.api
@@ -31,7 +31,119 @@ public final class com/arcgismaps/toolkit/featureforms/FeatureFormEditingEvent$S
 }
 
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormKt {
-	public static final fun FeatureForm (Lcom/arcgismaps/toolkit/featureforms/FeatureFormState;Landroidx/compose/ui/Modifier;ZZZLcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormColorScheme;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;Landroidx/compose/runtime/Composer;III)V
+	public static final fun FeatureForm (Lcom/arcgismaps/toolkit/featureforms/FeatureFormState;Landroidx/compose/ui/Modifier;ZZZLcom/arcgismaps/toolkit/featureforms/ValidationErrorVisibility;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormColorScheme;Lcom/arcgismaps/toolkit/featureforms/theme/FeatureFormTypography;Landroidx/compose/runtime/Composer;III)V
+}
+
+public abstract class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+}
+
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationResult : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationResult;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationResult;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$AssociationResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun getUtilityAssociationResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun component2 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public final fun component3 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$CreateAssociation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCandidate ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureCandidate;
+	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun getFeatureSource ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FeatureForm : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FeatureForm;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FilterResult : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FilterResult;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FilterResult;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$FilterResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun getUtilityAssociationsFilterResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationsFilterResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$GroupResult : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun component2 ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$GroupResult;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$GroupResult;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$GroupResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun getUtilityAssociationGroupResult ()Lcom/arcgismaps/utilitynetworks/UtilityAssociationGroupResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/utilitynetworks/UtilityAssetType;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun component2 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public final fun component3 ()Lcom/arcgismaps/utilitynetworks/UtilityAssetType;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/utilitynetworks/UtilityAssetType;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;Lcom/arcgismaps/utilitynetworks/UtilityAssetType;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureCandidate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssetType ()Lcom/arcgismaps/utilitynetworks/UtilityAssetType;
+	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun getFeatureSource ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectAssociationFeatureSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType : com/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute {
+	public static final field $stable I
+	public fun <init> (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;)V
+	public final fun component1 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun component2 ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public final fun copy (Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType;
+	public static synthetic fun copy$default (Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;ILjava/lang/Object;)Lcom/arcgismaps/toolkit/featureforms/FeatureFormNavigationRoute$SelectUtilityAssetType;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElement ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationsFormElement;
+	public final fun getFeatureSource ()Lcom/arcgismaps/mapping/featureforms/UtilityAssociationFeatureSource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/arcgismaps/toolkit/featureforms/FeatureFormState {

--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -165,6 +165,7 @@ apiValidation {
         "com.arcgismaps.toolkit.featureforms.internal.screens.ComposableSingletons\$CreateAssociationScreenKt",
         "com.arcgismaps.toolkit.featureforms.internal.screens.ComposableSingletons\$SelectAssociatedFeatureScreenKt",
         "com.arcgismaps.toolkit.featureforms.internal.screens.ComposableSingletons\$SelectNetworkSourceScreenKt",
+        "com.arcgismaps.toolkit.featureforms.internal.screens.ComposableSingletons\$UtilityAssociationDetailsScreenKt",
         "com.arcgismaps.toolkit.featureforms.internal.utils.ComposableSingletons\$SearchBarKt"
     )
     ignoredClasses.addAll(composableSingletons)

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/EventTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/EventTests.kt
@@ -147,7 +147,7 @@ class EventTests {
         }
         var filterEvent = lastEvent as FeatureFormNavigationRoute.AssociationsFilterResult
         assertThat(filterEvent.element).isEqualTo(element)
-        assertThat(filterEvent.filterResult.filter).isEqualTo(filterResult.filter)
+        assertThat(filterEvent.result.filter).isEqualTo(filterResult.filter)
 
         val groupResult = filterResult.groupResults.first()
 
@@ -159,8 +159,8 @@ class EventTests {
         }
         var groupEvent = lastEvent as FeatureFormNavigationRoute.AssociationGroupResult
         assertThat(groupEvent.element).isEqualTo(element)
-        assertThat(groupEvent.groupResult.name).isEqualTo(groupResult.name)
-        assertThat(groupEvent.groupResult.featureFormSource).isEqualTo(groupResult.featureFormSource)
+        assertThat(groupEvent.result.name).isEqualTo(groupResult.name)
+        assertThat(groupEvent.result.featureFormSource).isEqualTo(groupResult.featureFormSource)
 
         val associationResult = groupResult.associationResults.first()
         var listView = composeTestRule.onNode(hasScrollAction())
@@ -189,8 +189,8 @@ class EventTests {
         }
         groupEvent = lastEvent as FeatureFormNavigationRoute.AssociationGroupResult
         assertThat(groupEvent.element).isEqualTo(element)
-        assertThat(groupEvent.groupResult.name).isEqualTo(groupResult.name)
-        assertThat(groupEvent.groupResult.featureFormSource).isEqualTo(groupResult.featureFormSource)
+        assertThat(groupEvent.result.name).isEqualTo(groupResult.name)
+        assertThat(groupEvent.result.featureFormSource).isEqualTo(groupResult.featureFormSource)
 
         Espresso.pressBack()
 
@@ -200,7 +200,7 @@ class EventTests {
         }
         filterEvent = lastEvent as FeatureFormNavigationRoute.AssociationsFilterResult
         assertThat(filterEvent.element).isEqualTo(element)
-        assertThat(filterEvent.filterResult.filter).isEqualTo(filterResult.filter)
+        assertThat(filterEvent.result.filter).isEqualTo(filterResult.filter)
 
         // Get and click the add button
         val addButton = composeTestRule.onNodeWithContentDescription("Add Associations")
@@ -290,6 +290,6 @@ class EventTests {
         }
         filterEvent = lastEvent as FeatureFormNavigationRoute.AssociationsFilterResult
         assertThat(filterEvent.element).isEqualTo(element)
-        assertThat(filterEvent.filterResult.filter).isEqualTo(filterResult.filter)
+        assertThat(filterEvent.result.filter).isEqualTo(filterResult.filter)
     }
 }

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/EventTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/EventTests.kt
@@ -118,7 +118,7 @@ class EventTests {
 
         // Wait for the initial FeatureForm event
         composeTestRule.waitUntil {
-            lastEvent == FeatureFormNavigationRoute.FeatureForm
+            lastEvent == FeatureFormNavigationRoute.Form
         }
 
         val element = featureForm.elements.first {
@@ -143,11 +143,11 @@ class EventTests {
 
         // Verify that the UtilityAssociationsFilterResultNav event is received
         composeTestRule.waitUntil {
-            lastEvent is FeatureFormNavigationRoute.FilterResult
+            lastEvent is FeatureFormNavigationRoute.AssociationsFilterResult
         }
-        var filterEvent = lastEvent as FeatureFormNavigationRoute.FilterResult
+        var filterEvent = lastEvent as FeatureFormNavigationRoute.AssociationsFilterResult
         assertThat(filterEvent.element).isEqualTo(element)
-        assertThat(filterEvent.utilityAssociationsFilterResult.filter).isEqualTo(filterResult.filter)
+        assertThat(filterEvent.filterResult.filter).isEqualTo(filterResult.filter)
 
         val groupResult = filterResult.groupResults.first()
 
@@ -155,12 +155,12 @@ class EventTests {
         groupNode.performClick()
 
         composeTestRule.waitUntil {
-            lastEvent is FeatureFormNavigationRoute.GroupResult
+            lastEvent is FeatureFormNavigationRoute.AssociationGroupResult
         }
-        var groupEvent = lastEvent as FeatureFormNavigationRoute.GroupResult
+        var groupEvent = lastEvent as FeatureFormNavigationRoute.AssociationGroupResult
         assertThat(groupEvent.element).isEqualTo(element)
-        assertThat(groupEvent.utilityAssociationGroupResult.name).isEqualTo(groupResult.name)
-        assertThat(groupEvent.utilityAssociationGroupResult.featureFormSource).isEqualTo(groupResult.featureFormSource)
+        assertThat(groupEvent.groupResult.name).isEqualTo(groupResult.name)
+        assertThat(groupEvent.groupResult.featureFormSource).isEqualTo(groupResult.featureFormSource)
 
         val associationResult = groupResult.associationResults.first()
         var listView = composeTestRule.onNode(hasScrollAction())
@@ -173,11 +173,11 @@ class EventTests {
         }
         val associationEvent = lastEvent as FeatureFormNavigationRoute.AssociationResult
         assertThat(associationEvent.element).isEqualTo(element)
-        assertThat(associationEvent.utilityAssociationResult.title).isEqualTo(associationResult.title)
-        assertThat(associationEvent.utilityAssociationResult.association.globalId).isEqualTo(
+        assertThat(associationEvent.associationResult.title).isEqualTo(associationResult.title)
+        assertThat(associationEvent.associationResult.association.globalId).isEqualTo(
             associationResult.association.globalId
         )
-        assertThat(associationEvent.utilityAssociationResult.associatedFeature).isEqualTo(
+        assertThat(associationEvent.associationResult.associatedFeature).isEqualTo(
             associationResult.associatedFeature
         )
 
@@ -185,22 +185,22 @@ class EventTests {
 
         // Verify that we are back on the group result screen and the event is fired again
         composeTestRule.waitUntil {
-            lastEvent is FeatureFormNavigationRoute.GroupResult
+            lastEvent is FeatureFormNavigationRoute.AssociationGroupResult
         }
-        groupEvent = lastEvent as FeatureFormNavigationRoute.GroupResult
+        groupEvent = lastEvent as FeatureFormNavigationRoute.AssociationGroupResult
         assertThat(groupEvent.element).isEqualTo(element)
-        assertThat(groupEvent.utilityAssociationGroupResult.name).isEqualTo(groupResult.name)
-        assertThat(groupEvent.utilityAssociationGroupResult.featureFormSource).isEqualTo(groupResult.featureFormSource)
+        assertThat(groupEvent.groupResult.name).isEqualTo(groupResult.name)
+        assertThat(groupEvent.groupResult.featureFormSource).isEqualTo(groupResult.featureFormSource)
 
         Espresso.pressBack()
 
         // Verify that we are back on the filter result screen and the event is fired again
         composeTestRule.waitUntil {
-            lastEvent is FeatureFormNavigationRoute.FilterResult
+            lastEvent is FeatureFormNavigationRoute.AssociationsFilterResult
         }
-        filterEvent = lastEvent as FeatureFormNavigationRoute.FilterResult
+        filterEvent = lastEvent as FeatureFormNavigationRoute.AssociationsFilterResult
         assertThat(filterEvent.element).isEqualTo(element)
-        assertThat(filterEvent.utilityAssociationsFilterResult.filter).isEqualTo(filterResult.filter)
+        assertThat(filterEvent.filterResult.filter).isEqualTo(filterResult.filter)
 
         // Get and click the add button
         val addButton = composeTestRule.onNodeWithContentDescription("Add Associations")
@@ -286,10 +286,10 @@ class EventTests {
 
         // Verify that we are back on the filter result screen and the event is fired again
         composeTestRule.waitUntil(timeoutMillis = 2_000) {
-            lastEvent is FeatureFormNavigationRoute.FilterResult
+            lastEvent is FeatureFormNavigationRoute.AssociationsFilterResult
         }
-        filterEvent = lastEvent as FeatureFormNavigationRoute.FilterResult
+        filterEvent = lastEvent as FeatureFormNavigationRoute.AssociationsFilterResult
         assertThat(filterEvent.element).isEqualTo(element)
-        assertThat(filterEvent.utilityAssociationsFilterResult.filter).isEqualTo(filterResult.filter)
+        assertThat(filterEvent.filterResult.filter).isEqualTo(filterResult.filter)
     }
 }

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/EventTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/EventTests.kt
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2025 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms
+
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDialog
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildAt
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.test.espresso.Espresso
+import com.arcgismaps.ArcGISEnvironment
+import com.arcgismaps.data.ArcGISFeature
+import com.arcgismaps.data.QueryParameters
+import com.arcgismaps.mapping.ArcGISMap
+import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.mapping.featureforms.UtilityAssociationsFormElement
+import com.arcgismaps.mapping.layers.FeatureLayer
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class EventTests {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var map: ArcGISMap
+
+    private val scope = CoroutineScope(Dispatchers.Main)
+
+    init {
+        // Set the authentication challenge handler
+        ArcGISEnvironment.authenticationManager.arcGISAuthenticationChallengeHandler =
+            FeatureFormsTestChallengeHandler(
+                username = BuildConfig.traceToolUser,
+                password = BuildConfig.traceToolPassword,
+            )
+    }
+
+    @Before
+    fun setup() = runTest {
+        if (::map.isInitialized.not()) {
+            map = ArcGISMap(
+                uri = "https://www.arcgis.com/home/item.html?id=a93ff75c66644c02bdb3a785cc0ba795"
+            )
+        }
+        map.assertIsLoaded()
+        map.utilityNetworks.forEach {
+            it.assertIsLoaded()
+        }
+    }
+
+    /**
+     * Given a FeatureForm with a [UtilityAssociationsFormElement]
+     * When navigation events occur
+     * Then the appropriate [FeatureFormNavigationRoute] events are fired
+     *
+     * @since 300.0.0
+     */
+    @Test
+    fun testUtilityAssociationNavigationEvents() = runTest {
+        val groupLayer = map.operationalLayers.first()
+        val layer = groupLayer.subLayerContents.value.find {
+            it.name == "Electric Distribution Device"
+        } as FeatureLayer?
+        assertThat(layer).isNotNull()
+
+        val queryResult = layer!!.featureTable!!.queryFeatures(
+            QueryParameters().apply {
+                objectIds.add(3221)
+            }
+        ).getOrNull()
+        assertThat(queryResult).isNotNull()
+
+        val feature = queryResult!!.firstOrNull() as? ArcGISFeature
+        assertThat(feature).isNotNull()
+
+        val featureForm = FeatureForm(feature!!)
+        val state = FeatureFormState(
+            featureForm = featureForm,
+            coroutineScope = scope
+        )
+        var lastEvent: FeatureFormNavigationRoute? = null
+        composeTestRule.setContent {
+            FeatureForm(
+                featureFormState = state,
+                onNavigationEvent = {
+                    lastEvent = it
+                }
+            )
+        }
+
+        // Wait for the initial FeatureForm event
+        composeTestRule.waitUntil {
+            lastEvent == FeatureFormNavigationRoute.FeatureForm
+        }
+
+        val element = featureForm.elements.first {
+            it is UtilityAssociationsFormElement
+        } as UtilityAssociationsFormElement
+
+        // Wait for the associations to load
+        composeTestRule.waitUntil(timeoutMillis = 30_000) {
+            element.associationsFilterResults.isNotEmpty()
+        }
+
+        val lazyColumnNode = composeTestRule.onNodeWithContentDescription("lazy column")
+        lazyColumnNode.performScrollToNode(hasText("Associations")).assertIsDisplayed()
+
+        val filterResult = element.associationsFilterResults.first {
+            it.filter.title == "Connected"
+        }
+
+        // Find and click the filter node
+        val filterNode = composeTestRule.onNodeWithText(text = filterResult.filter.title)
+        filterNode.performClick()
+
+        // Verify that the UtilityAssociationsFilterResultNav event is received
+        composeTestRule.waitUntil {
+            lastEvent is FeatureFormNavigationRoute.FilterResult
+        }
+        var filterEvent = lastEvent as FeatureFormNavigationRoute.FilterResult
+        assertThat(filterEvent.element).isEqualTo(element)
+        assertThat(filterEvent.utilityAssociationsFilterResult.filter).isEqualTo(filterResult.filter)
+
+        val groupResult = filterResult.groupResults.first()
+
+        val groupNode = composeTestRule.onNode(hasText(groupResult.name))
+        groupNode.performClick()
+
+        composeTestRule.waitUntil {
+            lastEvent is FeatureFormNavigationRoute.GroupResult
+        }
+        var groupEvent = lastEvent as FeatureFormNavigationRoute.GroupResult
+        assertThat(groupEvent.element).isEqualTo(element)
+        assertThat(groupEvent.utilityAssociationGroupResult.name).isEqualTo(groupResult.name)
+        assertThat(groupEvent.utilityAssociationGroupResult.featureFormSource).isEqualTo(groupResult.featureFormSource)
+
+        val associationResult = groupResult.associationResults.first()
+        var listView = composeTestRule.onNode(hasScrollAction())
+        val associationNode = listView.onChildAt(0)
+        // Click the details button on the association node
+        associationNode.onChildWithContentDescription("details").performClick()
+
+        composeTestRule.waitUntil {
+            lastEvent is FeatureFormNavigationRoute.AssociationResult
+        }
+        val associationEvent = lastEvent as FeatureFormNavigationRoute.AssociationResult
+        assertThat(associationEvent.element).isEqualTo(element)
+        assertThat(associationEvent.utilityAssociationResult.title).isEqualTo(associationResult.title)
+        assertThat(associationEvent.utilityAssociationResult.association.globalId).isEqualTo(
+            associationResult.association.globalId
+        )
+        assertThat(associationEvent.utilityAssociationResult.associatedFeature).isEqualTo(
+            associationResult.associatedFeature
+        )
+
+        Espresso.pressBack()
+
+        // Verify that we are back on the group result screen and the event is fired again
+        composeTestRule.waitUntil {
+            lastEvent is FeatureFormNavigationRoute.GroupResult
+        }
+        groupEvent = lastEvent as FeatureFormNavigationRoute.GroupResult
+        assertThat(groupEvent.element).isEqualTo(element)
+        assertThat(groupEvent.utilityAssociationGroupResult.name).isEqualTo(groupResult.name)
+        assertThat(groupEvent.utilityAssociationGroupResult.featureFormSource).isEqualTo(groupResult.featureFormSource)
+
+        Espresso.pressBack()
+
+        // Verify that we are back on the filter result screen and the event is fired again
+        composeTestRule.waitUntil {
+            lastEvent is FeatureFormNavigationRoute.FilterResult
+        }
+        filterEvent = lastEvent as FeatureFormNavigationRoute.FilterResult
+        assertThat(filterEvent.element).isEqualTo(element)
+        assertThat(filterEvent.utilityAssociationsFilterResult.filter).isEqualTo(filterResult.filter)
+
+        // Get and click the add button
+        val addButton = composeTestRule.onNodeWithContentDescription("Add Associations")
+        addButton.performClick()
+
+        // Tap the from network data source option
+        val options = composeTestRule.onNode(isDialog())
+        options.onChildWithText("From Network Data Source", recurse = true).performClick()
+
+        // Verify that the SelectAssociationFeatureSource event is received
+        composeTestRule.waitUntil {
+            lastEvent is FeatureFormNavigationRoute.SelectAssociationFeatureSource
+        }
+        val sourceEvent = lastEvent as FeatureFormNavigationRoute.SelectAssociationFeatureSource
+        assertThat(sourceEvent.element).isEqualTo(element)
+
+        // Get the list view
+        listView = composeTestRule.onNode(hasScrollAction())
+        // Wait for the list to populate
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            listView.onChildren().fetchSemanticsNodes().isNotEmpty()
+        }
+        // Assert the expected sources are present
+        val source = listView.onChildWithText("Electric Distribution Device")
+        // Click the source
+        source.performClick()
+
+        // Verify that the SelectUtilityAssetType event is received
+        composeTestRule.waitUntil {
+            lastEvent is FeatureFormNavigationRoute.SelectUtilityAssetType
+        }
+        val assetTypeEvent = lastEvent as FeatureFormNavigationRoute.SelectUtilityAssetType
+        assertThat(assetTypeEvent.element).isEqualTo(element)
+        assertThat(assetTypeEvent.featureSource.name).isEqualTo("Electric Distribution Device")
+
+        // Update the list view
+        listView = composeTestRule.onNode(hasScrollAction())
+        // Wait for the list to populate with asset types
+        composeTestRule.waitUntil {
+            listView.onChildren().fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Might have to scroll to find the asset type
+        listView.performScrollToNode(hasText("Cabinet Fuse"))
+        val assetType = listView.onChildWithText("Cabinet Fuse").assertIsDisplayed()
+        assetType.performClick()
+
+        // Verify that the SelectAssociationFeatureCandidate event is received
+        composeTestRule.waitUntil {
+            lastEvent is FeatureFormNavigationRoute.SelectAssociationFeatureCandidate
+        }
+        val candidateEvent = lastEvent as FeatureFormNavigationRoute.SelectAssociationFeatureCandidate
+        assertThat(candidateEvent.element).isEqualTo(element)
+        assertThat(candidateEvent.featureSource.name).isEqualTo("Electric Distribution Device")
+        assertThat(candidateEvent.assetType.name).isEqualTo("Cabinet Fuse")
+
+        // Wait for the list of feature candidates to load
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            composeTestRule.onNode(hasScrollAction()).isDisplayed()
+        }
+
+        // Update the list view
+        listView = composeTestRule.onNode(hasScrollAction())
+        val featureNode = listView.onChildAt(0)
+        featureNode.assert(hasText("Fuse"))
+        featureNode.assertHasClickAction().performClick()
+
+        // Verify that the CreateAssociation event is received
+        composeTestRule.waitUntil {
+            lastEvent is FeatureFormNavigationRoute.CreateAssociation
+        }
+        val createEvent = lastEvent as FeatureFormNavigationRoute.CreateAssociation
+        assertThat(createEvent.element).isEqualTo(element)
+        assertThat(createEvent.featureSource.name).isEqualTo("Electric Distribution Device")
+        assertThat(createEvent.candidate.title).isEqualTo("Fuse")
+
+        // Wait for the add button to be enabled
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithText("Add").isEnabled()
+        }
+        // Click the add button to create the association
+        composeTestRule.onNodeWithText("Add").performClick()
+
+        // Verify that we are back on the filter result screen and the event is fired again
+        composeTestRule.waitUntil(timeoutMillis = 2_000) {
+            lastEvent is FeatureFormNavigationRoute.FilterResult
+        }
+        filterEvent = lastEvent as FeatureFormNavigationRoute.FilterResult
+        assertThat(filterEvent.element).isEqualTo(element)
+        assertThat(filterEvent.utilityAssociationsFilterResult.filter).isEqualTo(filterResult.filter)
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -267,7 +267,7 @@ public fun FeatureForm(
     isNavigationEnabled : Boolean = true,
     validationErrorVisibility: ValidationErrorVisibility = ValidationErrorVisibility.Automatic,
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)? = null,
-    onShowOnMapRequest : ((ArcGISFeature) -> Unit)? = null,
+    onShowOnMapRequest : (ArcGISFeature) -> Unit = {},
     onDismiss: () -> Unit = {},
     onEditingEvent: (FeatureFormEditingEvent) -> Unit = {},
     onNavigationEvent: (FeatureFormNavigationEvent) -> Unit = {},
@@ -365,9 +365,8 @@ public fun FeatureForm(
                 onSaveForm = ::saveForm,
                 onDiscardForm = ::discardForm,
                 onBarcodeButtonClick = onBarcodeButtonClick,
-                onShowOnMapRequest = { feature ->
-                    onShowOnMapRequest?.invoke(feature)
-                },
+                onShowOnMapRequest = onShowOnMapRequest,
+                onNavigationEvent = onNavigationEvent,
                 modifier = Modifier.fillMaxSize()
             )
         },
@@ -385,7 +384,7 @@ public fun FeatureForm(
     }
     LaunchedEffect(navController, featureFormState) {
         navController.currentBackStackEntryFlow.collect { entry ->
-            Log.e("TAG", "FeatureForm: $entry.", )
+            //Log.e("TAG", "FeatureForm: $entry.", )
         }
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -20,7 +20,6 @@ package com.arcgismaps.toolkit.featureforms
 
 import android.Manifest
 import android.content.Context
-import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
@@ -30,7 +29,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -58,7 +56,6 @@ import com.arcgismaps.mapping.featureforms.UtilityAssociationsFormElement
 import com.arcgismaps.mapping.featureforms.UtilityAssociationFeatureCandidate
 import com.arcgismaps.mapping.featureforms.UtilityAssociationFeatureSource
 import com.arcgismaps.toolkit.featureforms.internal.components.text.TextFormElement
-import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
 import com.arcgismaps.toolkit.featureforms.internal.navigation.FeatureFormNavHost
 import com.arcgismaps.toolkit.featureforms.internal.screens.ContentAwareTopBar
 import com.arcgismaps.toolkit.featureforms.internal.utils.DialogType
@@ -122,49 +119,116 @@ public sealed class FeatureFormEditingEvent {
 }
 
 /**
- * Indicates a navigation event that occurs within the [FeatureForm] composable.
+ * Indicates the navigation route within a [FeatureForm] when dealing with [UtilityAssociation]s.
  *
  * @since 300.0.0
  */
-public sealed class FeatureFormNavigationEvent {
+public sealed class FeatureFormNavigationRoute {
 
-    public data object FeatureForm : FeatureFormNavigationEvent()
+    /**
+     * Indicates the route for the main [FeatureForm] screen. The associated [FeatureForm] can be
+     * obtained from the [FeatureFormState.activeFeatureForm] property.
+     *
+     * @since 300.0.0
+     */
+    public data object FeatureForm : FeatureFormNavigationRoute()
 
-    public data class UtilityAssociationsFilterResultNav(
+    /**
+     * Indicates the route for [UtilityAssociationsFilterResult] screen.
+     *
+     * @param element The [UtilityAssociationsFormElement] associated with the filter result.
+     * @param utilityAssociationsFilterResult The selected [UtilityAssociationsFilterResult].
+     *
+     * @since 300.0.0
+     */
+    public data class FilterResult(
         val element: UtilityAssociationsFormElement,
         val utilityAssociationsFilterResult: UtilityAssociationsFilterResult
-    ) : FeatureFormNavigationEvent()
+    ) : FeatureFormNavigationRoute()
 
-    public data class UtilityAssociationsGroupResultNav(
+    /**
+     * Indicates the route for [UtilityAssociationGroupResult] screen.
+     *
+     * @param element The [UtilityAssociationsFormElement] associated with the group result.
+     * @param utilityAssociationGroupResult The selected [UtilityAssociationGroupResult].
+     *
+     * @since 300.0.0
+     */
+    public data class GroupResult(
         val element: UtilityAssociationsFormElement,
         val utilityAssociationGroupResult: UtilityAssociationGroupResult
-    ) : FeatureFormNavigationEvent()
+    ) : FeatureFormNavigationRoute()
 
-    public data class UtilityAssociationResultView(
+    /**
+     * Indicates the route for [UtilityAssociationResult] details screen.
+     *
+     * @param element The [UtilityAssociationsFormElement] associated with the association result.
+     * @param utilityAssociationResult The selected [UtilityAssociationResult].
+     *
+     * @since 300.0.0
+     */
+    public data class AssociationResult(
         val element: UtilityAssociationsFormElement,
         val utilityAssociationResult: UtilityAssociationResult
-    ) : FeatureFormNavigationEvent()
+    ) : FeatureFormNavigationRoute()
 
-    public data class SelectUtilityAssociationFeatureSource(
+    /**
+     * Indicates the route for selecting a [UtilityAssociationFeatureSource] when adding a new
+     * association.
+     *
+     * @param element The [UtilityAssociationsFormElement] where the association is being added.
+     *
+     * @since 300.0.0
+     */
+    public data class SelectAssociationFeatureSource(
         val element: UtilityAssociationsFormElement
-    ) : FeatureFormNavigationEvent()
+    ) : FeatureFormNavigationRoute()
 
+    /**
+     * Indicates the route for selecting a [UtilityAssetType] from a [UtilityAssociationFeatureSource]
+     * when adding a new association.
+     *
+     * @param element The [UtilityAssociationsFormElement] where the association is being added.
+     * @param featureSource The selected [UtilityAssociationFeatureSource].
+     *
+     * @since 300.0.0
+     */
     public data class SelectUtilityAssetType(
         val element: UtilityAssociationsFormElement,
         val featureSource: UtilityAssociationFeatureSource
-    ) : FeatureFormNavigationEvent()
+    ) : FeatureFormNavigationRoute()
 
-    public data class SelectUtilityAssociationFeatureCandidate(
+    /**
+     * Indicates the route for selecting a [UtilityAssociationFeatureCandidate] from a
+     * [UtilityAssetType] when adding a new association.
+     *
+     * @param element The [UtilityAssociationsFormElement] where the association is being added.
+     * @param featureSource The selected [UtilityAssociationFeatureSource] the asset type belongs to.
+     * @param assetType The selected [UtilityAssetType].
+     *
+     * @since 300.0.0
+     */
+    public data class SelectAssociationFeatureCandidate(
         val element: UtilityAssociationsFormElement,
         val featureSource: UtilityAssociationFeatureSource,
         val assetType: UtilityAssetType
-    ) : FeatureFormNavigationEvent()
+    ) : FeatureFormNavigationRoute()
 
-    public data class CreateNewUtilityAssociation(
+    /**
+     * Indicates the route for creating a new association with the selected
+     * [UtilityAssociationFeatureCandidate].
+     *
+     * @param element The [UtilityAssociationsFormElement] where the association is being added.
+     * @param featureSource The selected [UtilityAssociationFeatureSource] the candidate belongs to.
+     * @param candidate The selected [UtilityAssociationFeatureCandidate].
+     *
+     * @since 300.0.0
+     */
+    public data class CreateAssociation(
         val element: UtilityAssociationsFormElement,
         val featureSource: UtilityAssociationFeatureSource,
         val candidate: UtilityAssociationFeatureCandidate
-    ) : FeatureFormNavigationEvent()
+    ) : FeatureFormNavigationRoute()
 }
 
 /**
@@ -253,6 +317,10 @@ public sealed class FeatureFormNavigationEvent {
  * If the edit action is triggered by navigating to another form, the `willNavigate` parameter will
  * be true. Note that if the action happens due to the close button, the `willNavigate` parameter
  * will be false.
+ * @param onNavigationEvent A callback that is invoked when a navigation event occurs in the form.
+ * This is triggered when the user navigates to different screens within the form, currently when
+ * dealing with [UtilityAssociation]s. The specific [FeatureFormNavigationRoute] is provided which
+ * contains the relevant data for the route.
  * @param colorScheme The [FeatureFormColorScheme] to use for the FeatureForm.
  * @param typography The [FeatureFormTypography] to use for the FeatureForm.
  *
@@ -270,7 +338,7 @@ public fun FeatureForm(
     onShowOnMapRequest : (ArcGISFeature) -> Unit = {},
     onDismiss: () -> Unit = {},
     onEditingEvent: (FeatureFormEditingEvent) -> Unit = {},
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit = {},
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit = {},
     colorScheme: FeatureFormColorScheme = FeatureFormDefaults.colorScheme(),
     typography: FeatureFormTypography = FeatureFormDefaults.typography(),
 ) {
@@ -380,11 +448,6 @@ public fun FeatureForm(
             // Clear the navigation actions when the composition is disposed
             state.setNavigationCallback(null)
             state.setNavigateBack(null)
-        }
-    }
-    LaunchedEffect(navController, featureFormState) {
-        navController.currentBackStackEntryFlow.collect { entry ->
-            //Log.e("TAG", "FeatureForm: $entry.", )
         }
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -138,13 +138,13 @@ public sealed class FeatureFormNavigationRoute {
      * Indicates the route for [UtilityAssociationsFilterResult] screen.
      *
      * @param element The [UtilityAssociationsFormElement] associated with the filter result.
-     * @param filterResult The selected [UtilityAssociationsFilterResult].
+     * @param result The selected [UtilityAssociationsFilterResult].
      *
      * @since 300.0.0
      */
     public data class AssociationsFilterResult(
         val element: UtilityAssociationsFormElement,
-        val filterResult: UtilityAssociationsFilterResult
+        val result: UtilityAssociationsFilterResult
     ) : FeatureFormNavigationRoute()
 
     /**
@@ -152,14 +152,14 @@ public sealed class FeatureFormNavigationRoute {
      *
      * @param element The [UtilityAssociationsFormElement] associated with the group result.
      * @param filter The selected [UtilityAssociationsFilter].
-     * @param groupResult The selected [UtilityAssociationGroupResult].
+     * @param result The selected [UtilityAssociationGroupResult].
      *
      * @since 300.0.0
      */
     public data class AssociationGroupResult(
         val element: UtilityAssociationsFormElement,
         val filter: UtilityAssociationsFilter,
-        val groupResult: UtilityAssociationGroupResult
+        val result: UtilityAssociationGroupResult
     ) : FeatureFormNavigationRoute()
 
     /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -132,45 +132,47 @@ public sealed class FeatureFormNavigationRoute {
      *
      * @since 300.0.0
      */
-    public data object FeatureForm : FeatureFormNavigationRoute()
+    public data object Form : FeatureFormNavigationRoute()
 
     /**
      * Indicates the route for [UtilityAssociationsFilterResult] screen.
      *
      * @param element The [UtilityAssociationsFormElement] associated with the filter result.
-     * @param utilityAssociationsFilterResult The selected [UtilityAssociationsFilterResult].
+     * @param filterResult The selected [UtilityAssociationsFilterResult].
      *
      * @since 300.0.0
      */
-    public data class FilterResult(
+    public data class AssociationsFilterResult(
         val element: UtilityAssociationsFormElement,
-        val utilityAssociationsFilterResult: UtilityAssociationsFilterResult
+        val filterResult: UtilityAssociationsFilterResult
     ) : FeatureFormNavigationRoute()
 
     /**
      * Indicates the route for [UtilityAssociationGroupResult] screen.
      *
      * @param element The [UtilityAssociationsFormElement] associated with the group result.
-     * @param utilityAssociationGroupResult The selected [UtilityAssociationGroupResult].
+     * @param filter The selected [UtilityAssociationsFilter].
+     * @param groupResult The selected [UtilityAssociationGroupResult].
      *
      * @since 300.0.0
      */
-    public data class GroupResult(
+    public data class AssociationGroupResult(
         val element: UtilityAssociationsFormElement,
-        val utilityAssociationGroupResult: UtilityAssociationGroupResult
+        val filter: UtilityAssociationsFilter,
+        val groupResult: UtilityAssociationGroupResult
     ) : FeatureFormNavigationRoute()
 
     /**
      * Indicates the route for [UtilityAssociationResult] details screen.
      *
      * @param element The [UtilityAssociationsFormElement] associated with the association result.
-     * @param utilityAssociationResult The selected [UtilityAssociationResult].
+     * @param associationResult The selected [UtilityAssociationResult].
      *
      * @since 300.0.0
      */
     public data class AssociationResult(
         val element: UtilityAssociationsFormElement,
-        val utilityAssociationResult: UtilityAssociationResult
+        val associationResult: UtilityAssociationResult
     ) : FeatureFormNavigationRoute()
 
     /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -20,6 +20,7 @@ package com.arcgismaps.toolkit.featureforms
 
 import android.Manifest
 import android.content.Context
+import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
@@ -29,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -54,7 +56,9 @@ import com.arcgismaps.mapping.featureforms.GroupFormElement
 import com.arcgismaps.mapping.featureforms.TextFormElement
 import com.arcgismaps.mapping.featureforms.UtilityAssociationsFormElement
 import com.arcgismaps.mapping.featureforms.UtilityAssociationFeatureCandidate
+import com.arcgismaps.mapping.featureforms.UtilityAssociationFeatureSource
 import com.arcgismaps.toolkit.featureforms.internal.components.text.TextFormElement
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
 import com.arcgismaps.toolkit.featureforms.internal.navigation.FeatureFormNavHost
 import com.arcgismaps.toolkit.featureforms.internal.screens.ContentAwareTopBar
 import com.arcgismaps.toolkit.featureforms.internal.utils.DialogType
@@ -64,8 +68,17 @@ import com.arcgismaps.toolkit.featureforms.theme.FeatureFormColorScheme
 import com.arcgismaps.toolkit.featureforms.theme.FeatureFormDefaults
 import com.arcgismaps.toolkit.featureforms.theme.FeatureFormTheme
 import com.arcgismaps.toolkit.featureforms.theme.FeatureFormTypography
+import com.arcgismaps.utilitynetworks.UtilityAssetType
 import com.arcgismaps.utilitynetworks.UtilityAssociation
+import com.arcgismaps.utilitynetworks.UtilityAssociationGroupResult
+import com.arcgismaps.utilitynetworks.UtilityAssociationResult
+import com.arcgismaps.utilitynetworks.UtilityAssociationsFilterResult
 
+/**
+ * Defines the visibility behavior of validation errors in a [FeatureForm].
+ *
+ * @since 200.4.0
+ */
 @Immutable
 public sealed class ValidationErrorVisibility {
 
@@ -84,6 +97,8 @@ public sealed class ValidationErrorVisibility {
 
 /**
  * Indicates an event that occurs during the editing of a feature form.
+ *
+ * @since 200.8.0
  */
 public sealed class FeatureFormEditingEvent {
 
@@ -104,6 +119,52 @@ public sealed class FeatureFormEditingEvent {
      */
     public data class SavedEdits(val featureForm: FeatureForm, val willNavigate: Boolean) :
         FeatureFormEditingEvent()
+}
+
+/**
+ * Indicates a navigation event that occurs within the [FeatureForm] composable.
+ *
+ * @since 300.0.0
+ */
+public sealed class FeatureFormNavigationEvent {
+
+    public data object FeatureForm : FeatureFormNavigationEvent()
+
+    public data class UtilityAssociationsFilterResultNav(
+        val element: UtilityAssociationsFormElement,
+        val utilityAssociationsFilterResult: UtilityAssociationsFilterResult
+    ) : FeatureFormNavigationEvent()
+
+    public data class UtilityAssociationsGroupResultNav(
+        val element: UtilityAssociationsFormElement,
+        val utilityAssociationGroupResult: UtilityAssociationGroupResult
+    ) : FeatureFormNavigationEvent()
+
+    public data class UtilityAssociationResultView(
+        val element: UtilityAssociationsFormElement,
+        val utilityAssociationResult: UtilityAssociationResult
+    ) : FeatureFormNavigationEvent()
+
+    public data class SelectUtilityAssociationFeatureSource(
+        val element: UtilityAssociationsFormElement
+    ) : FeatureFormNavigationEvent()
+
+    public data class SelectUtilityAssetType(
+        val element: UtilityAssociationsFormElement,
+        val featureSource: UtilityAssociationFeatureSource
+    ) : FeatureFormNavigationEvent()
+
+    public data class SelectUtilityAssociationFeatureCandidate(
+        val element: UtilityAssociationsFormElement,
+        val featureSource: UtilityAssociationFeatureSource,
+        val assetType: UtilityAssetType
+    ) : FeatureFormNavigationEvent()
+
+    public data class CreateNewUtilityAssociation(
+        val element: UtilityAssociationsFormElement,
+        val featureSource: UtilityAssociationFeatureSource,
+        val candidate: UtilityAssociationFeatureCandidate
+    ) : FeatureFormNavigationEvent()
 }
 
 /**
@@ -209,6 +270,7 @@ public fun FeatureForm(
     onShowOnMapRequest : ((ArcGISFeature) -> Unit)? = null,
     onDismiss: () -> Unit = {},
     onEditingEvent: (FeatureFormEditingEvent) -> Unit = {},
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit = {},
     colorScheme: FeatureFormColorScheme = FeatureFormDefaults.colorScheme(),
     typography: FeatureFormTypography = FeatureFormDefaults.typography(),
 ) {
@@ -319,6 +381,11 @@ public fun FeatureForm(
             // Clear the navigation actions when the composition is disposed
             state.setNavigationCallback(null)
             state.setNavigateBack(null)
+        }
+    }
+    LaunchedEffect(navController, featureFormState) {
+        navController.currentBackStackEntryFlow.collect { entry ->
+            Log.e("TAG", "FeatureForm: $entry.", )
         }
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -69,6 +69,7 @@ import com.arcgismaps.utilitynetworks.UtilityAssetType
 import com.arcgismaps.utilitynetworks.UtilityAssociation
 import com.arcgismaps.utilitynetworks.UtilityAssociationGroupResult
 import com.arcgismaps.utilitynetworks.UtilityAssociationResult
+import com.arcgismaps.utilitynetworks.UtilityAssociationsFilter
 import com.arcgismaps.utilitynetworks.UtilityAssociationsFilterResult
 
 /**
@@ -177,11 +178,13 @@ public sealed class FeatureFormNavigationRoute {
      * association.
      *
      * @param element The [UtilityAssociationsFormElement] where the association is being added.
+     * @param filter The selected [UtilityAssociationsFilter].
      *
      * @since 300.0.0
      */
     public data class SelectAssociationFeatureSource(
-        val element: UtilityAssociationsFormElement
+        val element: UtilityAssociationsFormElement,
+        val filter : UtilityAssociationsFilter
     ) : FeatureFormNavigationRoute()
 
     /**
@@ -189,12 +192,14 @@ public sealed class FeatureFormNavigationRoute {
      * when adding a new association.
      *
      * @param element The [UtilityAssociationsFormElement] where the association is being added.
+     * @param filter The selected [UtilityAssociationsFilter].
      * @param featureSource The selected [UtilityAssociationFeatureSource].
      *
      * @since 300.0.0
      */
     public data class SelectUtilityAssetType(
         val element: UtilityAssociationsFormElement,
+        val filter : UtilityAssociationsFilter,
         val featureSource: UtilityAssociationFeatureSource
     ) : FeatureFormNavigationRoute()
 
@@ -203,6 +208,7 @@ public sealed class FeatureFormNavigationRoute {
      * [UtilityAssetType] when adding a new association.
      *
      * @param element The [UtilityAssociationsFormElement] where the association is being added.
+     * @param filter The selected [UtilityAssociationsFilter].
      * @param featureSource The selected [UtilityAssociationFeatureSource] the asset type belongs to.
      * @param assetType The selected [UtilityAssetType].
      *
@@ -210,6 +216,7 @@ public sealed class FeatureFormNavigationRoute {
      */
     public data class SelectAssociationFeatureCandidate(
         val element: UtilityAssociationsFormElement,
+        val filter : UtilityAssociationsFilter,
         val featureSource: UtilityAssociationFeatureSource,
         val assetType: UtilityAssetType
     ) : FeatureFormNavigationRoute()
@@ -219,6 +226,7 @@ public sealed class FeatureFormNavigationRoute {
      * [UtilityAssociationFeatureCandidate].
      *
      * @param element The [UtilityAssociationsFormElement] where the association is being added.
+     * @param filter The selected [UtilityAssociationsFilter].
      * @param featureSource The selected [UtilityAssociationFeatureSource] the candidate belongs to.
      * @param candidate The selected [UtilityAssociationFeatureCandidate].
      *
@@ -226,6 +234,7 @@ public sealed class FeatureFormNavigationRoute {
      */
     public data class CreateAssociation(
         val element: UtilityAssociationsFormElement,
+        val filter : UtilityAssociationsFilter,
         val featureSource: UtilityAssociationFeatureSource,
         val candidate: UtilityAssociationFeatureCandidate
     ) : FeatureFormNavigationRoute()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork
 
+import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -282,12 +283,16 @@ internal class AddAssociationFromSourceViewModel(
      * If the sources have already been fetched for the filter, this method does nothing.
      */
     suspend fun fetchFeatureSources() {
+        Log.e("TAG", "fetchFeatureSources: fetching..", )
         if (_featureSources.value.isNotEmpty()) {
             // already fetched
             return
         }
         element.getAssociationFeatureSources(filter).onSuccess { sources ->
+            Log.e("TAG", "fetchFeatureSources: $sources", )
             _featureSources.value = sources
+        }.onFailure {
+            Log.e("TAG", "fetchFeatureSources: failure", it)
         }
     }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork
 
-import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -283,16 +282,12 @@ internal class AddAssociationFromSourceViewModel(
      * If the sources have already been fetched for the filter, this method does nothing.
      */
     suspend fun fetchFeatureSources() {
-        Log.e("TAG", "fetchFeatureSources: fetching..", )
         if (_featureSources.value.isNotEmpty()) {
             // already fetched
             return
         }
         element.getAssociationFeatureSources(filter).onSuccess { sources ->
-            Log.e("TAG", "fetchFeatureSources: $sources", )
             _featureSources.value = sources
-        }.onFailure {
-            Log.e("TAG", "fetchFeatureSources: failure", it)
         }
     }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -58,7 +58,7 @@ import kotlinx.coroutines.launch
 internal class AddAssociationFromSourceViewModel(
     val featureForm : FeatureForm,
     val element: UtilityAssociationsFormElement,
-    private val filter: UtilityAssociationsFilter,
+    val filter: UtilityAssociationsFilter,
     private val onAssociationAdded: suspend () -> Unit
 ) : ViewModel() {
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.launch
  */
 internal class AddAssociationFromSourceViewModel(
     val featureForm : FeatureForm,
-    private val element: UtilityAssociationsFormElement,
+    val element: UtilityAssociationsFormElement,
     private val filter: UtilityAssociationsFilter,
     private val onAssociationAdded: suspend () -> Unit
 ) : ViewModel() {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationsElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationsElementState.kt
@@ -138,7 +138,7 @@ internal class UtilityAssociationsElementState(
             )
         }
         // update the selections as the filter results may have changed
-        val updatedFilter = _filters.find { it == selectedFilterResult }
+        val updatedFilter = _filters.find { it.filter == selectedFilterResult?.filter }
         // if the filter was found, update the selected filter result
         if (updatedFilter != null) {
             _selectedFilterResult.value = updatedFilter
@@ -273,24 +273,4 @@ internal class MutableFilterResult(
      */
     val resultCount: Int
         get() = _resultCount.value
-
-    override fun hashCode(): Int {
-        return 31 * filter.title.hashCode() +
-            filter.description.hashCode() +
-            filter.filterType.hashCode() +
-            filter.assetGroup.hashCode()
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is MutableFilterResult) return false
-
-        // Deep comparison of the `filter` property
-        if (filter.title != other.filter.title) return false
-        if (filter.description != other.filter.description) return false
-        if (filter.filterType != other.filter.filterType) return false
-        if (filter.assetGroup != other.filter.assetGroup) return false
-        if (filter.assetType != other.filter.assetType) return false
-        return true
-    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationsElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationsElementState.kt
@@ -120,25 +120,13 @@ internal class UtilityAssociationsElementState(
         element.fetchAssociationsFilterResults()
         _filters.clear()
         element.associationsFilterResults.forEach {
-            val groupResults = it.groupResults.map { groupResult ->
-                MutableGroupResult(
-                    results = groupResult.associationResults,
-                    name = groupResult.name,
-                    source = groupResult.featureFormSource
-                )
-            }
-            _filters += MutableFilterResult(
-                filter = it.filter,
-                groupResults = groupResults,
-                resultCount = it.resultCount,
-                onDelete = { association ->
-                    // delete the association from the element when it is deleted from the state
-                    element.deleteAssociation(association)
-                }
-            )
+            _filters += MutableFilterResult.create(it, element)
         }
         // update the selections as the filter results may have changed
-        val updatedFilter = _filters.find { it.filter == selectedFilterResult?.filter }
+        val updatedFilter = _filters.find {
+            // find the filter that matches the previously selected filter
+            it.filter == selectedFilterResult?.filter
+        }
         // if the filter was found, update the selected filter result
         if (updatedFilter != null) {
             _selectedFilterResult.value = updatedFilter
@@ -180,11 +168,14 @@ internal class UtilityAssociationsElementState(
  *
  * @param results The initial list of [UtilityAssociationResult] in this group.
  * @param name The name of the group.
+ * @param source The [FeatureFormSource] of the group.
+ * @param groupResult The [UtilityAssociationGroupResult] represented by this result.
  */
-internal class MutableGroupResult(
+internal class MutableGroupResult private constructor(
     results: List<UtilityAssociationResult>,
     val name: String,
-    val source : FeatureFormSource
+    val source: FeatureFormSource,
+    val groupResult: UtilityAssociationGroupResult
 ) {
     private val _associationResults: SnapshotStateList<UtilityAssociationResult> =
         mutableStateListOf<UtilityAssociationResult>().apply { addAll(results) }
@@ -219,22 +210,45 @@ internal class MutableGroupResult(
     fun setOnAssociationDeletedListener(listener: (UtilityAssociation) -> Unit) {
         onAssociationDeleted = listener
     }
+
+    companion object {
+
+        /**
+         * Creates a new [MutableGroupResult] from the given parameters.
+         *
+         * @param groupResult The [UtilityAssociationGroupResult] to wrap.
+         * @return A new [MutableGroupResult].
+         */
+        fun create(groupResult: UtilityAssociationGroupResult): MutableGroupResult {
+            return MutableGroupResult(
+                results = groupResult.associationResults,
+                name = groupResult.name,
+                source = groupResult.featureFormSource,
+                groupResult = groupResult
+            )
+        }
+    }
 }
 
 /**
  * A mutable version of [UtilityAssociationsFilterResult] that allows deleting associations.
  *
- * @param filter The [UtilityAssociationsFilter] represented by this result.
+ * @param filterResult The [UtilityAssociationsFilterResult] represented by this result.
  * @param groupResults The initial list of [MutableGroupResult] in this filter result.
  * @param resultCount The initial count of results in this filter result.
  * @param onDelete A callback that is called after an association is deleted.
  */
-internal class MutableFilterResult(
-    val filter: UtilityAssociationsFilter,
+internal class MutableFilterResult private constructor(
+    val filterResult: UtilityAssociationsFilterResult,
     groupResults: List<MutableGroupResult>,
     resultCount: Int,
     onDelete: (UtilityAssociation) -> Unit
 ) {
+
+    /**
+     * The [UtilityAssociationsFilter] represented by this filter result.
+     */
+    val filter = filterResult.filter
 
     /**
      * Backing list for the [groupResults] property.
@@ -273,4 +287,34 @@ internal class MutableFilterResult(
      */
     val resultCount: Int
         get() = _resultCount.value
+
+
+    companion object {
+
+        /**
+         * Creates a new [MutableFilterResult] from the given [UtilityAssociationsFilterResult]
+         * and [UtilityAssociationsFormElement].
+         *
+         * @param filterResult The [UtilityAssociationsFilterResult] to wrap.
+         * @param element The [UtilityAssociationsFormElement] to delete associations from.
+         * @return A new [MutableFilterResult].
+         */
+        fun create(
+            filterResult: UtilityAssociationsFilterResult,
+            element: UtilityAssociationsFormElement
+        ): MutableFilterResult {
+            val groupResults = filterResult.groupResults.map { groupResult ->
+                MutableGroupResult.create(groupResult = groupResult)
+            }
+            return MutableFilterResult(
+                filterResult = filterResult,
+                groupResults = groupResults,
+                resultCount = filterResult.resultCount,
+                onDelete = { association ->
+                    // delete the association from the element when it is deleted from the state
+                    element.deleteAssociation(association)
+                }
+            )
+        }
+    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/AddFromSourceNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/AddFromSourceNavigation.kt
@@ -21,6 +21,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -29,6 +30,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.arcgismaps.data.ArcGISFeature
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.AddAssociationFromSourceViewModel
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
@@ -41,6 +43,7 @@ internal fun NavGraphBuilder.selectSourceDestination(
     onBackPressed: (NavBackStackEntry) -> Unit,
     onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry,
     onSourceSelected: (NavBackStackEntry) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
     state: FeatureFormState
 ) {
     composable<AddFromSourceNavRoute.SelectSource>(
@@ -61,7 +64,7 @@ internal fun NavGraphBuilder.selectSourceDestination(
                 factory = AddAssociationFromSourceViewModel.Factory(
                     element = state.element,
                     featureForm = formData.featureForm,
-                    filter = state.selectedFilterResult!!.filter,
+                    filter = state.selectedFilterResult!!.filterResult.filter,
                     onAssociationAdded = {
                         state.refreshResults()
                     }
@@ -77,6 +80,12 @@ internal fun NavGraphBuilder.selectSourceDestination(
                 },
                 modifier = Modifier.fillMaxSize()
             )
+            LaunchedEffect(state) {
+                val eventData = FeatureFormNavigationEvent.SelectUtilityAssociationFeatureSource(
+                    element = state.element
+                )
+                onNavigationEvent(eventData)
+            }
         }
     }
 }
@@ -84,14 +93,16 @@ internal fun NavGraphBuilder.selectSourceDestination(
 internal fun NavGraphBuilder.selectAssetTypeDestination(
     onAssetTypeSelected: (NavBackStackEntry) -> Unit,
     onBackPressed: (NavBackStackEntry) -> Unit,
-    onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry
+    onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry,
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit
 ) {
     composable<AddFromSourceNavRoute.SelectAssetType> { backStackEntry ->
         val parent = remember(backStackEntry) {
             onGetParentEntry(backStackEntry)
         }
+        val viewModel: AddAssociationFromSourceViewModel = viewModel(parent)
         SelectAssetTypeScreen(
-            viewModel = viewModel(parent),
+            viewModel = viewModel,
             onBackPressed = {
                 onBackPressed(backStackEntry)
             },
@@ -100,21 +111,33 @@ internal fun NavGraphBuilder.selectAssetTypeDestination(
             },
             modifier = Modifier.fillMaxSize()
         )
+        LaunchedEffect(viewModel.selectedSource) {
+            viewModel.selectedSource?.let { source ->
+                // only send event if we have a selected source
+                val eventData = FeatureFormNavigationEvent.SelectUtilityAssetType(
+                    element = viewModel.element,
+                    featureSource = source
+                )
+                onNavigationEvent(eventData)
+            }
+        }
     }
 }
 
 internal fun NavGraphBuilder.selectFeatureDestination(
     onBackPressed: (NavBackStackEntry) -> Unit,
     onFeatureCandidateSelected: (NavBackStackEntry) -> Unit,
-    onFeatureCandidateLocateRequest : (ArcGISFeature) -> Unit,
+    onFeatureCandidateLocateRequest: (ArcGISFeature) -> Unit,
     onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry,
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit
 ) {
     composable<AddFromSourceNavRoute.SelectAssociatedFeature> { backStackEntry ->
         val parent = remember(backStackEntry) {
             onGetParentEntry(backStackEntry)
         }
+        val viewModel: AddAssociationFromSourceViewModel = viewModel(parent)
         SelectAssociatedFeatureScreen(
-            viewModel = viewModel(parent),
+            viewModel = viewModel,
             onBackPressed = {
                 onBackPressed(backStackEntry)
             },
@@ -124,13 +147,27 @@ internal fun NavGraphBuilder.selectFeatureDestination(
             onFeatureCandidateLocateRequest = onFeatureCandidateLocateRequest,
             modifier = Modifier.fillMaxSize()
         )
+        LaunchedEffect(viewModel.selectedAssetType) {
+            viewModel.selectedSource?.let { source ->
+                viewModel.selectedAssetType?.let { assetType ->
+                    val eventData =
+                        FeatureFormNavigationEvent.SelectUtilityAssociationFeatureCandidate(
+                            element = viewModel.element,
+                            featureSource = source,
+                            assetType = assetType
+                        )
+                    onNavigationEvent(eventData)
+                }
+            }
+        }
     }
 }
 
 internal fun NavGraphBuilder.createAssociationDestination(
     onAssociationCreated: (NavBackStackEntry) -> Unit,
     onBackPressed: (NavBackStackEntry) -> Unit,
-    onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry
+    onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry,
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit
 ) {
     composable<AddFromSourceNavRoute.CreateAssociation>(
         enterTransition = { slideInVertically { h -> h } },
@@ -141,8 +178,9 @@ internal fun NavGraphBuilder.createAssociationDestination(
         val parent = remember(backStackEntry) {
             onGetParentEntry(backStackEntry)
         }
+        val viewModel: AddAssociationFromSourceViewModel = viewModel(parent)
         CreateAssociationScreen(
-            viewModel = viewModel(parent),
+            viewModel = viewModel,
             onAssociationCreated = {
                 onAssociationCreated(backStackEntry)
             },
@@ -151,6 +189,18 @@ internal fun NavGraphBuilder.createAssociationDestination(
             },
             modifier = Modifier.fillMaxSize()
         )
+        LaunchedEffect(viewModel.newAssociationOptions) {
+            viewModel.selectedSource?.let { source ->
+                viewModel.newAssociationOptions?.let { options ->
+                    val eventData = FeatureFormNavigationEvent.CreateNewUtilityAssociation(
+                        element = viewModel.element,
+                        featureSource = source,
+                        candidate = options.candidate
+                    )
+                    onNavigationEvent(eventData)
+                }
+            }
+        }
     }
 }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/AddFromSourceNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/AddFromSourceNavigation.kt
@@ -30,7 +30,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.arcgismaps.data.ArcGISFeature
-import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationRoute
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.AddAssociationFromSourceViewModel
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
@@ -43,7 +43,7 @@ internal fun NavGraphBuilder.selectSourceDestination(
     onBackPressed: (NavBackStackEntry) -> Unit,
     onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry,
     onSourceSelected: (NavBackStackEntry) -> Unit,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit,
     state: FeatureFormState
 ) {
     composable<AddFromSourceNavRoute.SelectSource>(
@@ -81,7 +81,7 @@ internal fun NavGraphBuilder.selectSourceDestination(
                 modifier = Modifier.fillMaxSize()
             )
             LaunchedEffect(state) {
-                val eventData = FeatureFormNavigationEvent.SelectUtilityAssociationFeatureSource(
+                val eventData = FeatureFormNavigationRoute.SelectAssociationFeatureSource(
                     element = state.element
                 )
                 onNavigationEvent(eventData)
@@ -94,7 +94,7 @@ internal fun NavGraphBuilder.selectAssetTypeDestination(
     onAssetTypeSelected: (NavBackStackEntry) -> Unit,
     onBackPressed: (NavBackStackEntry) -> Unit,
     onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit
 ) {
     composable<AddFromSourceNavRoute.SelectAssetType> { backStackEntry ->
         val parent = remember(backStackEntry) {
@@ -114,7 +114,7 @@ internal fun NavGraphBuilder.selectAssetTypeDestination(
         LaunchedEffect(viewModel.selectedSource) {
             viewModel.selectedSource?.let { source ->
                 // only send event if we have a selected source
-                val eventData = FeatureFormNavigationEvent.SelectUtilityAssetType(
+                val eventData = FeatureFormNavigationRoute.SelectUtilityAssetType(
                     element = viewModel.element,
                     featureSource = source
                 )
@@ -129,7 +129,7 @@ internal fun NavGraphBuilder.selectFeatureDestination(
     onFeatureCandidateSelected: (NavBackStackEntry) -> Unit,
     onFeatureCandidateLocateRequest: (ArcGISFeature) -> Unit,
     onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit
 ) {
     composable<AddFromSourceNavRoute.SelectAssociatedFeature> { backStackEntry ->
         val parent = remember(backStackEntry) {
@@ -151,7 +151,7 @@ internal fun NavGraphBuilder.selectFeatureDestination(
             viewModel.selectedSource?.let { source ->
                 viewModel.selectedAssetType?.let { assetType ->
                     val eventData =
-                        FeatureFormNavigationEvent.SelectUtilityAssociationFeatureCandidate(
+                        FeatureFormNavigationRoute.SelectAssociationFeatureCandidate(
                             element = viewModel.element,
                             featureSource = source,
                             assetType = assetType
@@ -167,7 +167,7 @@ internal fun NavGraphBuilder.createAssociationDestination(
     onAssociationCreated: (NavBackStackEntry) -> Unit,
     onBackPressed: (NavBackStackEntry) -> Unit,
     onGetParentEntry: (NavBackStackEntry) -> NavBackStackEntry,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit
 ) {
     composable<AddFromSourceNavRoute.CreateAssociation>(
         enterTransition = { slideInVertically { h -> h } },
@@ -192,7 +192,7 @@ internal fun NavGraphBuilder.createAssociationDestination(
         LaunchedEffect(viewModel.newAssociationOptions) {
             viewModel.selectedSource?.let { source ->
                 viewModel.newAssociationOptions?.let { options ->
-                    val eventData = FeatureFormNavigationEvent.CreateNewUtilityAssociation(
+                    val eventData = FeatureFormNavigationRoute.CreateAssociation(
                         element = viewModel.element,
                         featureSource = source,
                         candidate = options.candidate

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/AddFromSourceNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/AddFromSourceNavigation.kt
@@ -82,7 +82,8 @@ internal fun NavGraphBuilder.selectSourceDestination(
             )
             LaunchedEffect(state) {
                 val eventData = FeatureFormNavigationRoute.SelectAssociationFeatureSource(
-                    element = state.element
+                    element = state.element,
+                    filter = viewModel.filter
                 )
                 onNavigationEvent(eventData)
             }
@@ -116,6 +117,7 @@ internal fun NavGraphBuilder.selectAssetTypeDestination(
                 // only send event if we have a selected source
                 val eventData = FeatureFormNavigationRoute.SelectUtilityAssetType(
                     element = viewModel.element,
+                    filter = viewModel.filter,
                     featureSource = source
                 )
                 onNavigationEvent(eventData)
@@ -153,6 +155,7 @@ internal fun NavGraphBuilder.selectFeatureDestination(
                     val eventData =
                         FeatureFormNavigationRoute.SelectAssociationFeatureCandidate(
                             element = viewModel.element,
+                            filter = viewModel.filter,
                             featureSource = source,
                             assetType = assetType
                         )
@@ -194,6 +197,7 @@ internal fun NavGraphBuilder.createAssociationDestination(
                 viewModel.newAssociationOptions?.let { options ->
                     val eventData = FeatureFormNavigationRoute.CreateAssociation(
                         element = viewModel.element,
+                        filter = viewModel.filter,
                         featureSource = source,
                         candidate = options.candidate
                     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
@@ -30,7 +30,7 @@ import androidx.navigation.navigation
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationRoute
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 
@@ -44,7 +44,7 @@ internal fun FeatureFormNavHost(
     onDiscardForm: suspend (Boolean) -> Unit,
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)?,
     onShowOnMapRequest: (ArcGISFeature) -> Unit,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -80,7 +80,7 @@ internal fun FeatureFormNavHost(
             onNavigateToAssociation = navController::navigateToUNAssociationDetails,
             onNavigateToFeature =  state::navigateTo,
             onNavigationEvent = onNavigationEvent,
-            onBack =  navController::popBackStack,
+            onBack =  state::popBackStack,
         )
 
         associationDetailsDestination(
@@ -89,6 +89,9 @@ internal fun FeatureFormNavHost(
                 if (isGroupEmpty) {
                     navController.popBackStack<NavigationRoute.UNAssociationsFilterResult>(inclusive = false)
                 }
+            },
+            onClose = { entry ->
+                state.popBackStack(entry)
             },
             onNavigationEvent = onNavigationEvent,
             state = state,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
@@ -68,6 +68,7 @@ internal fun FeatureFormNavHost(
         associationsFilterResultDestination(
             onGroupSelected =  navController::navigateToUNAssociationGroupResult,
             onAddFromSourceClick = navController::navigateToAddUNAssociationFromSource,
+            onNavigationEvent = onNavigationEvent,
             state = state
         )
 
@@ -76,8 +77,21 @@ internal fun FeatureFormNavHost(
             onSave = onSaveForm,
             onDiscard = onDiscardForm,
             isNavigationEnabled = isNavigationEnabled,
+            onNavigateToAssociation = navController::navigateToUNAssociationDetails,
             onNavigateToFeature =  state::navigateTo,
+            onNavigationEvent = onNavigationEvent,
             onBack =  navController::popBackStack,
+        )
+
+        associationDetailsDestination(
+            onDeleteAssociation = { isGroupEmpty ->
+                // If the group is empty after deletion, navigate back to the filter view
+                if (isGroupEmpty) {
+                    navController.popBackStack<NavigationRoute.UNAssociationsFilterResult>(inclusive = false)
+                }
+            },
+            onNavigationEvent = onNavigationEvent,
+            state = state,
         )
 
         navigation<NavigationRoute.AddUNAssociationFromSource>(
@@ -89,6 +103,7 @@ internal fun FeatureFormNavHost(
                     navController.getBackStackEntry(it.destination.parent!!.id)
                 },
                 onSourceSelected = navController::navigateToSelectAssetType,
+                onNavigationEvent = onNavigationEvent,
                 state = state
             )
 
@@ -97,7 +112,8 @@ internal fun FeatureFormNavHost(
                 onBackPressed = state::popBackStack,
                 onGetParentEntry = {
                     navController.getBackStackEntry(it.destination.parent!!.id)
-                }
+                },
+                onNavigationEvent = onNavigationEvent
             )
 
             selectFeatureDestination(
@@ -108,7 +124,8 @@ internal fun FeatureFormNavHost(
                 onFeatureCandidateLocateRequest = onShowOnMapRequest,
                 onGetParentEntry = {
                     navController.getBackStackEntry(it.destination.parent!!.id)
-                }
+                },
+                onNavigationEvent = onNavigationEvent
             )
 
             createAssociationDestination(
@@ -118,7 +135,8 @@ internal fun FeatureFormNavHost(
                 onBackPressed = state::popBackStack,
                 onGetParentEntry = {
                     navController.getBackStackEntry(it.destination.parent!!.id)
-                }
+                },
+                onNavigationEvent = onNavigationEvent
             )
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavHost.kt
@@ -30,6 +30,7 @@ import androidx.navigation.navigation
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FieldFormElement
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 
@@ -43,6 +44,7 @@ internal fun FeatureFormNavHost(
     onDiscardForm: suspend (Boolean) -> Unit,
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)?,
     onShowOnMapRequest: (ArcGISFeature) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -59,6 +61,7 @@ internal fun FeatureFormNavHost(
             state = state,
             onBarcodeButtonClick = onBarcodeButtonClick,
             onUtilityFilterSelected = navController::navigateToUNAssociationsFilterResult,
+            onNavigationEvent = onNavigationEvent,
             validationErrorVisibility = validationErrorVisibility
         )
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavigation.kt
@@ -46,7 +46,7 @@ internal fun NavGraphBuilder.featureFormDestination(
         LaunchedEffect(formData) {
             // Update the active feature form if we navigate back to this screen from another form.
             state.updateActiveFeatureForm()
-            onNavigationEvent(FeatureFormNavigationRoute.FeatureForm)
+            onNavigationEvent(FeatureFormNavigationRoute.Form)
         }
         // launch a new side effect in a launched effect when validationErrorVisibility changes
         // for a given form

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavigation.kt
@@ -22,6 +22,7 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.arcgismaps.mapping.featureforms.FieldFormElement
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureforms.internal.screens.FeatureFormScreen
@@ -29,6 +30,7 @@ import com.arcgismaps.toolkit.featureforms.internal.screens.FeatureFormScreen
 internal fun NavGraphBuilder.featureFormDestination(
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)?,
     onUtilityFilterSelected: (NavBackStackEntry, Int) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
     state : FeatureFormState,
     validationErrorVisibility : ValidationErrorVisibility
 ) {
@@ -44,6 +46,7 @@ internal fun NavGraphBuilder.featureFormDestination(
         LaunchedEffect(formData) {
             // Update the active feature form if we navigate back to this screen from another form.
             state.updateActiveFeatureForm()
+            onNavigationEvent(FeatureFormNavigationEvent.FeatureForm)
         }
         // launch a new side effect in a launched effect when validationErrorVisibility changes
         // for a given form

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/FeatureFormNavigation.kt
@@ -22,7 +22,7 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationRoute
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureforms.internal.screens.FeatureFormScreen
@@ -30,7 +30,7 @@ import com.arcgismaps.toolkit.featureforms.internal.screens.FeatureFormScreen
 internal fun NavGraphBuilder.featureFormDestination(
     onBarcodeButtonClick: ((FieldFormElement) -> Unit)?,
     onUtilityFilterSelected: (NavBackStackEntry, Int) -> Unit,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit,
     state : FeatureFormState,
     validationErrorVisibility : ValidationErrorVisibility
 ) {
@@ -46,7 +46,7 @@ internal fun NavGraphBuilder.featureFormDestination(
         LaunchedEffect(formData) {
             // Update the active feature form if we navigate back to this screen from another form.
             state.updateActiveFeatureForm()
-            onNavigationEvent(FeatureFormNavigationEvent.FeatureForm)
+            onNavigationEvent(FeatureFormNavigationRoute.FeatureForm)
         }
         // launch a new side effect in a launched effect when validationErrorVisibility changes
         // for a given form

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/NavigationRoute.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/NavigationRoute.kt
@@ -67,6 +67,17 @@ internal sealed class NavigationRoute {
     data class AddUNAssociationFromSource(
         val stateId: Int
     ) : NavigationRoute()
+
+    /**
+     * Represents a route for navigating to a specific association's details.
+     *
+     * @param stateId The state ID of the [UtilityAssociationsElementState] which contains the
+     * selected association.
+     */
+    @Serializable
+    data class UNAssociationDetails(
+        val stateId: Int
+    ) : NavigationRoute()
 }
 
 /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationDetailsNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationDetailsNavigation.kt
@@ -16,6 +16,10 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.navigation
 
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -25,17 +29,23 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationRoute
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
-import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationDetails
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
+import com.arcgismaps.toolkit.featureforms.internal.screens.UtilityAssociationDetailsScreen
 
 internal fun NavGraphBuilder.associationDetailsDestination(
     onDeleteAssociation: (isGroupEmpty: Boolean) -> Unit,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
+    onClose: (NavBackStackEntry) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit,
     state: FeatureFormState,
 ) {
-    composable<NavigationRoute.UNAssociationDetails> { backStackEntry ->
+    composable<NavigationRoute.UNAssociationDetails>(
+        enterTransition = { slideInVertically { h -> h } },
+        exitTransition = { fadeOut() },
+        popEnterTransition = { fadeIn() },
+        popExitTransition = { slideOutVertically { h -> h } }
+    ) { backStackEntry ->
         val route = backStackEntry.toRoute<NavigationRoute.UNAssociationGroupResult>()
         val formData = remember(backStackEntry) { state.getActiveFormStateData() }
         val states = formData.stateCollection
@@ -43,14 +53,17 @@ internal fun NavGraphBuilder.associationDetailsDestination(
         val utilityAssociationsElementState =
             states[route.stateId] as? UtilityAssociationsElementState
         if (utilityAssociationsElementState != null) {
-            UtilityAssociationDetails(
-                state = utilityAssociationsElementState,
+            UtilityAssociationDetailsScreen(
                 onDelete = onDeleteAssociation,
+                onClose = {
+                    onClose(backStackEntry)
+                },
+                state = utilityAssociationsElementState,
                 modifier = Modifier.fillMaxSize()
             )
             LaunchedEffect(utilityAssociationsElementState.selectedAssociationResult) {
                 utilityAssociationsElementState.selectedAssociationResult?.let { result ->
-                    val eventData = FeatureFormNavigationEvent.UtilityAssociationResultView(
+                    val eventData = FeatureFormNavigationRoute.AssociationResult(
                         element = utilityAssociationsElementState.element,
                         utilityAssociationResult = result
                     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationDetailsNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationDetailsNavigation.kt
@@ -65,7 +65,7 @@ internal fun NavGraphBuilder.associationDetailsDestination(
                 utilityAssociationsElementState.selectedAssociationResult?.let { result ->
                     val eventData = FeatureFormNavigationRoute.AssociationResult(
                         element = utilityAssociationsElementState.element,
-                        utilityAssociationResult = result
+                        associationResult = result
                     )
                     onNavigationEvent(eventData)
                 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationDetailsNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationDetailsNavigation.kt
@@ -27,53 +27,44 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationDetails
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
-import com.arcgismaps.toolkit.featureforms.internal.screens.UNAssociationsFilterResultScreen
 
-internal fun NavGraphBuilder.associationsFilterResultDestination(
-    onGroupSelected: (NavBackStackEntry, Int) -> Unit,
-    onAddFromSourceClick: (NavBackStackEntry, Int) -> Unit,
+internal fun NavGraphBuilder.associationDetailsDestination(
+    onDeleteAssociation: (isGroupEmpty: Boolean) -> Unit,
     onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
     state: FeatureFormState,
 ) {
-    composable<NavigationRoute.UNAssociationsFilterResult> { backStackEntry ->
-        val route = backStackEntry.toRoute<NavigationRoute.UNAssociationsFilterResult>()
+    composable<NavigationRoute.UNAssociationDetails> { backStackEntry ->
+        val route = backStackEntry.toRoute<NavigationRoute.UNAssociationGroupResult>()
         val formData = remember(backStackEntry) { state.getActiveFormStateData() }
         val states = formData.stateCollection
         // Get the selected UtilityAssociationsElementState from the state collection
-        val utilityAssociationsElementState = states[route.stateId]
-            // guard against null value
-            as? UtilityAssociationsElementState
-        // Get the selected filter from the UtilityAssociationsElementState
-        val filterResult = utilityAssociationsElementState?.selectedFilterResult
-        // guard against null value
-        if (filterResult != null) {
-            UNAssociationsFilterResultScreen(
+        val utilityAssociationsElementState =
+            states[route.stateId] as? UtilityAssociationsElementState
+        if (utilityAssociationsElementState != null) {
+            UtilityAssociationDetails(
                 state = utilityAssociationsElementState,
-                onGroupSelected = { stateId ->
-                    onGroupSelected(backStackEntry, stateId)
-                },
-                onAddFromSourceClick = { stateId ->
-                    onAddFromSourceClick(backStackEntry, stateId)
-                },
+                onDelete = onDeleteAssociation,
                 modifier = Modifier.fillMaxSize()
             )
-            LaunchedEffect(filterResult) {
-                val eventData = FeatureFormNavigationEvent.UtilityAssociationsFilterResultNav(
-                    element = utilityAssociationsElementState.element,
-                    utilityAssociationsFilterResult = filterResult.filterResult
-                )
-                onNavigationEvent(eventData)
+            LaunchedEffect(utilityAssociationsElementState.selectedAssociationResult) {
+                utilityAssociationsElementState.selectedAssociationResult?.let { result ->
+                    val eventData = FeatureFormNavigationEvent.UtilityAssociationResultView(
+                        element = utilityAssociationsElementState.element,
+                        utilityAssociationResult = result
+                    )
+                    onNavigationEvent(eventData)
+                }
             }
         }
     }
 }
 
-internal fun NavHostController.navigateToUNAssociationsFilterResult(
+internal fun NavHostController.navigateToUNAssociationDetails(
     backStackEntry: NavBackStackEntry,
     stateId: Int
 ) {
-    val newRoute = NavigationRoute.UNAssociationsFilterResult(stateId = stateId)
-    // Navigate to the filter view
+    val newRoute = NavigationRoute.UNAssociationDetails(stateId = stateId)
     navigateSafely(backStackEntry, newRoute)
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.navigation
 
-import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -28,6 +27,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.featureforms.FeatureForm
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
 import com.arcgismaps.toolkit.featureforms.internal.screens.UNAssociationGroupResultScreen
@@ -36,7 +36,9 @@ internal fun NavGraphBuilder.associationGroupResultDestination(
     state: FeatureFormState,
     onSave: suspend (FeatureForm, Boolean) -> Result<Unit>,
     onDiscard: suspend (Boolean) -> Unit,
+    onNavigateToAssociation : (NavBackStackEntry, Int) -> Unit,
     onNavigateToFeature: (NavBackStackEntry, ArcGISFeature) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
     onBack: () -> Unit,
     isNavigationEnabled: Boolean,
 ) {
@@ -56,6 +58,9 @@ internal fun NavGraphBuilder.associationGroupResultDestination(
                 isNavigationEnabled = isNavigationEnabled,
                 onSave = onSave,
                 onDiscard = onDiscard,
+                onNavigateToAssociation = {
+                    onNavigateToAssociation(backStackEntry, utilityAssociationsElementState.id)
+                },
                 onNavigateToFeature = { feature ->
                     onNavigateToFeature(backStackEntry, feature)
                 },
@@ -68,7 +73,11 @@ internal fun NavGraphBuilder.associationGroupResultDestination(
                 state.updateActiveFeatureForm()
             }
             LaunchedEffect(groupResult) {
-                Log.e("TAG", "associationGroupResultDestination: $groupResult", )
+                val eventData = FeatureFormNavigationEvent.UtilityAssociationsGroupResultNav(
+                    element = utilityAssociationsElementState.element,
+                    utilityAssociationGroupResult = groupResult.groupResult
+                )
+                onNavigationEvent(eventData)
             }
         } else {
             // If we don't have a valid state or group, navigate back to the previous screen.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
@@ -75,9 +75,10 @@ internal fun NavGraphBuilder.associationGroupResultDestination(
                 state.updateActiveFeatureForm()
             }
             LaunchedEffect(groupResult) {
-                val eventData = FeatureFormNavigationRoute.GroupResult(
+                val eventData = FeatureFormNavigationRoute.AssociationGroupResult(
                     element = utilityAssociationsElementState.element,
-                    utilityAssociationGroupResult = groupResult.groupResult
+                    filter = utilityAssociationsElementState.selectedFilterResult!!.filter,
+                    groupResult = groupResult.groupResult
                 )
                 onNavigationEvent(eventData)
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
@@ -78,7 +78,7 @@ internal fun NavGraphBuilder.associationGroupResultDestination(
                 val eventData = FeatureFormNavigationRoute.AssociationGroupResult(
                     element = utilityAssociationsElementState.element,
                     filter = utilityAssociationsElementState.selectedFilterResult!!.filter,
-                    groupResult = groupResult.groupResult
+                    result = groupResult.groupResult
                 )
                 onNavigationEvent(eventData)
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.navigation
 
+import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -65,6 +66,9 @@ internal fun NavGraphBuilder.associationGroupResultDestination(
                 // Update the active feature form when we navigate back to this screen from another
                 // form.
                 state.updateActiveFeatureForm()
+            }
+            LaunchedEffect(groupResult) {
+                Log.e("TAG", "associationGroupResultDestination: $groupResult", )
             }
         } else {
             // If we don't have a valid state or group, navigate back to the previous screen.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationGroupResultNavigation.kt
@@ -27,7 +27,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.featureforms.FeatureForm
-import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationRoute
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
 import com.arcgismaps.toolkit.featureforms.internal.screens.UNAssociationGroupResultScreen
@@ -38,8 +38,8 @@ internal fun NavGraphBuilder.associationGroupResultDestination(
     onDiscard: suspend (Boolean) -> Unit,
     onNavigateToAssociation : (NavBackStackEntry, Int) -> Unit,
     onNavigateToFeature: (NavBackStackEntry, ArcGISFeature) -> Unit,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
-    onBack: () -> Unit,
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit,
+    onBack: (NavBackStackEntry) -> Unit,
     isNavigationEnabled: Boolean,
 ) {
     composable<NavigationRoute.UNAssociationGroupResult> { backStackEntry ->
@@ -64,7 +64,9 @@ internal fun NavGraphBuilder.associationGroupResultDestination(
                 onNavigateToFeature = { feature ->
                     onNavigateToFeature(backStackEntry, feature)
                 },
-                onBack = onBack,
+                onBack = {
+                    onBack(backStackEntry)
+                },
                 modifier = Modifier.fillMaxSize()
             )
             LaunchedEffect(formData) {
@@ -73,7 +75,7 @@ internal fun NavGraphBuilder.associationGroupResultDestination(
                 state.updateActiveFeatureForm()
             }
             LaunchedEffect(groupResult) {
-                val eventData = FeatureFormNavigationEvent.UtilityAssociationsGroupResultNav(
+                val eventData = FeatureFormNavigationRoute.GroupResult(
                     element = utilityAssociationsElementState.element,
                     utilityAssociationGroupResult = groupResult.groupResult
                 )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationsFilterResultNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationsFilterResultNavigation.kt
@@ -59,9 +59,9 @@ internal fun NavGraphBuilder.associationsFilterResultDestination(
                 modifier = Modifier.fillMaxSize()
             )
             LaunchedEffect(filterResult) {
-                val eventData = FeatureFormNavigationRoute.FilterResult(
+                val eventData = FeatureFormNavigationRoute.AssociationsFilterResult(
                     element = utilityAssociationsElementState.element,
-                    utilityAssociationsFilterResult = filterResult.filterResult
+                    filterResult = filterResult.filterResult
                 )
                 onNavigationEvent(eventData)
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationsFilterResultNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationsFilterResultNavigation.kt
@@ -25,7 +25,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationRoute
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
 import com.arcgismaps.toolkit.featureforms.internal.screens.UNAssociationsFilterResultScreen
@@ -33,7 +33,7 @@ import com.arcgismaps.toolkit.featureforms.internal.screens.UNAssociationsFilter
 internal fun NavGraphBuilder.associationsFilterResultDestination(
     onGroupSelected: (NavBackStackEntry, Int) -> Unit,
     onAddFromSourceClick: (NavBackStackEntry, Int) -> Unit,
-    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationRoute) -> Unit,
     state: FeatureFormState,
 ) {
     composable<NavigationRoute.UNAssociationsFilterResult> { backStackEntry ->
@@ -59,7 +59,7 @@ internal fun NavGraphBuilder.associationsFilterResultDestination(
                 modifier = Modifier.fillMaxSize()
             )
             LaunchedEffect(filterResult) {
-                val eventData = FeatureFormNavigationEvent.UtilityAssociationsFilterResultNav(
+                val eventData = FeatureFormNavigationRoute.FilterResult(
                     element = utilityAssociationsElementState.element,
                     utilityAssociationsFilterResult = filterResult.filterResult
                 )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationsFilterResultNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationsFilterResultNavigation.kt
@@ -16,7 +16,9 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.navigation
 
+import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavBackStackEntry
@@ -24,6 +26,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.arcgismaps.toolkit.featureforms.FeatureFormNavigationEvent
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
 import com.arcgismaps.toolkit.featureforms.internal.screens.UNAssociationsFilterResultScreen
@@ -31,6 +34,7 @@ import com.arcgismaps.toolkit.featureforms.internal.screens.UNAssociationsFilter
 internal fun NavGraphBuilder.associationsFilterResultDestination(
     onGroupSelected: (NavBackStackEntry, Int) -> Unit,
     onAddFromSourceClick: (NavBackStackEntry, Int) -> Unit,
+    onNavigationEvent: (FeatureFormNavigationEvent) -> Unit,
     state: FeatureFormState,
 ) {
     composable<NavigationRoute.UNAssociationsFilterResult> { backStackEntry ->
@@ -55,6 +59,12 @@ internal fun NavGraphBuilder.associationsFilterResultDestination(
                 },
                 modifier = Modifier.fillMaxSize()
             )
+            LaunchedEffect(filterResult) {
+                val eventData = FeatureFormNavigationEvent.UtilityAssociationsFilterResultNav(
+                    element = utilityAssociationsElementState.element,
+                    utilityAssociationsFilterResult = filterResult.filter
+                )
+            }
         }
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationsFilterResultNavigation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/navigation/UNAssociationsFilterResultNavigation.kt
@@ -61,7 +61,7 @@ internal fun NavGraphBuilder.associationsFilterResultDestination(
             LaunchedEffect(filterResult) {
                 val eventData = FeatureFormNavigationRoute.AssociationsFilterResult(
                     element = utilityAssociationsElementState.element,
-                    filterResult = filterResult.filterResult
+                    result = filterResult.filterResult
                 )
                 onNavigationEvent(eventData)
             }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/ContentAwareTopBar.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/ContentAwareTopBar.kt
@@ -409,6 +409,7 @@ private fun InitializingExpressions(
 private fun NavBackStackEntry.shouldEnableTopBar(): Boolean {
     return when {
         this.destination.parent?.hasRoute<NavigationRoute.AddUNAssociationFromSource>() == true -> false
+        this.destination.hasRoute<NavigationRoute.UNAssociationDetails>() -> false
         else -> true
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UNAssociationGroupResultScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UNAssociationGroupResultScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavBackStackEntry
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.toolkit.featureforms.R
@@ -73,6 +74,7 @@ internal fun UNAssociationGroupResultScreen(
     isNavigationEnabled: Boolean,
     onSave: suspend (FeatureForm, Boolean) -> Result<Unit>,
     onDiscard: suspend (Boolean) -> Unit,
+    onNavigateToAssociation : () -> Unit,
     onNavigateToFeature: (ArcGISFeature) -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier
@@ -115,7 +117,8 @@ internal fun UNAssociationGroupResultScreen(
             val association = groupResult.associationResults[index]
             state.setSelectedAssociationResult(association)
             // show the details sheet
-            showDetails = true
+            // showDetails = true
+            onNavigateToAssociation()
         },
         onDelete = { isGroupEmpty ->
             if (isGroupEmpty) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UNAssociationGroupResultScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UNAssociationGroupResultScreen.kt
@@ -16,18 +16,8 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.screens
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -35,18 +25,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavBackStackEntry
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.featureforms.FeatureForm
-import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.dialogs.SaveEditsDialog
-import com.arcgismaps.toolkit.featureforms.internal.components.material3.ModalBottomSheet
-import com.arcgismaps.toolkit.featureforms.internal.components.material3.rememberModalBottomSheetState
-import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationDetails
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationGroupResult
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
 import com.arcgismaps.toolkit.featureforms.internal.navigation.NavigationAction
@@ -81,7 +64,6 @@ internal fun UNAssociationGroupResultScreen(
 ) {
     val groupResult = state.selectedGroupResult ?: return
     val hasEdits by featureForm.hasEdits.collectAsState()
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val isEditable by state.isEditable.collectAsState()
     val scope = rememberCoroutineScope()
     // State to hold the pending navigation action when the form has unsaved edits
@@ -96,9 +78,6 @@ internal fun UNAssociationGroupResultScreen(
                 onNavigateToFeature(feature)
             }
         }
-    }
-    var showDetails by rememberSaveable {
-        mutableStateOf(false)
     }
     UtilityAssociationGroupResult(
         groupResult = groupResult,
@@ -154,55 +133,5 @@ internal fun UNAssociationGroupResultScreen(
                 }
             }
         )
-    }
-    if (showDetails) {
-        ModalBottomSheet(
-            onDismissRequest = {
-                scope.launch { sheetState.hide() }.invokeOnCompletion {
-                    if (!sheetState.isVisible) {
-                        showDetails = false
-                    }
-                }
-            },
-            sheetState = sheetState,
-            modifier = Modifier.systemBarsPadding()
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 24.dp, end = 16.dp, bottom = 8.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.association_settings),
-                    style = MaterialTheme.typography.titleLarge
-                )
-                IconButton(onClick = {
-                    scope.launch { sheetState.hide() }.invokeOnCompletion {
-                        if (!sheetState.isVisible) {
-                            showDetails = false
-                        }
-                    }
-                }) {
-                    Icon(imageVector = Icons.Default.Close, contentDescription = "Close Details")
-                }
-            }
-            UtilityAssociationDetails(
-                state = state,
-                onDelete = { isGroupEmpty ->
-                    scope.launch { sheetState.hide() }.invokeOnCompletion {
-                        if (!sheetState.isVisible) {
-                            showDetails = false
-                            // If the group is empty after deletion, navigate back to the filter view
-                            if (isGroupEmpty) {
-                                onBack()
-                            }
-                        }
-                    }
-                },
-                modifier = Modifier.fillMaxSize()
-            )
-        }
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UtilityAssociationDetailsScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UtilityAssociationDetailsScreen.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.arcgismaps.toolkit.featureforms.R
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationDetails
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityAssociationsElementState
+
+@Composable
+internal fun UtilityAssociationDetailsScreen(
+    onDelete: (isGroupEmpty: Boolean) -> Unit,
+    onClose: () -> Unit,
+    state: UtilityAssociationsElementState,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 24.dp, end = 16.dp, bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.association_settings),
+                style = MaterialTheme.typography.titleLarge
+            )
+            IconButton(onClick = onClose) {
+                Icon(imageVector = Icons.Default.Close, contentDescription = "Close Details")
+            }
+        }
+        UtilityAssociationDetails(
+            state = state,
+            onDelete = onDelete,
+            modifier = modifier
+        )
+    }
+}


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/apollo/issues/1487

<!-- link to design, if applicable -->

### Description:

Added a new event that is invoked on navigation events within the form along with metadata.

### Summary of changes:

- Added new parameter `onNavigationEvent: (FeatureFormNavigationRoute) -> Unit` which is invoked when any navigation happens internally. 
- The event data is a new class of type `FeatureFormNavigationRoute`. Each path in this route is tied to a specific internal destination. Open to suggestion on naming here.
- Changed the association details screen to its own destination instead of a bottomsheet.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1019/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  