### PR TITLE
`FeatureForm` : Refactor how association options are generated

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -56,13 +56,14 @@ import kotlinx.coroutines.launch
  * added. This can be used to refresh the UI or perform other actions in response to the addition.
  */
 internal class AddAssociationFromSourceViewModel(
-    val featureForm : FeatureForm,
+    val featureForm: FeatureForm,
     private val element: UtilityAssociationsFormElement,
     private val filter: UtilityAssociationsFilter,
     private val onAssociationAdded: suspend () -> Unit
 ) : ViewModel() {
 
     private val _featureSourcesFilterText: MutableState<String> = mutableStateOf("")
+
     /**
      * The current text used to filter the list of feature sources. This can be set via
      * [setFeatureSourcesFilterText].
@@ -70,6 +71,7 @@ internal class AddAssociationFromSourceViewModel(
     val featureSourcesFilterText by _featureSourcesFilterText
 
     private val _assetTypesFilterText: MutableState<String> = mutableStateOf("")
+
     /**
      * The current text used to filter the list of asset types. This can be set via
      * [setAssetTypesFilterText].
@@ -77,6 +79,7 @@ internal class AddAssociationFromSourceViewModel(
     val assetTypesFilterText by _assetTypesFilterText
 
     private val _associatedFeaturesFilterText: MutableState<String> = mutableStateOf("")
+
     /**
      * The current text used to filter the list of associated feature candidates. This can be set
      * via [setAssociatedFeaturesFilterText].
@@ -300,10 +303,38 @@ internal class AddAssociationFromSourceViewModel(
      */
     fun selectFeatureCandidate(candidate: UtilityAssociationFeatureCandidate) {
         viewModelScope.launch {
-            element.getOptionsForAssociationCandidate(candidate.feature).onSuccess {
+            element.getOptionsForAssociationCandidate(candidate.feature).onSuccess { options ->
+                val (fromEndPoint, toEndPoint) = when (filter.filterType) {
+                    is UtilityAssociationsFilterType.Connectivity -> {
+                        AssociationEndpoint(
+                            featureForm.title.value,
+                            options.formFeatureTerminalConfiguration
+                        ) to
+                            AssociationEndpoint(
+                                candidate.title,
+                                options.candidateFeatureTerminalConfiguration
+                            )
+                    }
+
+                    is UtilityAssociationsFilterType.Container,
+                    is UtilityAssociationsFilterType.Structure -> {
+                        AssociationEndpoint(name = candidate.title) to
+                            AssociationEndpoint(featureForm.title.value)
+                    }
+
+                    else -> {
+                        AssociationEndpoint(featureForm.title.value) to
+                            AssociationEndpoint(candidate.title)
+                    }
+                }
+
                 _newAssociationOptions.value = NewAssociationOptions(
                     candidate = candidate,
-                    options = it,
+                    fromElement = fromEndPoint.name,
+                    fromTerminalConfiguration = fromEndPoint.terminalConfiguration,
+                    toElement = toEndPoint.name,
+                    toTerminalConfiguration = toEndPoint.terminalConfiguration,
+                    isFractionAlongEdgeValid = options.isFractionAlongEdgeValid,
                     type = filter.filterType
                 )
             }
@@ -325,25 +356,25 @@ internal class AddAssociationFromSourceViewModel(
     suspend fun addAssociation(
         isContainmentVisible: Boolean,
         fractionAlongEdge: Float? = null,
-        fromTerminalId : Int? = null,
-        toTerminalId : Int? = null,
-    ) : Result<UtilityAssociationResult> = runCatching {
+        fromTerminalId: Int? = null,
+        toTerminalId: Int? = null,
+    ): Result<UtilityAssociationResult> = runCatching {
         val feature = newAssociationOptions?.candidate?.feature
         require(feature != null) {
             "No feature candidate selected"
         }
         val fromTerminal = fromTerminalId?.let { id ->
-            newAssociationOptions?.options?.formFeatureTerminalConfiguration.getTerminalById(id)
+            newAssociationOptions?.fromTerminalConfiguration.getTerminalById(id)
         }
         val toTerminal = toTerminalId?.let { id ->
-            newAssociationOptions?.options?.candidateFeatureTerminalConfiguration.getTerminalById(id)
+            newAssociationOptions?.toTerminalConfiguration.getTerminalById(id)
         }
         // First check if we can add an association to the feature with the provided filter
         val canAddAssociation = element.canAddAssociation(
             feature,
             filter
         ).getOrThrow()
-        if (canAddAssociation.not())  {
+        if (canAddAssociation.not()) {
             throw IllegalStateException("Cannot add an association to the provided feature")
         }
         // Capture the result of adding the association based on the filter type
@@ -486,21 +517,48 @@ internal class AddAssociationFromSourceViewModel(
  * Holds the options for creating a new association based on a selected candidate feature.
  *
  * @param candidate The selected [UtilityAssociationFeatureCandidate].
- * @param options The [UtilityAssociationFeatureOptions] for the candidate feature.
+ * @param fromElement The name of the "from" element in the association.
+ * @param fromTerminalConfiguration The [UtilityTerminalConfiguration] for the "from" element,
+ * if applicable.
+ * @param toElement The name of the "to" element in the association.
+ * @param toTerminalConfiguration The [UtilityTerminalConfiguration] for the "to" element,
+ * if applicable.
+ * @param isFractionAlongEdgeValid Whether the fraction along edge is valid for connectivity
+ * associations.
  * @param type The [UtilityAssociationsFilterType] defining the type of association to create
  */
 internal data class NewAssociationOptions(
     val candidate: UtilityAssociationFeatureCandidate,
-    val options: UtilityAssociationFeatureOptions,
+    val fromElement: String,
+    val fromTerminalConfiguration: UtilityTerminalConfiguration?,
+    val toElement: String,
+    val toTerminalConfiguration: UtilityTerminalConfiguration?,
+    val isFractionAlongEdgeValid: Boolean,
     val type: UtilityAssociationsFilterType
 )
 
+/**
+ * Represents the UI state for loading feature candidates, including loading status,
+ * any errors encountered, and the list of loaded candidates.
+ */
 internal data class FeatureCandidatesUiState(
     val isLoading: Boolean = false,
     val error: Throwable? = null,
     val candidates: List<UtilityAssociationFeatureCandidate> = emptyList()
 )
 
+/**
+ * Returns the [UtilityTerminal] with the specified [id] from the [UtilityTerminalConfiguration].
+ */
 internal fun UtilityTerminalConfiguration?.getTerminalById(id: Int): UtilityTerminal? {
     return this?.terminals?.find { it.terminalId == id }
 }
+
+/**
+ * Holds information about an association endpoint, including its name and optional terminal
+ * configuration.
+ */
+private data class AssociationEndpoint(
+    val name: String,
+    val terminalConfiguration: UtilityTerminalConfiguration? = null
+)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/CreateAssociationScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/CreateAssociationScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -80,7 +81,7 @@ internal fun CreateAssociationScreen(
         mutableStateOf(false)
     }
     var fractionAlongEdge by rememberSaveable(associationOptions) {
-        val initialValue = if (associationOptions?.options?.isFractionAlongEdgeValid == true) {
+        val initialValue = if (associationOptions?.isFractionAlongEdgeValid == true) {
             0f
         } else {
             null
@@ -133,36 +134,8 @@ internal fun CreateAssociationScreen(
                 Text(text = stringResource(R.string.add))
             }
         }
-        associationOptions?.let {
-            val candidate = it.candidate
-            val options = it.options
-            val filterType = it.type
-            val isContainerOrStructure = filterType is UtilityAssociationsFilterType.Container ||
-                filterType is UtilityAssociationsFilterType.Structure
-            val (fromElement, fromTerminalConfig) = remember(associationOptions) {
-                if (isContainerOrStructure) {
-                    candidate.title to
-                        options.candidateFeatureTerminalConfiguration
-                } else {
-                    viewModel.featureForm.title.value to
-                        options.formFeatureTerminalConfiguration
-                }
-            }.also { pair ->
-                selectedFromTerminalId = pair.second?.terminals?.firstOrNull()?.terminalId
-            }
-            val (toElement, toTerminalConfig) = remember(associationOptions) {
-                if (isContainerOrStructure) {
-                    viewModel.featureForm.title.value to
-                        options.formFeatureTerminalConfiguration
-
-                } else {
-                    candidate.title to
-                        options.candidateFeatureTerminalConfiguration
-                }
-            }.also { pair ->
-                selectedToTerminalId = pair.second?.terminals?.firstOrNull()?.terminalId
-            }
-
+        associationOptions?.let { options ->
+            val filterType = options.type
             LazyColumn {
                 item {
                     // First show the Association Type
@@ -207,13 +180,13 @@ internal fun CreateAssociationScreen(
                     ) {
                         PropertyRow(
                             title = stringResource(R.string.from_element),
-                            value = fromElement,
+                            value = options.fromElement,
                             modifier = Modifier
                                 .padding(20.dp)
                                 .fillMaxWidth()
                         )
                         // if terminal config is available show terminal selection
-                        fromTerminalConfig?.let { terminalConfig ->
+                        options.fromTerminalConfiguration?.let { terminalConfig ->
                             UtilityTerminalControl(
                                 selected = selectedFromTerminalId?.let { id ->
                                     terminalConfig.getTerminalById(id)
@@ -239,13 +212,13 @@ internal fun CreateAssociationScreen(
                     ) {
                         PropertyRow(
                             title = stringResource(R.string.to_element),
-                            value = toElement,
+                            value = options.toElement,
                             modifier = Modifier
                                 .padding(20.dp)
                                 .fillMaxWidth()
                         )
                         // if terminal config is available show terminal selection
-                        toTerminalConfig?.let { terminalConfig ->
+                        options.toTerminalConfiguration?.let { terminalConfig ->
                             UtilityTerminalControl(
                                 selected = selectedToTerminalId?.let { id ->
                                     terminalConfig.getTerminalById(id)
@@ -289,5 +262,18 @@ internal fun CreateAssociationScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
+    }
+    LaunchedEffect(associationOptions) {
+        // set initial terminal selections if available
+        associationOptions?.let { options ->
+            if (options.fromTerminalConfiguration != null) {
+                selectedFromTerminalId =
+                    options.fromTerminalConfiguration.terminals.firstOrNull()?.terminalId
+            }
+            if (options.toTerminalConfiguration != null) {
+                selectedToTerminalId =
+                    options.toTerminalConfiguration.terminals.firstOrNull()?.terminalId
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#1484](https://devtopia.esri.com/runtime/apollo/issues/1484)

<!-- link to design, if applicable -->

### Description:

Only connectivity association should allow terminal selection and this PR updates how the association options are generated to solve this across the board.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1024/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  