### PR TITLE
Refactor Fraction along edge -> Percent along

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/UtilityAssociationsFormElementAddTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/UtilityAssociationsFormElementAddTests.kt
@@ -337,10 +337,10 @@ class UtilityAssociationsFormElementAddTests {
         val terminalControl = composeTestRule.onNode(hasTextExactly("Terminal", "High"))
         terminalControl.assertIsDisplayed()
         // Verify the fraction control is displayed
-        composeTestRule.onNodeWithText("Fraction Along Edge").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Percent Along").assertIsDisplayed()
         composeTestRule.onNodeWithText("0 %").assertIsDisplayed()
         val fractionControl =
-            composeTestRule.onNodeWithContentDescription("fraction along edge slider")
+            composeTestRule.onNodeWithContentDescription("percent along slider")
         fractionControl.assertIsDisplayed()
         // Verify the slider has the correct initial state
         fractionControl.assertRangeInfoEquals(ProgressBarRangeInfo(0.0f, 0.0f..1.0f, 0))

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -334,7 +334,7 @@ internal class AddAssociationFromSourceViewModel(
                     fromTerminalConfiguration = fromEndPoint.terminalConfiguration,
                     toElement = toEndPoint.name,
                     toTerminalConfiguration = toEndPoint.terminalConfiguration,
-                    isFractionAlongEdgeValid = options.isFractionAlongEdgeValid,
+                    isPercentAlongValid = options.isFractionAlongEdgeValid,
                     type = filter.filterType
                 )
             }
@@ -347,7 +347,7 @@ internal class AddAssociationFromSourceViewModel(
      *
      * @param isContainmentVisible Whether the containment is visible. This is only applicable for
      * [UtilityAssociationsFilterType.Container] and [UtilityAssociationsFilterType.Content] types.
-     * @param fractionAlongEdge The fraction along the edge for connectivity associations.
+     * @param percentAlong The percent along for connectivity associations.
      * @param fromTerminalId The terminal ID on the feature being edited.
      * @param toTerminalId The terminal ID on the candidate feature.
      * @return A [Result] containing the [UtilityAssociationResult] if the association was
@@ -355,7 +355,7 @@ internal class AddAssociationFromSourceViewModel(
      */
     suspend fun addAssociation(
         isContainmentVisible: Boolean,
-        fractionAlongEdge: Float? = null,
+        percentAlong: Float? = null,
         fromTerminalId: Int? = null,
         toTerminalId: Int? = null,
     ): Result<UtilityAssociationResult> = runCatching {
@@ -408,11 +408,11 @@ internal class AddAssociationFromSourceViewModel(
                     // junction (with the terminal) to edge
                     fromTerminal != null -> {
                         // these two methods can be defaulted at the sdk level
-                        if (fractionAlongEdge != null) {
+                        if (percentAlong != null) {
                             element.addAssociation(
                                 feature = feature,
                                 filter = filter,
-                                fractionAlongEdge = fractionAlongEdge.toDouble(),
+                                fractionAlongEdge = percentAlong.toDouble(),
                                 terminal = fromTerminal
                             )
                         } else {
@@ -428,11 +428,11 @@ internal class AddAssociationFromSourceViewModel(
                     // edge to junction (with the terminal)
                     toTerminal != null -> {
                         // these two methods can be defaulted at the sdk level
-                        if (fractionAlongEdge != null) {
+                        if (percentAlong != null) {
                             element.addAssociation(
                                 feature = feature,
                                 filter = filter,
-                                fractionAlongEdge = fractionAlongEdge.toDouble(),
+                                fractionAlongEdge = percentAlong.toDouble(),
                                 terminal = toTerminal
                             )
                         } else {
@@ -445,13 +445,13 @@ internal class AddAssociationFromSourceViewModel(
                         }
                     }
 
-                    // no terminals, but fraction along edge provided
-                    fractionAlongEdge != null -> {
+                    // no terminals, but percent along provided
+                    percentAlong != null -> {
                         // edge to edge
                         element.addAssociation(
                             feature = feature,
                             filter = filter,
-                            fractionAlongEdge = fractionAlongEdge.toDouble()
+                            fractionAlongEdge = percentAlong.toDouble()
                         )
                     }
 
@@ -523,7 +523,7 @@ internal class AddAssociationFromSourceViewModel(
  * @param toElement The name of the "to" element in the association.
  * @param toTerminalConfiguration The [UtilityTerminalConfiguration] for the "to" element,
  * if applicable.
- * @param isFractionAlongEdgeValid Whether the fraction along edge is valid for connectivity
+ * @param isPercentAlongValid Whether the percent along is valid for connectivity
  * associations.
  * @param type The [UtilityAssociationsFilterType] defining the type of association to create
  */
@@ -533,7 +533,7 @@ internal data class NewAssociationOptions(
     val fromTerminalConfiguration: UtilityTerminalConfiguration?,
     val toElement: String,
     val toTerminalConfiguration: UtilityTerminalConfiguration?,
-    val isFractionAlongEdgeValid: Boolean,
+    val isPercentAlongValid: Boolean,
     val type: UtilityAssociationsFilterType
 )
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -347,7 +347,8 @@ internal class AddAssociationFromSourceViewModel(
      *
      * @param isContainmentVisible Whether the containment is visible. This is only applicable for
      * [UtilityAssociationsFilterType.Container] and [UtilityAssociationsFilterType.Content] types.
-     * @param percentAlong The percent along for connectivity associations.
+     * @param percentAlong the value expected is a fraction between 0 and 1 rather than a percentage
+     *                      for connectivity associations.
      * @param fromTerminalId The terminal ID on the feature being edited.
      * @param toTerminalId The terminal ID on the candidate feature.
      * @return A [Result] containing the [UtilityAssociationResult] if the association was

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/PercentAlongControl.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/PercentAlongControl.kt
@@ -41,20 +41,20 @@ import com.arcgismaps.utilitynetworks.UtilityAssociation
 import com.arcgismaps.utilitynetworks.UtilityElement
 
 /**
- * A composable that represents a fraction along edge control of a [UtilityAssociation]. This can
+ * A composable that represents a percent along control of a [UtilityAssociation]. This can
  * represent the [UtilityAssociation.fractionAlongEdge] property if one of the element is a non-spatial
  * edge or the [UtilityElement.fractionAlongEdge] when the element represents a spatial edge.
  *
  * This control displays a slider that allows the user to select a value between 0 and 1, which is then
  * multiplied by 100 to display the percentage value.
  *
- * @param fraction The current value of the fraction along edge control.
+ * @param fraction The current value of the percent along control.
  * @param enabled A boolean indicating whether the control is enabled or not.
  * @param onValueChanged A callback that is called when the value of the control changes.
  * @param modifier The [Modifier] to apply to this layout.
  */
 @Composable
-internal fun FractionAlongEdgeControl(
+internal fun PercentAlongControl(
     fraction: Float,
     enabled: Boolean,
     onValueChanged: (Float) -> Unit,
@@ -75,7 +75,7 @@ internal fun FractionAlongEdgeControl(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             PropertyRow(
-                title = stringResource(R.string.fraction_along_edge),
+                title = stringResource(R.string.percent_along),
                 value = stringResource(R.string.percent_along_edge, percent),
                 modifier = Modifier.fillMaxWidth()
             )
@@ -88,7 +88,7 @@ internal fun FractionAlongEdgeControl(
                 modifier = Modifier
                     .fillMaxWidth()
                     .semantics {
-                        this.contentDescription = "fraction along edge slider"
+                        this.contentDescription = "percent along slider"
                     },
                 onValueChangeFinished = {
                     onValueChanged(value)
@@ -100,8 +100,8 @@ internal fun FractionAlongEdgeControl(
 
 @Preview
 @Composable
-private fun FractionAlongEdgeControlPreview() {
-    FractionAlongEdgeControl(
+private fun PercentAlongControlPreview() {
+    PercentAlongControl(
         fraction = 0.5f,
         onValueChanged = {},
         enabled = true,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationDetails.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationDetails.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.utilitynetworks.UtilityAssociationResult
@@ -170,7 +169,7 @@ internal fun UtilityAssociationDetails(
             }
         }
         associationResult.getFractionAlongEdge()?.let { fraction ->
-            FractionAlongEdgeControl(
+            PercentAlongControl(
                 fraction = associationResult.getFractionAlongEdge()!!.toFloat(),
                 enabled = false,
                 onValueChanged = {},
@@ -261,9 +260,9 @@ internal fun RemoveAssociationConfirmationDialog(
 }
 
 /**
- * Extension function that returns the fraction along edge of the association result, if applicable.
+ * Extension function that returns the percent along of the association result, if applicable.
  *
- * @return The fraction along edge of the association result, or null if not applicable.
+ * @return The percent along of the association result, or null if not applicable.
  */
 internal fun UtilityAssociationResult.getFractionAlongEdge(): Double? {
     return when (association.associationType) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
@@ -141,7 +141,7 @@ internal fun UtilityAssociationGroupResult(
  *
  * - If the association is of type JunctionEdgeObjectConnectivityMidspan,
  * JunctionEdgeObjectConnectivityFromSide, JunctionEdgeObjectConnectivityToSide
- * then fractionAlongEdge and the terminal (if present) is displayed.
+ * then percentAlong and the terminal (if present) is displayed.
  *
  * - For a Connectivity association, the terminal (if present) is displayed.
  *

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/CreateAssociationScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/CreateAssociationScreen.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.AddAssociationFromSourceViewModel
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.ContentVisibleControl
-import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.FractionAlongEdgeControl
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.PercentAlongControl
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.PropertyRow
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.UtilityTerminalControl
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.getTerminalById
@@ -80,8 +80,8 @@ internal fun CreateAssociationScreen(
     var isContainmentVisible by rememberSaveable(associationOptions) {
         mutableStateOf(false)
     }
-    var fractionAlongEdge by rememberSaveable(associationOptions) {
-        val initialValue = if (associationOptions?.isFractionAlongEdgeValid == true) {
+    var percentAlong by rememberSaveable(associationOptions) {
+        val initialValue = if (associationOptions?.isPercentAlongValid == true) {
             0f
         } else {
             null
@@ -110,7 +110,7 @@ internal fun CreateAssociationScreen(
                             isContainmentVisible = isContainmentVisible,
                             fromTerminalId = selectedFromTerminalId,
                             toTerminalId = selectedToTerminalId,
-                            fractionAlongEdge = fractionAlongEdge
+                            percentAlong = percentAlong
                         ).onSuccess {
                             // switch to the main thread to invoke the navigation callback
                             withContext(Dispatchers.Main) {
@@ -244,15 +244,15 @@ internal fun CreateAssociationScreen(
                     }
                 }
 
-                // If isFractionAlongEdgeValid show fraction along edge control
-                if (options.isFractionAlongEdgeValid) {
+                // If isPercentAlongValid show percent along control
+                if (options.isPercentAlongValid) {
                     item {
                         Card(modifier = Modifier.padding(24.dp)) {
-                            FractionAlongEdgeControl(
-                                fraction = fractionAlongEdge ?: 0f,
+                            PercentAlongControl(
+                                fraction = percentAlong ?: 0f,
                                 enabled = true,
                                 onValueChanged = { fraction ->
-                                    fractionAlongEdge = fraction
+                                    percentAlong = fraction
                                 }
                             )
                         }

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -162,7 +162,7 @@
     <string name="terminal">Terminal</string>
     <string name="terminal_with_value">Terminal : %1$s</string>
     <string name="content_visible">Content Visible</string>
-    <string name="fraction_along_edge">Fraction Along Edge</string>
+    <string name="percent_along">Percent Along</string>
     <string name="from_element">From Element</string>
     <string name="to_element">To Element</string>
     <string name="association_type">Association Type</string>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/apollo/issues/1497

<!-- link to design, if applicable -->

### Description:

Refactor `FractionAlongEdge` to `PercentAlong`

### Summary of changes:

- Refactor `FractionAlongEdge` usage in UI and internal code to `PercentAlong`
- Update test

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1027/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  