### PR TITLE
`FeatureForm` : Use proper formatting and casting for a fractionAlongEdge

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -404,7 +404,7 @@ internal class AddAssociationFromSourceViewModel(
      */
     suspend fun addAssociation(
         isContainmentVisible: Boolean,
-        percentAlong: Float? = null,
+        percentAlong: Double? = null,
         fromTerminalId: Int? = null,
         toTerminalId: Int? = null,
     ): Result<UtilityAssociationResult> = runCatching {
@@ -461,7 +461,7 @@ internal class AddAssociationFromSourceViewModel(
                             element.addAssociation(
                                 feature = feature,
                                 filter = filter,
-                                fractionAlongEdge = percentAlong.toDouble(),
+                                fractionAlongEdge = percentAlong,
                                 terminal = fromTerminal
                             )
                         } else {
@@ -481,7 +481,7 @@ internal class AddAssociationFromSourceViewModel(
                             element.addAssociation(
                                 feature = feature,
                                 filter = filter,
-                                fractionAlongEdge = percentAlong.toDouble(),
+                                fractionAlongEdge = percentAlong,
                                 terminal = toTerminal
                             )
                         } else {
@@ -500,7 +500,7 @@ internal class AddAssociationFromSourceViewModel(
                         element.addAssociation(
                             feature = feature,
                             filter = filter,
-                            fractionAlongEdge = percentAlong.toDouble()
+                            fractionAlongEdge = percentAlong
                         )
                     }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/PercentAlongControl.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/PercentAlongControl.kt
@@ -39,8 +39,6 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.utilitynetworks.UtilityAssociation
 import com.arcgismaps.utilitynetworks.UtilityElement
-import java.math.BigDecimal
-import java.math.RoundingMode
 
 /**
  * A composable that represents a percent along control of a [UtilityAssociation]. This can
@@ -84,8 +82,7 @@ internal fun PercentAlongControl(
             Slider(
                 value = value.toFloat(),
                 onValueChange = {
-                    val decimal = BigDecimal(it.toString()).setScale(2, RoundingMode.DOWN)
-                    value = decimal.toDouble()
+                    value = (it * 100).toInt() / 100.0
                 },
                 enabled = enabled,
                 modifier = Modifier

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/PercentAlongControl.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/PercentAlongControl.kt
@@ -26,7 +26,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -39,6 +39,8 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.utilitynetworks.UtilityAssociation
 import com.arcgismaps.utilitynetworks.UtilityElement
+import java.math.BigDecimal
+import java.math.RoundingMode
 
 /**
  * A composable that represents a percent along control of a [UtilityAssociation]. This can
@@ -48,20 +50,20 @@ import com.arcgismaps.utilitynetworks.UtilityElement
  * This control displays a slider that allows the user to select a value between 0 and 1, which is then
  * multiplied by 100 to display the percentage value.
  *
- * @param fraction The current value of the percent along control.
+ * @param initialFraction The initial value of the percent along control.
  * @param enabled A boolean indicating whether the control is enabled or not.
  * @param onValueChanged A callback that is called when the value of the control changes.
  * @param modifier The [Modifier] to apply to this layout.
  */
 @Composable
 internal fun PercentAlongControl(
-    fraction: Float,
+    initialFraction: Double,
     enabled: Boolean,
-    onValueChanged: (Float) -> Unit,
+    onValueChanged: (Double) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var value by remember {
-        mutableFloatStateOf(fraction)
+        mutableDoubleStateOf(initialFraction)
     }
     val percent = (value * 100).toInt()
     Card(
@@ -80,9 +82,10 @@ internal fun PercentAlongControl(
                 modifier = Modifier.fillMaxWidth()
             )
             Slider(
-                value = value,
+                value = value.toFloat(),
                 onValueChange = {
-                    value = it
+                    val decimal = BigDecimal(it.toString()).setScale(2, RoundingMode.DOWN)
+                    value = decimal.toDouble()
                 },
                 enabled = enabled,
                 modifier = Modifier
@@ -102,7 +105,7 @@ internal fun PercentAlongControl(
 @Composable
 private fun PercentAlongControlPreview() {
     PercentAlongControl(
-        fraction = 0.5f,
+        initialFraction = 0.5,
         onValueChanged = {},
         enabled = true,
         modifier = Modifier.fillMaxWidth()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationDetails.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationDetails.kt
@@ -170,7 +170,7 @@ internal fun UtilityAssociationDetails(
         }
         associationResult.getFractionAlongEdge()?.let { fraction ->
             PercentAlongControl(
-                fraction = associationResult.getFractionAlongEdge()!!.toFloat(),
+                initialFraction = associationResult.getFractionAlongEdge()!!,
                 enabled = false,
                 onValueChanged = {},
                 modifier = Modifier.padding(top = 12.dp, start = 24.dp, end = 24.dp, bottom = 24.dp)
@@ -266,9 +266,7 @@ internal fun RemoveAssociationConfirmationDialog(
  */
 internal fun UtilityAssociationResult.getFractionAlongEdge(): Double? {
     return when (association.associationType) {
-        UtilityAssociationType.JunctionEdgeObjectConnectivityFromSide,
-        UtilityAssociationType.JunctionEdgeObjectConnectivityMidspan,
-        UtilityAssociationType.JunctionEdgeObjectConnectivityToSide -> {
+        UtilityAssociationType.JunctionEdgeObjectConnectivityMidspan -> {
             association.fractionAlongEdge
         }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/CreateAssociationScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/CreateAssociationScreen.kt
@@ -82,7 +82,7 @@ internal fun CreateAssociationScreen(
     }
     var percentAlong by rememberSaveable(associationOptions) {
         val initialValue = if (associationOptions?.isPercentAlongValid == true) {
-            0f
+            0.0
         } else {
             null
         }
@@ -249,7 +249,7 @@ internal fun CreateAssociationScreen(
                     item {
                         Card(modifier = Modifier.padding(24.dp)) {
                             PercentAlongControl(
-                                fraction = percentAlong ?: 0f,
+                                initialFraction = percentAlong ?: 0.0,
                                 enabled = true,
                                 onValueChanged = { fraction ->
                                     percentAlong = fraction


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#apollo/1512](https://devtopia.esri.com/runtime/apollo/issues/1512)

<!-- link to design, if applicable -->

### Description:

This PR fixes unneeded casting and adds formatting for the `PercentAlongEdge` control.

### Summary of changes:

- Updated the `PercentAlongEdge` to use a `double` type instead of a `float` to avoid casting to other float and back unnecessarily.
- Updated the precision of this fraction value to be to 2 digits after the decimal.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1043/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  