### PR TITLE
Add logic to not show option to locate non spatial features

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
@@ -347,6 +347,7 @@ private fun AssociationItem(
                 OptionsMenu(
                     expanded = showMenu,
                     onDismissRequest = { showMenu = false },
+                    isOnLocateEnabled = associatedFeature.geometry != null,
                     onLocate = {
                         showMenu = false
                         onLocateRequest()
@@ -433,6 +434,7 @@ internal fun UtilityAssociation.getIcon(): Painter? {
 private fun OptionsMenu(
     expanded: Boolean,
     onDismissRequest: () -> Unit,
+    isOnLocateEnabled: Boolean,
     onLocate: () -> Unit,
     onMoreInfo: () -> Unit,
     onRemove: () -> Unit,
@@ -442,18 +444,20 @@ private fun OptionsMenu(
         onDismissRequest = onDismissRequest,
         shape = RoundedCornerShape(15.dp)
     ) {
-        DropdownMenuItem(
-            text = {
-                Text(text = stringResource(R.string.show_on_map))
-            },
-            onClick = onLocate,
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Outlined.LocationSearching,
-                    contentDescription = "locate feature"
-                )
-            }
-        )
+        if (isOnLocateEnabled) {
+            DropdownMenuItem(
+                text = {
+                    Text(text = stringResource(R.string.show_on_map))
+                },
+                onClick = onLocate,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.LocationSearching,
+                        contentDescription = "locate feature"
+                    )
+                }
+            )
+        }
         DropdownMenuItem(
             text = {
                 Text(text = stringResource(R.string.more_information))


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/apollo/issues/1522

<!-- link to design, if applicable -->

### Description:

Do not show Target button when we have non-spatial features

### Summary of changes:

- Add logic to not show option to locate features that don't have geometry

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/300.0.0/job/vtest/job/toolkit/2/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  