### PR TITLE
Colinanderson/lsv locationtoscreen

### DIFF
--- a/toolkit/geoview-compose/api/geoview-compose.api
+++ b/toolkit/geoview-compose/api/geoview-compose.api
@@ -113,10 +113,11 @@ public final class com/arcgismaps/toolkit/geoviewcompose/LocalSceneViewKt {
 public final class com/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy : com/arcgismaps/toolkit/geoviewcompose/GeoViewProxy {
 	public static final field $stable I
 	public fun <init> ()V
+	public final fun locationToScreen (Lcom/arcgismaps/geometry/Point;)Lcom/arcgismaps/mapping/view/LocationToScreenResult;
 	public final fun screenToBaseSurface (Lcom/arcgismaps/mapping/view/DoubleXY;)Lcom/arcgismaps/geometry/Point;
 	public final fun screenToLocation-gIAlu-s (Lcom/arcgismaps/mapping/view/DoubleXY;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun setViewpointAnimated-JXpvp54 (Lcom/arcgismaps/mapping/Viewpoint;JLcom/arcgismaps/mapping/view/AnimationCurve;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun setViewpointAnimated-JXpvp54$default (Lcom/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy;Lcom/arcgismaps/mapping/Viewpoint;JLcom/arcgismaps/mapping/view/AnimationCurve;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun setViewpointAnimated-E0qYoyE (Lcom/arcgismaps/mapping/Viewpoint;Lcom/arcgismaps/mapping/view/AnimationCurve;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun setViewpointAnimated-E0qYoyE$default (Lcom/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy;Lcom/arcgismaps/mapping/Viewpoint;Lcom/arcgismaps/mapping/view/AnimationCurve;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun setViewpointCamera (Lcom/arcgismaps/mapping/view/Camera;)V
 	public final fun setViewpointCameraAnimated-BlKvXls (Lcom/arcgismaps/mapping/view/Camera;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun setViewpointCameraAnimated-BlKvXls$default (Lcom/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy;Lcom/arcgismaps/mapping/view/Camera;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy.kt
@@ -24,6 +24,7 @@ import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.mapping.view.AnimationCurve
 import com.arcgismaps.mapping.view.Camera
 import com.arcgismaps.mapping.view.LocalSceneView
+import com.arcgismaps.mapping.view.LocationToScreenResult
 import com.arcgismaps.mapping.view.ScreenCoordinate
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -132,14 +133,14 @@ public class LocalSceneViewProxy : GeoViewProxy("LocalSceneView") {
      *
      * To call this method, assign a local scene to the local scene view and ensure that it is loaded.
      *
-     * @param screen The screen coordinate to convert to a location on the base surface. The coordinate
+     * @param screenCoordinate The screen coordinate to convert to a location on the base surface. The coordinate
      * of the top left corner of the screen is 0,0.
      *
      * @return A point on the base surface.
      * @since 300.0.0
      */
-    public fun screenToBaseSurface(screen: ScreenCoordinate): Point? =
-        localSceneView?.screenToBaseSurface(screen)
+    public fun screenToBaseSurface(screenCoordinate: ScreenCoordinate): Point? =
+        localSceneView?.screenToBaseSurface(screenCoordinate)
 
     /**
      * Asynchronously converts a screen coordinate, relative to the upper-left corner of the
@@ -166,4 +167,31 @@ public class LocalSceneViewProxy : GeoViewProxy("LocalSceneView") {
                 nullSceneViewErrorMessage
             )
         )
+
+    /**
+     * Converts a location in map coordinates to a point in screen coordinates relative to the
+     * upper-left corner of the local scene view.
+     *
+     * The screen coordinates are in device-independent pixels (DIP) relative to the upper-left corner
+     * of the scene view at position 0,0. The [LocationToScreenResult] indicates whether the result
+     * screen point is visible in the local scene view. It will not be visible if it is outside the
+     * applied clipping area, is not within the current [Viewpoint], or is blocked by the base
+     * surface or elevation layer.
+     *
+     * If the input point does not have a spatial reference, it is assumed to be in the view's spatial
+     * reference.
+     *
+     * If the input point's spatial reference is not the same as the view's, it is projected to the
+     * view's spatial reference. If the projection fails, then null is returned.
+     *
+     * To call this method, assign a local scene to the local scene view and ensure that it is loaded.
+     *
+     * @param point A location defined within the spatial reference of the local scene view.
+     *
+     * @return A location to screen result object. If an error occurs, null is returned.
+     *
+     * @since 300.0.0
+     */
+    public fun locationToScreen(point: Point): LocationToScreenResult? =
+        localSceneView?.locationToScreen(point)
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/red-october/issues/2939 https://devtopia.esri.com/runtime/kotlin/issues/6879

<!-- link to design, if applicable -->

### Description:

Exposes `locationToScreen` on `LocalSceneViewProxy`

### Summary of changes:

- add `locationToScreen` to the proxy
- also change param name on `screenToBaseSurface` from `screen` to `screenCoordinate` to be consistent with `screenToLocation`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/Release/job/300.0.0/job/vtest/job/toolkit/11/console
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  