### PR TITLE
Reorder arguments to match API change

### DIFF
--- a/toolkit/geoview-compose/api/geoview-compose.api
+++ b/toolkit/geoview-compose/api/geoview-compose.api
@@ -115,8 +115,8 @@ public final class com/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy : c
 	public fun <init> ()V
 	public final fun screenToBaseSurface (Lcom/arcgismaps/mapping/view/DoubleXY;)Lcom/arcgismaps/geometry/Point;
 	public final fun screenToLocation-gIAlu-s (Lcom/arcgismaps/mapping/view/DoubleXY;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun setViewpointAnimated-JXpvp54 (Lcom/arcgismaps/mapping/Viewpoint;JLcom/arcgismaps/mapping/view/AnimationCurve;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun setViewpointAnimated-JXpvp54$default (Lcom/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy;Lcom/arcgismaps/mapping/Viewpoint;JLcom/arcgismaps/mapping/view/AnimationCurve;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun setViewpointAnimated-E0qYoyE (Lcom/arcgismaps/mapping/Viewpoint;Lcom/arcgismaps/mapping/view/AnimationCurve;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun setViewpointAnimated-E0qYoyE$default (Lcom/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy;Lcom/arcgismaps/mapping/Viewpoint;Lcom/arcgismaps/mapping/view/AnimationCurve;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun setViewpointCamera (Lcom/arcgismaps/mapping/view/Camera;)V
 	public final fun setViewpointCameraAnimated-BlKvXls (Lcom/arcgismaps/mapping/view/Camera;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun setViewpointCameraAnimated-BlKvXls$default (Lcom/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy;Lcom/arcgismaps/mapping/view/Camera;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/LocalSceneViewProxy.kt
@@ -87,8 +87,8 @@ public class LocalSceneViewProxy : GeoViewProxy("LocalSceneView") {
     ): Result<Boolean> {
         return localSceneView?.setViewpointAnimated(
             viewpoint,
-            duration.toDouble(DurationUnit.SECONDS).toFloat(),
-            animationCurve
+            animationCurve,
+            duration.toDouble(DurationUnit.SECONDS).toFloat()
         ) ?: Result.failure(IllegalStateException(nullGeoViewErrorMessage))
     }
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/6887

<!-- link to design, if applicable -->

### Description:

Reorder arguments to match api change. Can't run vTest at the moment since the api change has not yet made it into a daily build.

### Summary of changes:

- swap duration and animation curve to match the api ordering

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  