### PR TITLE
`FeatureForm` : Fix failing tests

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldNumericTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldNumericTests.kt
@@ -16,16 +16,18 @@
 
 package com.arcgismaps.toolkit.featureforms
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.unit.dp
 import com.arcgismaps.data.RangeDomain
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.internal.components.base.formattedValueAsStateFlow
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
@@ -33,7 +35,6 @@ import com.arcgismaps.toolkit.featureforms.internal.components.text.FormTextFiel
 import com.arcgismaps.toolkit.featureforms.internal.components.text.FormTextFieldState
 import com.arcgismaps.toolkit.featureforms.internal.components.text.TextFieldProperties
 import junit.framework.TestCase
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -103,7 +104,7 @@ class FormTextFieldNumericTests : FeatureFormTestRunner(
                     },
                 )
             }
-            FormTextField(state = state)
+            FormTextField(state = state, modifier = Modifier.padding(top = 25.dp))
         }
         val outlinedTextField =
             composeTestRule.onNodeWithContentDescription(outlinedTextFieldSemanticLabel)
@@ -153,7 +154,7 @@ class FormTextFieldNumericTests : FeatureFormTestRunner(
                     },
                 )
             }
-            FormTextField(state = state)
+            FormTextField(state = state, modifier = Modifier.padding(top = 25.dp))
         }
         val outlinedTextField =
             composeTestRule.onNodeWithContentDescription(outlinedTextFieldSemanticLabel)

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldRangeNumericTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldRangeNumericTests.kt
@@ -16,16 +16,18 @@
 
 package com.arcgismaps.toolkit.featureforms
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.unit.dp
 import com.arcgismaps.data.RangeDomain
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.internal.components.base.formattedValueAsStateFlow
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
@@ -95,7 +97,7 @@ class FormTextFieldRangeNumericTests : FeatureFormTestRunner(
                     },
                 )
             }
-            FormTextField(state = state)
+            FormTextField(state = state, modifier = Modifier.padding(top = 25.dp))
         }
         val outlinedTextField =
             composeTestRule.onNodeWithContentDescription(outlinedTextFieldSemanticLabel)

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/FormTextFieldTests.kt
@@ -18,8 +18,10 @@
 
 package com.arcgismaps.toolkit.featureforms
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
@@ -31,9 +33,9 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.unit.dp
 import com.arcgismaps.data.RangeDomain
 import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.mapping.featureforms.TextAreaFormInput
 import com.arcgismaps.mapping.featureforms.TextBoxFormInput
 import com.arcgismaps.toolkit.featureforms.internal.components.base.formattedValueAsStateFlow
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
@@ -105,7 +107,8 @@ class FormTextFieldTests : FeatureFormTestRunner(
                 )
             }
             FormTextField(
-                state = state
+                state = state,
+                modifier = Modifier.padding(top = 25.dp)
             )
         }
         featureForm.evaluateExpressions()


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#kotlin/7044](https://devtopia.esri.com/runtime/kotlin/issues/7044)

<!-- link to design, if applicable -->

### Description:

This PR fixes all the failing tests in the `FeatureForm` module.

### Summary of changes:

- After the recent Pixel 10 device swap some of the tests started to fail with a "The component is not displayed" error. For example, in this [daily test run](https://runtime-kotlin.esri.com/job/daily/job/toolkit/484/Test_20Report_20-_20Integration/).
- Since the Pixel 10 devices have a taller aspect ratio, the cause turned out to be a form of clipping outside the safe area. Hence the fix is to add some padding to the `FeatureForm` composable to ensure all parts of the component tree is displayed.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: **https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/1076/**
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  