### PR TITLE
Fail gracefully when there's no custom-tab support for IAP SignIn and SignOut

### DIFF
--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
@@ -30,6 +30,7 @@ import androidx.test.uiautomator.UiDevice
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallenge
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeResponse
+import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeType
 import com.arcgismaps.httpcore.authentication.OAuthUserConfiguration
 import com.arcgismaps.httpcore.authentication.OAuthUserCredential
 import com.google.common.truth.Truth.assertThat
@@ -92,7 +93,7 @@ class BrowserUserLauncherTests {
      * @since 200.8.0
      */
     @Test
-    fun successfulSignIn() = runTest {
+    fun successfulOAuthSignIn() = runTest {
         // configure the ArcGISHttpClient to intercept token requests and return a fake token response
         // this is necessary when we are faking a successful sign-in without entering credentials,
         // as we are not given a valid token from the OAuth server and RTC won't be able to verify it.
@@ -133,6 +134,36 @@ class BrowserUserLauncherTests {
             setupOAuthTokenRequestInterceptor()
         }
         val response = testOAuthChallengeWithStateRestoration(
+            waitForBrowser = false
+        ) {
+            // No user interaction, as the Custom Tabs cannot be launched
+        }.await().getOrThrow()
+
+        assertThat(response).isInstanceOf(
+            ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError::class.java
+        )
+        assertThat((response as ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError).error).isInstanceOf(
+            CustomTabsNotFoundException::class.java
+        )
+    }
+
+    /**
+     * Given a device with a default browser that does not support Custom Tabs,
+     * When the Authenticator receives an [ArcGISAuthenticationChallenge] for IAP sign in,
+     * Then the challenge will fail with a [CustomTabsNotFoundException].
+     *
+     * @since 200.8.0
+     */
+    @Test
+    fun iapSIgnInNoCustomTabs() = runTest {
+        // Mock the top-level extension so it returns null and simulates no browsers that support Custom Tabs
+        mockkStatic("com.arcgismaps.toolkit.authentication.ExtensionsKt")
+        every { any<android.content.Context>().canDefaultBrowserLaunchCustomTabs() } returns false
+
+        val response = testOAuthChallengeWithStateRestoration(
+            arcGISAuthenticationChallenge = makeMockArcGISAuthenticationChallenge(
+                challengeType = ArcGISAuthenticationChallengeType.Iap
+            ),
             waitForBrowser = false
         ) {
             // No user interaction, as the Custom Tabs cannot be launched
@@ -191,6 +222,7 @@ class BrowserUserLauncherTests {
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun TestScope.testOAuthChallengeWithStateRestoration(
         waitForBrowser: Boolean = true,
+        arcGISAuthenticationChallenge: ArcGISAuthenticationChallenge = makeMockArcGISAuthenticationChallenge(),
         userInputOnDialog: UiDevice.() -> Unit,
     ): Deferred<Result<ArcGISAuthenticationChallengeResponse>> {
         // start the activity (which contains the Authenticator)

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
@@ -155,7 +155,7 @@ class BrowserUserLauncherTests {
      * @since 300.0.0
      */
     @Test
-    fun iapSIgnInNoCustomTabs() = runTest {
+    fun iapSignInNoCustomTabs() = runTest {
         // Mock the top-level extension so it returns null and simulates no browsers that support Custom Tabs
         mockkStatic("com.arcgismaps.toolkit.authentication.ExtensionsKt")
         every { any<android.content.Context>().canDefaultBrowserLaunchCustomTabs() } returns false

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
@@ -152,7 +152,7 @@ class BrowserUserLauncherTests {
      * When the Authenticator receives an [ArcGISAuthenticationChallenge] for IAP sign in,
      * Then the challenge will fail with a [CustomTabsNotFoundException].
      *
-     * @since 200.8.0
+     * @since 300.0.0
      */
     @Test
     fun iapSIgnInNoCustomTabs() = runTest {

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/IapAuthenticatorTest.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/IapAuthenticatorTest.kt
@@ -20,6 +20,10 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 
@@ -32,6 +36,12 @@ class IapAuthenticatorTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @After
+    fun tearDown() {
+        // Unmock all mocked static methods after each test
+        unmockkAll()
+    }
 
     /**
      * Given an [IapSignInAuthenticator] composable,
@@ -54,7 +64,7 @@ class IapAuthenticatorTest {
             IapSignInAuthenticator(
                 authorizeUrl = "https://www.arcgis.com/index.html",
                 onComplete = { receivedRedirectUri = it },
-                onCancel = { cancellationHandled= true }
+                onCancel = { cancellationHandled = true }
             )
         }
 
@@ -67,6 +77,41 @@ class IapAuthenticatorTest {
         // Verify that the redirect URI was received
         assertThat(cancellationHandled).isFalse()
         assertThat(receivedRedirectUri).contains(expectedRedirectUri)
+    }
+
+    /**
+     * Given an [IapSignInAuthenticator] composable,
+     * When it is launched on a device with no Custom Tab support,
+     * Then it should not launch a Custom Tab
+     * And it should handle the absence of Custom Tabs by invoking the cancellation callback with an exception.
+     *
+     * @since 200.8.0
+     */
+    @Test
+    fun verifyIapAuthenticatorCallsOnCancelWhenNoCustomTabIsAvailable() {
+        // Mock the top-level extension so it returns null (no Custom Tab available)
+        mockkStatic("com.arcgismaps.toolkit.authentication.ExtensionsKt")
+        every { any<android.content.Context>().canDefaultBrowserLaunchCustomTabs() } returns false
+
+        var receivedRedirectUri: String? = null
+        var cancellationException: Exception? = null
+        val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        composeTestRule.setContent {
+            IapSignInAuthenticator(
+                authorizeUrl = "https://www.arcgis.com/index.html",
+                onComplete = { receivedRedirectUri = it },
+                onCancel = { cancellationException = it }
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        // Verify that the Custom Tab is not launched
+        val isCustomTabLaunched = uiDevice.waitForWindowUpdate("com.android.chrome", 2000)
+        // Since no Custom Tab is available, it should not be launched
+        assertThat(isCustomTabLaunched).isFalse()
+        // Verify that cancellation was handled with an exception
+        assertThat(cancellationException).isInstanceOf(CustomTabsNotFoundException::class.java)
+        assertThat(receivedRedirectUri).isNull()
     }
 
 
@@ -82,12 +127,16 @@ class IapAuthenticatorTest {
     fun verifyIapAuthenticatorHandlesCancellation() {
         var onCompleteCalled = false
         var cancellationHandled = false
+        var signOutException : Exception? = null
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         composeTestRule.setContent {
             IapSignInAuthenticator(
                 authorizeUrl = "https://www.arcgis.com/index.html",
                 onComplete = { onCompleteCalled = true },
-                onCancel = { cancellationHandled = true }
+                onCancel = {
+                    cancellationHandled = true
+                    signOutException = it
+                }
             )
         }
 
@@ -97,6 +146,7 @@ class IapAuthenticatorTest {
         composeTestRule.waitForIdle()
         // Verify that the cancellation was handled
         assertThat(cancellationHandled).isTrue()
+        assertThat(signOutException).isNull()
         assertThat(onCompleteCalled).isFalse()
     }
 
@@ -114,13 +164,17 @@ class IapAuthenticatorTest {
     fun verifyIapSignOutAuthenticatorCompletesOnBackPress() {
         var signOutCompleted = false
         var signOutCancelled = false
+        var signOutException : Exception? = null
         val expectedSignOutUrl = "https://www.arcgis.com/index.html"
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         composeTestRule.setContent {
             IapSignOutAuthenticator(
                 iapSignOutUrl = expectedSignOutUrl,
                 onCompleteSignOut = { signOutCompleted = it },
-                onCancelSignOut = { signOutCancelled = true }
+                onCancelSignOut = {
+                    signOutCancelled = true
+                    signOutException = it
+                }
             )
         }
 
@@ -132,5 +186,6 @@ class IapAuthenticatorTest {
         // Verify that the sign out was completed
         assertThat(signOutCompleted).isTrue()
         assertThat(signOutCancelled).isFalse()
+        assertThat(signOutException).isNull()
     }
 }

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/IapAuthenticatorTest.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/IapAuthenticatorTest.kt
@@ -85,7 +85,7 @@ class IapAuthenticatorTest {
      * Then it should not launch a Custom Tab
      * And it should handle the absence of Custom Tabs by invoking the cancellation callback with an exception.
      *
-     * @since 200.8.0
+     * @since 300.0.0
      */
     @Test
     fun verifyIapAuthenticatorCallsOnCancelWhenNoCustomTabIsAvailable() {

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/IapAuthenticatorTest.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/IapAuthenticatorTest.kt
@@ -127,7 +127,7 @@ class IapAuthenticatorTest {
     fun verifyIapAuthenticatorHandlesCancellation() {
         var onCompleteCalled = false
         var cancellationHandled = false
-        var signOutException : Exception? = null
+        var signOutException: Exception? = null
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         composeTestRule.setContent {
             IapSignInAuthenticator(
@@ -164,7 +164,7 @@ class IapAuthenticatorTest {
     fun verifyIapSignOutAuthenticatorCompletesOnBackPress() {
         var signOutCompleted = false
         var signOutCancelled = false
-        var signOutException : Exception? = null
+        var signOutException: Exception? = null
         val expectedSignOutUrl = "https://www.arcgis.com/index.html"
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         composeTestRule.setContent {

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthDefaultConfigurationTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthDefaultConfigurationTests.kt
@@ -28,6 +28,9 @@ import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeRespo
 import com.arcgismaps.httpcore.authentication.OAuthUserConfiguration
 import com.arcgismaps.httpcore.authentication.OAuthUserCredential
 import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -54,7 +57,10 @@ class OAuthDefaultConfigurationTests {
     fun signOutBefore() = signOut()
 
     @After
-    fun signOutAfter() = signOut()
+    fun signOutAfter() {
+        signOut()
+        unmockkAll()
+    }
 
     private fun signOut() {
         runBlocking {
@@ -90,6 +96,29 @@ class OAuthDefaultConfigurationTests {
         }.await().getOrNull()
         assert(response is ArcGISAuthenticationChallengeResponse.ContinueWithCredential)
         assert((response as ArcGISAuthenticationChallengeResponse.ContinueWithCredential).credential is OAuthUserCredential)
+    }
+
+    /**
+     * Given an [AuthenticatorState] configured with an [OAuthUserConfiguration] for ArcGIS Online,
+     * When an [ArcGISAuthenticationChallenge] is received on a device with no Custom Tabs support,
+     * Then the [ArcGISAuthenticationChallengeResponse] should be [ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError]
+     * with a [CustomTabsNotFoundException].
+     *
+     * @since 200.5.0
+     */
+    @Test
+    fun testFailedWhenNoCustomTabsSupport() = runTest {
+        // Mock the top-level extension so it returns false for Custom Tabs support
+        mockkStatic("com.arcgismaps.toolkit.authentication.ExtensionsKt")
+        every { any<android.content.Context>().canDefaultBrowserLaunchCustomTabs() } returns false
+
+        val response = testOAuthChallengeWithStateRestoration(waitForBrowser = false) {
+            // No user action needed, as the lack of Custom Tabs support should cause immediate cancellation
+        }.await().getOrThrow()
+
+        assertThat(response).isInstanceOf(ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError::class.java)
+        assertThat((response as ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError).error)
+            .isInstanceOf(CustomTabsNotFoundException::class.java)
     }
 
     /**
@@ -215,6 +244,7 @@ class OAuthDefaultConfigurationTests {
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun TestScope.testOAuthChallengeWithStateRestoration(
+        waitForBrowser: Boolean = true,
         userInputOnDialog: UiDevice.() -> Unit,
     ): Deferred<Result<ArcGISAuthenticationChallengeResponse>> {
         val authenticatorState = AuthenticatorState().apply {
@@ -254,7 +284,9 @@ class OAuthDefaultConfigurationTests {
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         // wait for the browser to be launched
-        uiDevice.awaitViewVisible("com.android.chrome")
+        if (waitForBrowser) {
+            uiDevice.awaitViewVisible("com.android.chrome")
+        }
 
         // rotate the device to ensure the Authenticator can handle configuration changes
         uiDevice.setOrientationLandscape()

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthDefaultConfigurationTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthDefaultConfigurationTests.kt
@@ -104,7 +104,7 @@ class OAuthDefaultConfigurationTests {
      * Then the [ArcGISAuthenticationChallengeResponse] should be [ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError]
      * with a [CustomTabsNotFoundException].
      *
-     * @since 200.5.0
+     * @since 300.0.0
      */
     @Test
     fun testFailedWhenNoCustomTabsSupport() = runTest {

--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthDefaultConfigurationTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/OAuthDefaultConfigurationTests.kt
@@ -107,14 +107,14 @@ class OAuthDefaultConfigurationTests {
      * @since 300.0.0
      */
     @Test
-    fun testFailedWhenNoCustomTabsSupport() = runTest {
+    fun authenticationFailsWhenNoCustomTabsSupport() = runTest {
         // Mock the top-level extension so it returns false for Custom Tabs support
         mockkStatic("com.arcgismaps.toolkit.authentication.ExtensionsKt")
         every { any<android.content.Context>().canDefaultBrowserLaunchCustomTabs() } returns false
 
         val response = testOAuthChallengeWithStateRestoration(waitForBrowser = false) {
             // No user action needed, as the lack of Custom Tabs support should cause immediate cancellation
-        }.await().getOrThrow()
+        }.await().getOrNull()
 
         assertThat(response).isInstanceOf(ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError::class.java)
         assertThat((response as ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError).error)

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticationActivity.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticationActivity.kt
@@ -231,7 +231,8 @@ public class AuthenticationActivity internal constructor() : ComponentActivity()
             val exceptionMessage = intent?.getStringExtra(KEY_INTENT_EXTRA_EXCEPTION_MESSAGE)
             return when {
                 resultCode == RESULT_CODE_SUCCESS && redirectUrl != null -> OAuthUserSignInResult.Success(redirectUrl)
-                exceptionMessage == VALUE_INTENT_EXTRA_EXCEPTION_MESSAGE_NO_CUSTOM_TAB -> OAuthUserSignInResult.Failure(CustomTabsNotFoundException())
+                exceptionMessage == VALUE_INTENT_EXTRA_EXCEPTION_MESSAGE_NO_CUSTOM_TAB ->
+                    OAuthUserSignInResult.Failure(CustomTabsNotFoundException())
                 else -> OAuthUserSignInResult.Canceled
             }
         }
@@ -247,17 +248,20 @@ public class AuthenticationActivity internal constructor() : ComponentActivity()
      *
      * @since 200.8.0
      */
-    internal class IapSignInContract : ActivityResultContract<String, String?>() {
+    internal class IapSignInContract : ActivityResultContract<String, IapSignInResult>() {
         override fun createIntent(context: Context, input: String): Intent =
             Intent(context, AuthenticationActivity::class.java).apply {
                 putExtra(KEY_INTENT_EXTRA_URL, input)
             }
 
-        override fun parseResult(resultCode: Int, intent: Intent?): String? {
-            return if (resultCode == RESULT_CODE_SUCCESS) {
-                intent?.getStringExtra(KEY_INTENT_EXTRA_RESPONSE_URI)
-            } else {
-                null
+        override fun parseResult(resultCode: Int, intent: Intent?): IapSignInResult {
+            val redirectUri = intent?.getStringExtra(KEY_INTENT_EXTRA_RESPONSE_URI)
+            val exceptionMessage = intent?.getStringExtra(KEY_INTENT_EXTRA_EXCEPTION_MESSAGE)
+            return when {
+                resultCode == RESULT_CODE_SUCCESS && !redirectUri.isNullOrEmpty() -> IapSignInResult.Success(redirectUri)
+                exceptionMessage == VALUE_INTENT_EXTRA_EXCEPTION_MESSAGE_NO_CUSTOM_TAB ->
+                    IapSignInResult.Failure(CustomTabsNotFoundException())
+                else -> IapSignInResult.Canceled
             }
         }
     }
@@ -270,18 +274,25 @@ public class AuthenticationActivity internal constructor() : ComponentActivity()
      *
      * @since 200.8.0
      */
-    internal class IapSignOutContract : ActivityResultContract<String, Boolean>() {
+    internal class IapSignOutContract : ActivityResultContract<String, IapSignOutResult>() {
         override fun createIntent(context: Context, input: String): Intent =
             Intent(context, AuthenticationActivity::class.java).apply {
                 putExtra(KEY_INTENT_EXTRA_URL, input)
                 putExtra(KEY_INTENT_EXTRA_PROMPT_TYPE, VALUE_INTENT_EXTRA_PROMPT_TYPE_SIGN_OUT)
             }
 
-        override fun parseResult(resultCode: Int, intent: Intent?): Boolean {
-            return if (resultCode == RESULT_CODE_SUCCESS)
-                intent?.getBooleanExtra(KEY_INTENT_EXTRA_IAP_SIGN_OUT_RESPONSE, false) ?: false
-            else
-                false
+        override fun parseResult(resultCode: Int, intent: Intent?): IapSignOutResult {
+            val exceptionMessage = intent?.getStringExtra(KEY_INTENT_EXTRA_EXCEPTION_MESSAGE)
+            return when {
+                resultCode == RESULT_CODE_SUCCESS -> {
+                    val signOutResponse =
+                        intent?.getBooleanExtra(KEY_INTENT_EXTRA_IAP_SIGN_OUT_RESPONSE, false) ?: false
+                    IapSignOutResult.Success(signOutResponse)
+                }
+                exceptionMessage == VALUE_INTENT_EXTRA_EXCEPTION_MESSAGE_NO_CUSTOM_TAB ->
+                    IapSignOutResult.Failure(CustomTabsNotFoundException())
+                else -> IapSignOutResult.Canceled
+            }
         }
     }
 
@@ -294,6 +305,26 @@ public class AuthenticationActivity internal constructor() : ComponentActivity()
         data class Failure(val exception: Exception) : OAuthUserSignInResult()
         data object Canceled : OAuthUserSignInResult()
     }
+
+    /**
+     * Represents the result of an IAP sign-in operation.
+     * @since 300.0.0
+     */
+    internal sealed class IapSignInResult {
+        data class Success(val redirectUri: String) : IapSignInResult()
+        data class Failure(val exception: Exception) : IapSignInResult()
+        data object Canceled : IapSignInResult()
+    }
+
+    /**
+     * Represents the result of an IAP sign-out operation.
+     * @since 300.0.0
+     */
+    internal sealed class IapSignOutResult {
+        data class Success(val result: Boolean) : IapSignOutResult()
+        data class Failure(val exception: Exception) : IapSignOutResult()
+        data object Canceled : IapSignOutResult()
+    }
 }
 
 /**
@@ -301,4 +332,5 @@ public class AuthenticationActivity internal constructor() : ComponentActivity()
  *
  * @since 300.0.0
  */
-public class CustomTabsNotFoundException internal constructor() : Exception(VALUE_INTENT_EXTRA_EXCEPTION_MESSAGE_NO_CUSTOM_TAB)
+public class CustomTabsNotFoundException internal constructor() :
+    Exception(VALUE_INTENT_EXTRA_EXCEPTION_MESSAGE_NO_CUSTOM_TAB)

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -293,8 +293,7 @@ private class AuthenticatorStateImpl(
      * @since 200.8.0
      */
     private suspend fun handleIapChallenge(requestUrl: String): ArcGISAuthenticationChallengeResponse {
-        val matchingIapConfiguration = iapConfigurations.firstOrNull { it.canBeUsedForUrl(requestUrl) }
-        return matchingIapConfiguration?.let { config ->
+        return iapConfigurations.firstOrNull { it.canBeUsedForUrl(requestUrl) }?.let { config ->
             val iapCredentialResult = config.handleIapChallenge { onPendingSignIn ->
                 _pendingIapSignIn.value = onPendingSignIn
             }

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/AuthenticatorState.kt
@@ -293,20 +293,24 @@ private class AuthenticatorStateImpl(
      * @since 200.8.0
      */
     private suspend fun handleIapChallenge(requestUrl: String): ArcGISAuthenticationChallengeResponse {
-        val matchingIapConfiguration = iapConfigurations.firstOrNull {
-            it.canBeUsedForUrl(requestUrl)
-        }
-        return matchingIapConfiguration?.let {
-            val iapCredential = it.handleIapChallenge { onPendingSignIn -> _pendingIapSignIn.value = onPendingSignIn }
-                .also {
-                    // At this point we have suspended until the IAP workflow is complete, so
-                    // we can get rid of the pending IAP sign in. Composables observing this can know
-                    // to remove the IAP prompt when this value changes.
-                    _pendingIapSignIn.value = null
-                }
-                .getOrThrow()
+        val matchingIapConfiguration = iapConfigurations.firstOrNull { it.canBeUsedForUrl(requestUrl) }
+        return matchingIapConfiguration?.let { config ->
+            val iapCredentialResult = config.handleIapChallenge { onPendingSignIn ->
+                _pendingIapSignIn.value = onPendingSignIn
+            }
 
-            ArcGISAuthenticationChallengeResponse.ContinueWithCredential(iapCredential)
+            // At this point we have suspended until the IAP workflow is complete, so
+            // we can get rid of the pending IAP sign in. Composables observing this can know
+            // to remove the IAP prompt when this value changes.
+            _pendingIapSignIn.value = null
+
+            iapCredentialResult.fold(
+                onSuccess = { ArcGISAuthenticationChallengeResponse.ContinueWithCredential(it) },
+                onFailure = {
+                    if (it is OperationCancelledException) ArcGISAuthenticationChallengeResponse.Cancel
+                    else ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError(it)
+                }
+            )
         } ?: ArcGISAuthenticationChallengeResponse.ContinueAndFail
     }
 

--- a/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/IapAuthenticator.kt
+++ b/toolkit/authentication/src/main/java/com/arcgismaps/toolkit/authentication/IapAuthenticator.kt
@@ -39,17 +39,17 @@ import androidx.compose.runtime.setValue
 @Composable
 internal fun IapSignInAuthenticator(
     authorizeUrl: String,
-    onComplete : (String) -> Unit,
-    onCancel: () -> Unit,
+    onComplete: (String) -> Unit,
+    onCancel: (Exception?) -> Unit,
 ) {
     var hasLaunched by rememberSaveable(authorizeUrl) { mutableStateOf(false) }
     val launcher = rememberLauncherForActivityResult(
         contract = AuthenticationActivity.IapSignInContract()
-    ) { redirectUrl ->
-        if (!redirectUrl.isNullOrEmpty()) {
-            onComplete(redirectUrl)
-        } else {
-            onCancel()
+    ) { signInResult ->
+        when (signInResult) {
+            is AuthenticationActivity.IapSignInResult.Success -> onComplete(signInResult.redirectUri)
+            is AuthenticationActivity.IapSignInResult.Failure -> onCancel(signInResult.exception)
+            is AuthenticationActivity.IapSignInResult.Canceled -> onCancel(null)
         }
     }
 
@@ -70,7 +70,7 @@ internal fun IapSignInAuthenticator(
  */
 @Composable
 internal fun IapSignInAuthenticator(
-    browserChallengeHandler : () -> Unit
+    browserChallengeHandler: () -> Unit
 ) {
     var hasLaunched by rememberSaveable(browserChallengeHandler) { mutableStateOf(false) }
     LaunchedEffect(browserChallengeHandler) {
@@ -94,16 +94,16 @@ internal fun IapSignInAuthenticator(
 internal fun IapSignOutAuthenticator(
     iapSignOutUrl: String,
     onCompleteSignOut: (Boolean) -> Unit,
-    onCancelSignOut: () -> Unit
+    onCancelSignOut: (Exception?) -> Unit
 ) {
     var hasLaunched by rememberSaveable(iapSignOutUrl) { mutableStateOf(false) }
     val launcher = rememberLauncherForActivityResult(
         contract = AuthenticationActivity.IapSignOutContract()
-    ) { res ->
-        if (res) {
-            onCompleteSignOut(true)
-        } else {
-            onCancelSignOut()
+    ) { signOutResult ->
+        when (signOutResult) {
+            is AuthenticationActivity.IapSignOutResult.Success -> onCompleteSignOut(signOutResult.result)
+            is AuthenticationActivity.IapSignOutResult.Failure -> onCancelSignOut(signOutResult.exception)
+            is AuthenticationActivity.IapSignOutResult.Canceled -> onCancelSignOut(null)
         }
     }
 
@@ -123,7 +123,7 @@ internal fun IapSignOutAuthenticator(
  */
 @Composable
 internal fun IapSignOutAuthenticator(
-    browserChallengeHandler : () -> Unit
+    browserChallengeHandler: () -> Unit
 ) {
     var hasLaunched by rememberSaveable(browserChallengeHandler) { mutableStateOf(false) }
     LaunchedEffect(browserChallengeHandler) {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/7019

<!-- link to design, if applicable -->
Description: 
Follow-up to PR to https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/pull/1044 for IAP.
Now, when the default browser does not support Custom Tabs, the loadable will fail to load with `CustomTabsException`. 
### Summary of changes:
- Modify Code to avoid a crash when the default browser does not support custom tabs
- Adds more test to verify IAP behavior when the browser does not support custom tabs 
- Adds additional test for OAuth to verify login fails 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/1088/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  