### PR TITLE
removes iapSignInNoCustomTabs test

### DIFF
--- a/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
+++ b/toolkit/authentication/src/androidTest/java/com/arcgismaps/toolkit/authentication/BrowserUserLauncherTests.kt
@@ -30,7 +30,6 @@ import androidx.test.uiautomator.UiDevice
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallenge
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeResponse
-import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeType
 import com.arcgismaps.httpcore.authentication.OAuthUserConfiguration
 import com.arcgismaps.httpcore.authentication.OAuthUserCredential
 import com.google.common.truth.Truth.assertThat
@@ -93,7 +92,7 @@ class BrowserUserLauncherTests {
      * @since 200.8.0
      */
     @Test
-    fun successfulOAuthSignIn() = runTest {
+    fun successfulSignIn() = runTest {
         // configure the ArcGISHttpClient to intercept token requests and return a fake token response
         // this is necessary when we are faking a successful sign-in without entering credentials,
         // as we are not given a valid token from the OAuth server and RTC won't be able to verify it.
@@ -134,36 +133,6 @@ class BrowserUserLauncherTests {
             setupOAuthTokenRequestInterceptor()
         }
         val response = testOAuthChallengeWithStateRestoration(
-            waitForBrowser = false
-        ) {
-            // No user interaction, as the Custom Tabs cannot be launched
-        }.await().getOrThrow()
-
-        assertThat(response).isInstanceOf(
-            ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError::class.java
-        )
-        assertThat((response as ArcGISAuthenticationChallengeResponse.ContinueAndFailWithError).error).isInstanceOf(
-            CustomTabsNotFoundException::class.java
-        )
-    }
-
-    /**
-     * Given a device with a default browser that does not support Custom Tabs,
-     * When the Authenticator receives an [ArcGISAuthenticationChallenge] for IAP sign in,
-     * Then the challenge will fail with a [CustomTabsNotFoundException].
-     *
-     * @since 300.0.0
-     */
-    @Test
-    fun iapSignInNoCustomTabs() = runTest {
-        // Mock the top-level extension so it returns null and simulates no browsers that support Custom Tabs
-        mockkStatic("com.arcgismaps.toolkit.authentication.ExtensionsKt")
-        every { any<android.content.Context>().canDefaultBrowserLaunchCustomTabs() } returns false
-
-        val response = testOAuthChallengeWithStateRestoration(
-            arcGISAuthenticationChallenge = makeMockArcGISAuthenticationChallenge(
-                challengeType = ArcGISAuthenticationChallengeType.Iap
-            ),
             waitForBrowser = false
         ) {
             // No user interaction, as the Custom Tabs cannot be launched
@@ -222,7 +191,6 @@ class BrowserUserLauncherTests {
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun TestScope.testOAuthChallengeWithStateRestoration(
         waitForBrowser: Boolean = true,
-        arcGISAuthenticationChallenge: ArcGISAuthenticationChallenge = makeMockArcGISAuthenticationChallenge(),
         userInputOnDialog: UiDevice.() -> Unit,
     ): Deferred<Result<ArcGISAuthenticationChallengeResponse>> {
         // start the activity (which contains the Authenticator)


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/7019

### Summary of changes:
- This test was merged with a bug as part of [this commit](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/commit/2ecd0dbb06152e6698925b38029a4fa0b7231469) but it was found that this bug was hiding an structural problem with the test code in `testOAuthChallengeWithStateRestoration ` as this class was written to explicitly test OAuth not IAP.  
- This test will be covered as part of this issue https://devtopia.esri.com/runtime/kotlin/issues/2944

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1089/Test_20Report_20-_20Integration/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  