### PR TITLE
300.0-beta Fix build warnings

### DIFF
--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -89,7 +89,6 @@ dependencies {
     ksp(libs.hilt.compiler)
     // room
     implementation(libs.room.runtime)
-    annotationProcessor(libs.room.compiler)
     implementation(libs.room.ext)
     ksp(libs.room.compiler)
     // jetpack window manager

--- a/microapps/FeatureFormsApp/app/build.gradle.kts
+++ b/microapps/FeatureFormsApp/app/build.gradle.kts
@@ -32,6 +32,9 @@ secrets {
 
 kotlin {
     jvmToolchain(17)
+    compilerOptions {
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
+    }
 }
 
 android {

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalSettings.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/data/PortalSettings.kt
@@ -136,6 +136,7 @@ class PortalSettings(
     /**
      * Signs out the current user and clears the stored portal settings.
      */
+    @Suppress("DEPRECATION")
     suspend fun signOut() = withContext(Dispatchers.IO) {
         preferences.edit { settings ->
             settings.remove(URL_KEY)

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/navigation/Navigator.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/navigation/Navigator.kt
@@ -79,6 +79,7 @@ sealed class NavigationRoute {
 }
 
 @Composable
+@Suppress("DEPRECATION")
 fun AppNavigation(
     navController: NavHostController,
     navigator: Navigator,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/FolderContentScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/FolderContentScreen.kt
@@ -53,6 +53,7 @@ import kotlinx.serialization.json.Json
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("DEPRECATION")
 fun FolderContentScreen(
     viewModel: FolderContentViewModel = hiltViewModel(),
     onItemSelected: () -> Unit,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentScreen.kt
@@ -76,6 +76,7 @@ import java.time.format.DateTimeFormatter
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("DEPRECATION")
 fun PortalContentScreen(
     modifier: Modifier = Modifier,
     onFolderClick: (PortalFolder) -> Unit,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
@@ -101,6 +101,7 @@ import com.arcgismaps.toolkit.featureformsapp.AnimatedLoading
 import com.arcgismaps.toolkit.featureformsapp.R
 
 @Composable
+@Suppress("DEPRECATION")
 fun LoginScreen(
     viewModel: LoginViewModel = hiltViewModel(),
     onSuccessfulLogin: () -> Unit = {}

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -118,6 +118,7 @@ import com.arcgismaps.toolkit.geoviewcompose.MapView
 import kotlinx.coroutines.launch
 
 @Composable
+@Suppress("DEPRECATION")
 fun MapScreen(mapViewModel: MapViewModel = hiltViewModel(), onBackPressed: () -> Unit = {}) {
     val uiState by mapViewModel.uiState
     val scope = rememberCoroutineScope()

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchScreen.kt
@@ -58,6 +58,7 @@ import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("DEPRECATION")
 fun SearchScreen(
     viewModel: SearchViewModel = hiltViewModel(),
     onItemSelected: () -> Unit,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
@@ -161,6 +161,7 @@ internal fun UtilityAssociationGroupResult(
  *
  */
 @Composable
+@Suppress("DEPRECATION")
 private fun AssociationItem(
     title: String,
     association: UtilityAssociation,

--- a/toolkit/offline/build.gradle.kts
+++ b/toolkit/offline/build.gradle.kts
@@ -29,6 +29,9 @@ plugins {
 
 kotlin {
     jvmToolchain(17)
+    compilerOptions {
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
+    }
 }
 
 android {

--- a/toolkit/utilitynetworks/build.gradle.kts
+++ b/toolkit/utilitynetworks/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
     jvmToolchain(17)
     compilerOptions {
         freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
 }
 

--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TabRow.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/internal/util/TabRow.kt
@@ -16,6 +16,7 @@
 package com.arcgismaps.toolkit.utilitynetworks.internal.util
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,7 +36,7 @@ internal fun TabRow(
         stringResource(R.string.new_trace) to TraceNavRoute.TraceOptions,
         stringResource(R.string.results) to TraceNavRoute.TraceResults
     )
-    TabRow(
+    SecondaryTabRow(
         selectedTabIndex = selectedIndex,
         modifier = Modifier.padding(bottom = 16.dp)
     ) {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/kotlin/issues/6964

<!-- link to design, if applicable -->

### Description:

Fixes warnings thrown in the build

### Summary of changes:

1. For warning
`8 2026-01-02 12:01:47.997 w: file:///Users/Shared/devops/jenkins/workspace/daily/toolkit/arcgis-maps-sdk-kotlin-toolkit/toolkit/offline/src/main/java/com/arcgismaps/toolkit/offline/internal/utils/ZoomLevel.kt:34:5 This annotation is currently applied to the value parameter only, but in the future it will also be applied to field.` 

  _- To opt in to applying to both value parameter and field, add '-Xannotation-default-target=param-property' to your compiler arguments.
  To keep applying to the value parameter only, use the '@param:' annotation target.
  See https://youtrack.jetbrains.com/issue/KT-73255 for more details._
  
To resolve it added `kotlin.compilerOptions.freeCompilerArgs.add("-Xannotation-default-target=param-property")` in Gradle  

2. For warnings in app code related to use of deprecated API added `@Suppress("DEPRECATION")`
3. For warnings related to the use of Deprecated `TabRow`, replaced `TabRow` with its replacement `SecondaryTabRow`
4. For `40 2026-01-02 12:01:44.344 warning: The following options were not recognized by any processor: '[dagger.fastInit, dagger.hilt.android.internal.disableAndroidSuperclassValidation, dagger.hilt.android.internal.projectType, dagger.hilt.internal.useAggregatingRootProcessor]'` 
removed the not needed `annotationProcessor(libs.room.compiler)` dependency which is causing the warning. It is not needed as we have added the ksp dependency `ksp(libs.room.compiler)`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1094/parsed_console/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  