### PR TITLE
`FeatureForm`: Refine attribute filtering behavior

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -19,7 +19,6 @@ package com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
@@ -36,7 +35,6 @@ import com.arcgismaps.mapping.featureforms.UtilityAssociationFeatureCandidate
 import com.arcgismaps.mapping.featureforms.UtilityAssociationFeatureOptions
 import com.arcgismaps.mapping.featureforms.UtilityAssociationFeatureSource
 import com.arcgismaps.mapping.featureforms.UtilityAssociationsFormElement
-import com.arcgismaps.toolkit.featureforms.internal.screens.FieldFilter
 import com.arcgismaps.toolkit.featureforms.internal.utils.isNumeric
 import com.arcgismaps.utilitynetworks.UtilityAssetType
 import com.arcgismaps.utilitynetworks.UtilityAssociationResult
@@ -249,15 +247,12 @@ internal class AddAssociationFromSourceViewModel(
         get() = _fields.value
 
     /**
-     * Backing list of attribute [FieldFilter] objects applied to the feature candidates query.
+     * Manages the state of attribute filters applied to the feature candidates.
      */
-    private val _attributeFieldFilters = mutableStateListOf<FieldFilter>()
-
-    /**
-     * A list of attribute [FieldFilter] objects applied to the feature candidates query.
-     */
-    val attributeFieldFilters: List<FieldFilter>
-        get() = _attributeFieldFilters
+    val attributeFilterStateManager = FilterStateManager(
+        onApplyFilter = ::applyAttributeFilters,
+        scope = viewModelScope
+    )
 
     private var _areAttributeFiltersApplied: MutableState<Boolean> = mutableStateOf(false)
 
@@ -313,7 +308,7 @@ internal class AddAssociationFromSourceViewModel(
                         )
                     }
                     // Clear any previously set attribute filters
-                    _attributeFieldFilters.clear()
+                    attributeFilterStateManager.clearFilters()
                     // Reset whether filters are applied
                     _areAttributeFiltersApplied.value = false
                 }
@@ -350,21 +345,6 @@ internal class AddAssociationFromSourceViewModel(
         return _featureCandidatesUiState.value.candidates.filter { candidate ->
             candidate.title.contains(filterString, ignoreCase = true)
         }
-    }
-
-    /**
-     * Adds a new attribute [FieldFilter] to the list of [attributeFieldFilters] at the
-     * beginning of the list.
-     */
-    fun addAttributeFieldFilter(fieldFilter: FieldFilter) {
-        _attributeFieldFilters.add(0, fieldFilter)
-    }
-
-    /**
-     * Removes the specified attribute [FieldFilter] from the list of [attributeFieldFilters].
-     */
-    fun deleteAttributeFieldFilter(fieldFilter: FieldFilter) {
-        _attributeFieldFilters.remove(fieldFilter)
     }
 
     /**
@@ -636,22 +616,13 @@ internal class AddAssociationFromSourceViewModel(
         }
     }
 
-    /**
-     * Applies the current [attributeFieldFilters] to the feature candidates query, updating the
-     * [featureCandidatesUiState] with the filtered results.
-     */
-    suspend fun applyAttributeFilters(): Result<Unit> {
+    private suspend fun applyAttributeFilters(whereClause : String): Result<Unit> {
         val source = _selectedSource.value ?: return Result.failure(
             IllegalStateException("No source selected")
         )
         val assetType = _selectedAssetType.value ?: return Result.failure(
             IllegalStateException("No asset type selected")
         )
-        // Build the where clause from only valid attribute filters
-        val queries = attributeFieldFilters.mapNotNull { filter ->
-            filter.getQuery()
-        }
-        val whereClause = queries.joinToString(" AND ")
         val queryParams = QueryParameters().apply {
             this.whereClause = whereClause
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -249,10 +249,8 @@ internal class AddAssociationFromSourceViewModel(
     /**
      * Manages the state of attribute filters applied to the feature candidates.
      */
-    val attributeFilterStateManager = FilterStateManager(
-        onApplyFilter = ::applyAttributeFilters,
-        scope = viewModelScope
-    )
+    var attributeFilterStateManager = FilterStateManager(onApplyFilter = ::applyAttributeFilters)
+        private set
 
     private var _areAttributeFiltersApplied: MutableState<Boolean> = mutableStateOf(false)
 
@@ -307,8 +305,10 @@ internal class AddAssociationFromSourceViewModel(
                             error = error
                         )
                     }
-                    // Clear any previously set attribute filters
-                    attributeFilterStateManager.clearFilters()
+                    // Create a new filter state manager for the new source/asset type
+                    attributeFilterStateManager = FilterStateManager(
+                        onApplyFilter = ::applyAttributeFilters
+                    )
                     // Reset whether filters are applied
                     _areAttributeFiltersApplied.value = false
                 }
@@ -616,7 +616,7 @@ internal class AddAssociationFromSourceViewModel(
         }
     }
 
-    private suspend fun applyAttributeFilters(whereClause : String): Result<Unit> {
+    private suspend fun applyAttributeFilters(whereClause: String): Result<Unit> {
         val source = _selectedSource.value ?: return Result.failure(
             IllegalStateException("No source selected")
         )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2026 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork
+
+import android.util.Log
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.text.input.KeyboardType
+import com.arcgismaps.data.Field
+import com.arcgismaps.data.FieldType
+import com.arcgismaps.toolkit.featureforms.internal.utils.isNumeric
+
+/**
+ * Manages the state of [FieldFilter]s applied to filter candidate features. This supports adding,
+ * removing, duplicating, and applying filters, as well as building the corresponding where clause.
+ * Tracking edits to the filters is also supported to know when changes have been made. [hasEdits]
+ * will be true if there are unsaved changes to the filters. To ensure that the state is consistent,
+ * use [saveSnapshot] before making changes and [restoreSnapshot] to revert to the last saved state.
+ *
+ * When filters are applied via [applyFilters], the [onApplyFilter] callback is invoked with the
+ * current where clause. The callback should handle the application of the where clause and return
+ * a [Result] indicating success or failure.
+ *
+ * @param onApplyFilter A callback function that is invoked when filters need to be applied. A
+ * where clause string is passed to this function.
+ */
+internal class FilterStateManager(
+    private val onApplyFilter: suspend (String) -> Result<Unit>
+) {
+    private var whereClause : String = ""
+
+    private val _filters = mutableStateListOf<FieldFilter>()
+
+    /**
+     * The list of current [FieldFilter]s.
+     */
+    val filters: List<FieldFilter>
+        get() = _filters
+
+    private val _hasEdits = mutableStateOf(false)
+
+    /**
+     * Indicates whether there are unsaved edits to the filters.
+     */
+    val hasEdits: Boolean
+        get() = _hasEdits.value
+
+    /**
+     * Adds the [FieldFilter] to the start of the list and rebuilds the where clause.
+     */
+    private fun addFilter(filter: FieldFilter) {
+        _filters.add(0, filter)
+        buildWhereClause()
+    }
+
+    /**
+     * Builds the SQL where clause from the current filters. If [notifyEdits] is true, it updates
+     * the [hasEdits] state based on whether the where clause has changed.
+     */
+    private fun buildWhereClause(notifyEdits: Boolean = true) {
+        val queries = _filters.mapNotNull { it.getQuery() }
+        val fullQuery = queries.joinToString(separator = " AND ")
+        Log.e("TAG", "buildWhereClause: $fullQuery", )
+        if (fullQuery != whereClause && notifyEdits) {
+            whereClause = fullQuery
+            _hasEdits.value = true
+            whereClause
+        } else {
+            _hasEdits.value = false
+        }
+    }
+
+    /**
+     * Applies the current filters.
+     */
+    suspend fun applyFilters() : Result<Unit> {
+        return onApplyFilter(whereClause).onSuccess {
+            _hasEdits.value = false
+        }
+    }
+
+    /**
+     * Clears all filters and resets the where clause.
+     */
+    fun clearFilters() {
+        _filters.clear()
+        whereClause = ""
+    }
+
+    /**
+     * Creates a new [FieldFilter], adds it to the list.
+     */
+    fun createNewFilter() {
+        val newFilter = FieldFilter(
+            onFilterChanged = ::buildWhereClause
+        )
+        addFilter(newFilter)
+    }
+
+    /**
+     * Duplicates the given [FieldFilter] and adds it to the start of the list.
+     */
+    fun duplicateFilter(filter: FieldFilter) {
+        val newFilter = filter.copy(
+            onFilterChanged = ::buildWhereClause
+        )
+        addFilter(newFilter)
+    }
+
+    /**
+     * Removes the given [FieldFilter] from the list and rebuilds the where clause.
+     */
+    fun removeFilter(filter: FieldFilter) {
+        _filters.remove(filter)
+        buildWhereClause()
+    }
+
+    /**
+     * Saves a snapshot of the current filters to allow restoring later. Use [restoreSnapshot] to revert
+     * to this state.
+     */
+    fun saveSnapshot() {
+        _filters.forEach {
+            it.saveSnapshot()
+        }
+    }
+
+    /**
+     * Restores the filters to the last saved snapshot state. Use after [saveSnapshot] to revert changes.
+     */
+    fun restoreSnapshot() {
+        _filters.forEach {
+            it.restoreSnapshot()
+        }
+        // Restore where clause without notifying edits.
+        buildWhereClause(notifyEdits = false)
+    }
+}
+
+/**
+ * A snapshot of a [FieldFilter]'s state for saving and restoring.
+ */
+private data class FieldFilterSnapshot(
+    val field : Field?,
+    val operator : Operator?,
+    val value : String
+)
+
+/**
+ * Class representing a filter on a [Field] with a [Operator] and value.
+ */
+internal class FieldFilter(
+    private val onFilterChanged : () -> Unit
+) {
+
+    private var _field = mutableStateOf<Field?>(null)
+
+    /**
+     * The field to filter on.
+     */
+    val field: Field?
+        get() = _field.value
+
+    private var _operator = mutableStateOf<Operator?>(null)
+
+    /**
+     * The operator to use for filtering.
+     */
+    val operator: Operator?
+        get() = _operator.value
+
+    private var _value = mutableStateOf("")
+
+    /**
+     * The value to filter on.
+     */
+    val value: String
+        get() = _value.value
+
+
+    private var snapshot : FieldFilterSnapshot? = null
+
+    /**
+     * Checks if the filter is valid and can be used to generate a query.
+     *
+     * @return true if the filter is valid, false otherwise
+     */
+    private fun isValid(): Boolean {
+        val hasField = field != null
+        val operator = operator ?: return false
+        // For unary operators, value is not required
+        return hasField && (operator.isUnary() || value.isNotEmpty())
+    }
+
+    /**
+     * Sets the field for this filter. Resets the operator and value.
+     *
+     * @param value the field to set
+     */
+    fun setField(value: Field) {
+        _field.value = value
+        _operator.value = null // reset operator when field changes
+        _value.value = "" // reset value when field changes
+        // Notify that the filter has changed
+        onFilterChanged()
+    }
+
+    /**
+     * Sets the operator for this filter.
+     *
+     * @param value the operator to set
+     */
+    fun setOperator(value: Operator) {
+        _operator.value = value
+        // Notify that the filter has changed
+        onFilterChanged()
+    }
+
+    /**
+     * Sets the value for this filter.
+     *
+     * @param value the value to set
+     */
+    fun setValue(value: String) {
+        _value.value = value
+        // Notify that the filter has changed
+        onFilterChanged()
+    }
+
+    /**
+     * Gets the list of valid operators for the current field type.
+     *
+     * @return the list of valid operators
+     */
+    fun getOperators(): List<Operator> {
+        val fieldType = field?.fieldType ?: return emptyList()
+        return when {
+            fieldType.isNumeric || fieldType == FieldType.Oid -> FilterOperators.NUMERIC_OPERATORS
+            fieldType == FieldType.Text -> {
+                if (field!!.nullable) {
+                    FilterOperators.TEXT_OPERATORS
+                } else {
+                    FilterOperators.TEXT_OPERATORS + FilterOperators.NULLABLE_OPERATORS
+                }
+            }
+
+            else -> emptyList()
+        }
+    }
+
+    /**
+     * Gets the appropriate keyboard type for the current field type.
+     *
+     * @return the keyboard type
+     */
+    fun getKeyboardType(): KeyboardType {
+        val fieldType = field?.fieldType ?: return KeyboardType.Text
+
+        return when {
+            fieldType.isNumeric -> KeyboardType.Number
+            fieldType == FieldType.Oid -> KeyboardType.Number
+            else -> KeyboardType.Text
+        }
+    }
+
+    /**
+     * Generates the query string for this filter.
+     *
+     * @return the query string or null if the filter is not valid
+     */
+    fun getQuery(): String? {
+        if (isValid().not()) return null
+        val formattedValue = when (field!!.fieldType) {
+            is FieldType.Text -> "'${this.value}'"
+            else -> this.value
+        }
+        val field = this.field!!
+        return when (val operator = this.operator!!) {
+            is Operator.StartsWith -> {
+                "${field.name} ${operator.sign} '${value}%'"
+            }
+
+            is Operator.EndsWith -> {
+                "${field.name} ${operator.sign} '%${value}'"
+            }
+
+            Operator.Contains, Operator.DoesNotContain -> {
+                "${field.name} ${operator.sign} '%${value}%'"
+            }
+
+            is Operator.IsBlank, Operator.IsNotBlank, Operator.IsEmpty, Operator.IsNotEmpty -> {
+                "${field.name} ${operator.sign}"
+            }
+
+            else -> {
+                "${field.name} ${operator.sign} $formattedValue"
+            }
+        }
+    }
+
+    /**
+     * Creates a copy of this filter.
+     *
+     * @return the copied filter
+     */
+    fun copy(
+        onFilterChanged: () -> Unit
+    ): FieldFilter {
+        val newFilter = FieldFilter(onFilterChanged)
+        field?.let { newFilter.setField(it) }
+        operator?.let { newFilter.setOperator(it) }
+        newFilter.setValue(value)
+        return newFilter
+    }
+
+    /**
+     * Saves a snapshot of the current filter state.
+     */
+    fun saveSnapshot() {
+        snapshot = FieldFilterSnapshot(
+            field = field,
+            operator = operator,
+            value = value
+        )
+    }
+
+    /**
+     * Restores the filter state from the last saved snapshot, if available.
+     */
+    fun restoreSnapshot() {
+        snapshot?.let { snap ->
+            snap.field?.let { setField(it) }
+            snap.operator?.let { setOperator(it) }
+            setValue(snap.value)
+        }
+    }
+}
+
+/**
+ * Represents an operator that can be used in a [FieldFilter].
+ *
+ * @param name the display name of the operator.
+ * @param sign the sign of the operator used in queries.
+ */
+internal sealed class Operator(
+    val name: String,
+    val sign: String
+) {
+    object Equal : Operator("=", "=")
+    object NotEqual : Operator("!=", "<>")
+    object Is : Operator("is", "=")
+    object IsNot : Operator("is not", "<>")
+    object GreaterThan : Operator(">", ">")
+    object GreaterThanOrEqual : Operator(">=", ">=")
+    object LessThan : Operator("<", "<")
+    object LessThanOrEqual : Operator("<=", "<=")
+    object StartsWith : Operator("starts with", "LIKE")
+    object EndsWith : Operator("ends with", "LIKE")
+    object Contains : Operator("contains the text", "LIKE")
+    object DoesNotContain : Operator("does not contain the text", "not LIKE")
+    object IsBlank : Operator("is blank", "IS NULL")
+    object IsNotBlank : Operator("is not blank", "IS NOT NULL")
+    object IsEmpty : Operator("is empty", "= ''")
+    object IsNotEmpty : Operator("is not empty", "<> ''")
+
+    override fun toString(): String {
+        return sign
+    }
+
+    /**
+     * Checks if the operator is unary (does not require a value).
+     *
+     * @return true if the operator is unary, false otherwise
+     */
+    fun isUnary(): Boolean {
+        return this is IsBlank || this is IsNotBlank || this is IsEmpty || this is IsNotEmpty
+    }
+}
+
+private object FilterOperators {
+
+    /**
+     * The list of operators applicable to numeric fields.
+     */
+    val NUMERIC_OPERATORS = listOf(
+        Operator.Equal,
+        Operator.NotEqual,
+        Operator.GreaterThan,
+        Operator.GreaterThanOrEqual,
+        Operator.LessThan,
+        Operator.LessThanOrEqual
+    )
+
+    /**
+     * The list of operators applicable to text fields.
+     */
+    val TEXT_OPERATORS = listOf(
+        Operator.Is,
+        Operator.IsNot,
+        Operator.StartsWith,
+        Operator.EndsWith,
+        Operator.Contains,
+        Operator.DoesNotContain,
+        Operator.IsEmpty,
+        Operator.IsNotEmpty
+    )
+
+    /**
+     * The list of operators applicable to nullable fields.
+     */
+    val NULLABLE_OPERATORS = listOf(
+        Operator.IsBlank,
+        Operator.IsNotBlank
+    )
+}
+
+/**
+ * Gets the effective name of the field, using the alias if available, otherwise the actual name.
+ */
+internal val Field.fieldName: String
+    get() = this.alias.ifEmpty { this.name }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.text.input.KeyboardType
 import com.arcgismaps.data.Field
@@ -168,6 +169,7 @@ internal class FilterStateManager(
  * @param operator The [Operator] to use for filtering. Defaults to null.
  * @param value The value to filter against as a [String]. Defaults to an empty string
  */
+@Immutable
 internal data class FieldFilter(
     val id: String = UUID.randomUUID().toString(),
     val field: Field? = null,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -120,10 +120,12 @@ internal class FilterStateManager(
     }
 
     /**
-     * Removes the given [FieldFilter] from the list and rebuilds the where clause.
+     * Removes the given [FieldFilter] from the list.
      */
-    fun removeFilter(filter: FieldFilter) {
-        _filters.remove(filter)
+    fun removeFilter(index: Int) {
+        if (index in _filters.indices) {
+            _filters.removeAt(index)
+        }
     }
 
     /**
@@ -189,76 +191,6 @@ internal data class FieldFilter(
     }
 
     /**
-     * Gets the list of valid operators for the current field type.
-     *
-     * @return the list of valid operators
-     */
-    fun getOperators(): List<Operator> {
-        val fieldType = field?.fieldType ?: return emptyList()
-        return when {
-            fieldType.isNumeric || fieldType == FieldType.Oid -> FilterOperators.NUMERIC_OPERATORS
-            fieldType == FieldType.Text -> {
-                if (field.nullable) {
-                    FilterOperators.TEXT_OPERATORS
-                } else {
-                    FilterOperators.TEXT_OPERATORS + FilterOperators.NULLABLE_OPERATORS
-                }
-            }
-
-            else -> emptyList()
-        }
-    }
-
-    /**
-     * Gets the appropriate keyboard type for the current field type.
-     *
-     * @return the keyboard type
-     */
-    fun getKeyboardType(): KeyboardType {
-        val fieldType = field?.fieldType ?: return KeyboardType.Text
-
-        return when {
-            fieldType.isNumeric -> KeyboardType.Number
-            fieldType == FieldType.Oid -> KeyboardType.Number
-            else -> KeyboardType.Text
-        }
-    }
-
-    /**
-     * Generates the query string for this filter.
-     *
-     * @return the query string or null if the filter is not valid
-     */
-    fun getQuery(): String? {
-        if (isValid().not()) return null
-        val formattedValue = when (field!!.fieldType) {
-            is FieldType.Text -> "'${this.value}'"
-            else -> this.value
-        }
-        return when (val operator = this.operator!!) {
-            is Operator.StartsWith -> {
-                "${field.name} ${operator.sign} '${value}%'"
-            }
-
-            is Operator.EndsWith -> {
-                "${field.name} ${operator.sign} '%${value}'"
-            }
-
-            Operator.Contains, Operator.DoesNotContain -> {
-                "${field.name} ${operator.sign} '%${value}%'"
-            }
-
-            is Operator.IsBlank, Operator.IsNotBlank, Operator.IsEmpty, Operator.IsNotEmpty -> {
-                "${field.name} ${operator.sign}"
-            }
-
-            else -> {
-                "${field.name} ${operator.sign} $formattedValue"
-            }
-        }
-    }
-
-    /**
      * Creates a copy of this [FieldFilter] with the given new field.
      */
     fun withField(newField: Field): FieldFilter = copy(
@@ -284,6 +216,76 @@ internal data class FieldFilter(
         operator = operator,
         value = newValue
     )
+}
+
+/**
+ * Gets the list of valid operators for the current field type.
+ *
+ * @return the list of valid operators
+ */
+internal fun FieldFilter.getOperators(): List<Operator> {
+    val fieldType = field?.fieldType ?: return emptyList()
+    return when {
+        fieldType.isNumeric || fieldType == FieldType.Oid -> FilterOperators.NUMERIC_OPERATORS
+        fieldType == FieldType.Text -> {
+            if (field.nullable) {
+                FilterOperators.TEXT_OPERATORS
+            } else {
+                FilterOperators.TEXT_OPERATORS + FilterOperators.NULLABLE_OPERATORS
+            }
+        }
+
+        else -> emptyList()
+    }
+}
+
+/**
+ * Gets the appropriate keyboard type for the current field type.
+ *
+ * @return the keyboard type
+ */
+internal fun FieldFilter.getKeyboardType(): KeyboardType {
+    val fieldType = field?.fieldType ?: return KeyboardType.Text
+
+    return when {
+        fieldType.isNumeric -> KeyboardType.Number
+        fieldType == FieldType.Oid -> KeyboardType.Number
+        else -> KeyboardType.Text
+    }
+}
+
+/**
+ * Generates the query string for this filter.
+ *
+ * @return the query string or null if the filter is not valid
+ */
+internal fun FieldFilter.getQuery(): String? {
+    if (isValid().not()) return null
+    val formattedValue = when (field!!.fieldType) {
+        is FieldType.Text -> "'${this.value}'"
+        else -> this.value
+    }
+    return when (val operator = this.operator!!) {
+        is Operator.StartsWith -> {
+            "${field.name} ${operator.sign} '${value}%'"
+        }
+
+        is Operator.EndsWith -> {
+            "${field.name} ${operator.sign} '%${value}'"
+        }
+
+        Operator.Contains, Operator.DoesNotContain -> {
+            "${field.name} ${operator.sign} '%${value}%'"
+        }
+
+        is Operator.IsBlank, Operator.IsNotBlank, Operator.IsEmpty, Operator.IsNotEmpty -> {
+            "${field.name} ${operator.sign}"
+        }
+
+        else -> {
+            "${field.name} ${operator.sign} $formattedValue"
+        }
+    }
 }
 
 /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -372,7 +372,11 @@ private object FilterOperators {
 internal val Field.fieldName: String
     get() = this.alias.ifEmpty { this.name }
 
-
+/**
+ * Builds a where clause string from the list of [FieldFilter]s.
+ *
+ * @return the where clause string
+ */
 internal fun List<FieldFilter>.buildWhereClause(): String {
     val queries = this.mapNotNull { it.getQuery() }
     return queries.joinToString(separator = " AND ")

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -16,13 +16,12 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork
 
-import android.util.Log
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.text.input.KeyboardType
 import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.toolkit.featureforms.internal.utils.isNumeric
+import java.util.UUID
 
 /**
  * Snapshot of the filters to allow restoring later.
@@ -62,17 +61,13 @@ internal class FilterStateManager(
     private val _filters = mutableStateListOf<FieldFilter>()
 
     /**
-     * The list of current [FieldFilter]s.
+     * The list of current [FieldFilter]s. To modify the list or update any filters, use the
+     * provided methods on this class such as [createNewFilter], [removeFilter], and [updateFilter].
+     *
+     * This property is observable and will trigger recompositions when modified.
      */
     val filters: List<FieldFilter>
         get() = _filters
-
-    /**
-     * Adds the [FieldFilter] to the start of the list and rebuilds the where clause.
-     */
-    private fun addFilter(filter: FieldFilter) {
-        _filters.add(0, filter)
-    }
 
     /**
      * Removes invalid filters from the list.
@@ -86,30 +81,30 @@ internal class FilterStateManager(
     /**
      * Applies the current filters.
      */
-    suspend fun applyFilters() : Result<Unit> {
+    suspend fun applyFilters(): Result<Unit> {
         val whereClause = _filters.buildWhereClause()
-
-        Log.e("TAG", "applyFilters: $whereClause", )
-
         return onApplyFilter(whereClause).onSuccess {
             // Purge invalid filters after successful application
             purgeInvalidFilters()
             // Save snapshot of applied filters
             saveSnapshot()
-        }.onFailure {
-            Log.e("TAG", "failed applyFilters: $it", )
         }
     }
 
     /**
      * Creates a new [FieldFilter], adds it to the start of the list.
      */
-    fun createNewFilter() = addFilter(FieldFilter())
+    fun createNewFilter() = _filters.add(0, FieldFilter())
 
     /**
      * Duplicates the given [FieldFilter] and adds it to the start of the list.
      */
-    fun duplicateFilter(filter: FieldFilter) = addFilter(filter.copy())
+    fun duplicateFilter(filter: FieldFilter) = _filters.add(
+        index = 0,
+        element = filter.copy(
+            id = UUID.randomUUID().toString()
+        )
+    )
 
     /**
      * Checks if there are unsaved edits to the filters compared to the last saved snapshot. If
@@ -131,20 +126,25 @@ internal class FilterStateManager(
     }
 
     /**
+     * Updates the [FieldFilter] at the given index with the new filter values.
+     */
+    fun updateFilter(index: Int, newFilter: FieldFilter) {
+        _filters[index] = newFilter
+    }
+
+    /**
      * Saves a snapshot of the current filters to allow restoring later. Use [restoreSnapshot] to revert
      * to this state. This method must be called before making changes to the filters to track edits.
+     *
+     * Only valid filters are saved in the snapshot.
      */
     fun saveSnapshot() {
         val filtersToSnapshot = _filters.mapNotNull {
             if (it.isValid()) it.copy() else null
         }
-        filtersToSnapshot.forEach {
-            Log.e("TAG", "saveSnapshot filter: ${it.getQuery()}", )
-        }
         snapshot = FilterSnapshot(
             filters = filtersToSnapshot
         )
-        Log.e("TAG", "saveSnapshot: ${snapshot?.whereClause}", )
     }
 
     /**
@@ -158,34 +158,22 @@ internal class FilterStateManager(
 }
 
 /**
- * Class representing a filter on a [Field] with a [Operator] and value.
+ * Class representing a filter on a [Field] with a [Operator] and value. This class is immutable;
+ * to modify a filter, create a new instance using the provided copy methods ([withField],
+ * [withOperator], [withValue]). The copy methods return a new [FieldFilter] instance with the
+ * same [id] but updated properties.
+ *
+ * @param id Unique identifier for the filter. Defaults to a random UUID.
+ * @param field The [Field] to filter on. Defaults to null.
+ * @param operator The [Operator] to use for filtering. Defaults to null.
+ * @param value The value to filter against as a [String]. Defaults to an empty string
  */
-internal class FieldFilter() {
-
-    private var _field = mutableStateOf<Field?>(null)
-
-    /**
-     * The field to filter on.
-     */
-    val field: Field?
-        get() = _field.value
-
-    private var _operator = mutableStateOf<Operator?>(null)
-
-    /**
-     * The operator to use for filtering.
-     */
-    val operator: Operator?
-        get() = _operator.value
-
-    private var _value = mutableStateOf("")
-
-    /**
-     * The value to filter on.
-     */
-    val value: String
-        get() = _value.value
-
+internal data class FieldFilter(
+    val id: String = UUID.randomUUID().toString(),
+    val field: Field? = null,
+    val operator: Operator? = null,
+    val value: String = ""
+) {
     /**
      * Checks if the filter is valid and can be used to generate a query.
      *
@@ -199,35 +187,6 @@ internal class FieldFilter() {
     }
 
     /**
-     * Sets the field for this filter. Resets the operator and value.
-     *
-     * @param value the field to set
-     */
-    fun setField(value: Field) {
-        _field.value = value
-        _operator.value = null // reset operator when field changes
-        _value.value = "" // reset value when field changes
-    }
-
-    /**
-     * Sets the operator for this filter.
-     *
-     * @param value the operator to set
-     */
-    fun setOperator(value: Operator) {
-        _operator.value = value
-    }
-
-    /**
-     * Sets the value for this filter.
-     *
-     * @param value the value to set
-     */
-    fun setValue(value: String) {
-        _value.value = value
-    }
-
-    /**
      * Gets the list of valid operators for the current field type.
      *
      * @return the list of valid operators
@@ -237,7 +196,7 @@ internal class FieldFilter() {
         return when {
             fieldType.isNumeric || fieldType == FieldType.Oid -> FilterOperators.NUMERIC_OPERATORS
             fieldType == FieldType.Text -> {
-                if (field!!.nullable) {
+                if (field.nullable) {
                     FilterOperators.TEXT_OPERATORS
                 } else {
                     FilterOperators.TEXT_OPERATORS + FilterOperators.NULLABLE_OPERATORS
@@ -274,7 +233,6 @@ internal class FieldFilter() {
             is FieldType.Text -> "'${this.value}'"
             else -> this.value
         }
-        val field = this.field!!
         return when (val operator = this.operator!!) {
             is Operator.StartsWith -> {
                 "${field.name} ${operator.sign} '${value}%'"
@@ -299,20 +257,31 @@ internal class FieldFilter() {
     }
 
     /**
-     * Creates a copy of this filter.
-     *
-     * @return the copied filter
+     * Creates a copy of this [FieldFilter] with the given new field.
      */
-    fun copy(): FieldFilter {
-        val newFilter = FieldFilter()
-        _field.value?.let { newFilter.setField(it) }
-        _operator.value?.let { newFilter.setOperator(it) }
-        newFilter.setValue(value)
+    fun withField(newField: Field): FieldFilter = copy(
+        field = newField,
+        operator = operator,
+        value = value
+    )
 
-        Log.e("TAG", "copy: ${newFilter._value} - $_value", )
+    /**
+     * Creates a copy of this [FieldFilter] with the given new operator.
+     */
+    fun withOperator(newOperator: Operator): FieldFilter = copy(
+        field = field,
+        operator = newOperator,
+        value = value
+    )
 
-        return newFilter
-    }
+    /**
+     * Creates a copy of this [FieldFilter] with the given new value.
+     */
+    fun withValue(newValue: String): FieldFilter = copy(
+        field = field,
+        operator = operator,
+        value = newValue
+    )
 }
 
 /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -25,11 +25,20 @@ import com.arcgismaps.data.FieldType
 import com.arcgismaps.toolkit.featureforms.internal.utils.isNumeric
 
 /**
+ * Snapshot of the filters to allow restoring later.
+ */
+private data class FilterSnapshot(
+    val filters: List<FieldFilter>
+) {
+    val whereClause: String = filters.buildWhereClause()
+}
+
+/**
  * Manages the state of [FieldFilter]s applied to filter candidate features. This supports adding,
  * removing, duplicating, and applying filters, as well as building the corresponding where clause.
- * Tracking edits to the filters is also supported to know when changes have been made. [hasEdits]
- * will be true if there are unsaved changes to the filters. To ensure that the state is consistent,
- * use [saveSnapshot] before making changes and [restoreSnapshot] to revert to the last saved state.
+ * Tracking edits to the filters is also supported via the [hasEdits] method. To ensure that the
+ * state is consistent, use [saveSnapshot] before making changes and [restoreSnapshot] to revert to
+ * the last saved state.
  *
  * When filters are applied via [applyFilters], the [onApplyFilter] callback is invoked with the
  * current where clause. The callback should handle the application of the where clause and return
@@ -41,8 +50,15 @@ import com.arcgismaps.toolkit.featureforms.internal.utils.isNumeric
 internal class FilterStateManager(
     private val onApplyFilter: suspend (String) -> Result<Unit>
 ) {
-    private var whereClause : String = ""
 
+    /**
+     * Snapshot of the filters to allow restoring later. [saveSnapshot] populates this value.
+     */
+    private var snapshot: FilterSnapshot = FilterSnapshot(emptyList())
+
+    /**
+     * The mutable list of current [FieldFilter]s. Backs the public [filters] property.
+     */
     private val _filters = mutableStateListOf<FieldFilter>()
 
     /**
@@ -51,36 +67,19 @@ internal class FilterStateManager(
     val filters: List<FieldFilter>
         get() = _filters
 
-    private val _hasEdits = mutableStateOf(false)
-
-    /**
-     * Indicates whether there are unsaved edits to the filters.
-     */
-    val hasEdits: Boolean
-        get() = _hasEdits.value
-
     /**
      * Adds the [FieldFilter] to the start of the list and rebuilds the where clause.
      */
     private fun addFilter(filter: FieldFilter) {
         _filters.add(0, filter)
-        buildWhereClause()
     }
 
     /**
-     * Builds the SQL where clause from the current filters. If [notifyEdits] is true, it updates
-     * the [hasEdits] state based on whether the where clause has changed.
+     * Removes invalid filters from the list.
      */
-    private fun buildWhereClause(notifyEdits: Boolean = true) {
-        val queries = _filters.mapNotNull { it.getQuery() }
-        val fullQuery = queries.joinToString(separator = " AND ")
-        Log.e("TAG", "buildWhereClause: $fullQuery", )
-        if (fullQuery != whereClause && notifyEdits) {
-            whereClause = fullQuery
-            _hasEdits.value = true
-            whereClause
-        } else {
-            _hasEdits.value = false
+    private fun purgeInvalidFilters() {
+        _filters.removeIf {
+            it.isValid().not()
         }
     }
 
@@ -88,37 +87,40 @@ internal class FilterStateManager(
      * Applies the current filters.
      */
     suspend fun applyFilters() : Result<Unit> {
+        val whereClause = _filters.buildWhereClause()
+
+        Log.e("TAG", "applyFilters: $whereClause", )
+
         return onApplyFilter(whereClause).onSuccess {
-            _hasEdits.value = false
+            // Purge invalid filters after successful application
+            purgeInvalidFilters()
+            // Save snapshot of applied filters
+            saveSnapshot()
+        }.onFailure {
+            Log.e("TAG", "failed applyFilters: $it", )
         }
     }
 
     /**
-     * Clears all filters and resets the where clause.
+     * Creates a new [FieldFilter], adds it to the start of the list.
      */
-    fun clearFilters() {
-        _filters.clear()
-        whereClause = ""
-    }
-
-    /**
-     * Creates a new [FieldFilter], adds it to the list.
-     */
-    fun createNewFilter() {
-        val newFilter = FieldFilter(
-            onFilterChanged = ::buildWhereClause
-        )
-        addFilter(newFilter)
-    }
+    fun createNewFilter() = addFilter(FieldFilter())
 
     /**
      * Duplicates the given [FieldFilter] and adds it to the start of the list.
      */
-    fun duplicateFilter(filter: FieldFilter) {
-        val newFilter = filter.copy(
-            onFilterChanged = ::buildWhereClause
-        )
-        addFilter(newFilter)
+    fun duplicateFilter(filter: FieldFilter) = addFilter(filter.copy())
+
+    /**
+     * Checks if there are unsaved edits to the filters compared to the last saved snapshot. If
+     * no snapshot exists, this returns false.
+     *
+     * @return true if there are unsaved edits, false otherwise
+     */
+    fun hasEdits(): Boolean {
+        val currentWhereClause = _filters.buildWhereClause()
+        val snapshotWhereClause = snapshot.whereClause
+        return currentWhereClause != snapshotWhereClause
     }
 
     /**
@@ -126,46 +128,39 @@ internal class FilterStateManager(
      */
     fun removeFilter(filter: FieldFilter) {
         _filters.remove(filter)
-        buildWhereClause()
     }
 
     /**
      * Saves a snapshot of the current filters to allow restoring later. Use [restoreSnapshot] to revert
-     * to this state.
+     * to this state. This method must be called before making changes to the filters to track edits.
      */
     fun saveSnapshot() {
-        _filters.forEach {
-            it.saveSnapshot()
+        val filtersToSnapshot = _filters.mapNotNull {
+            if (it.isValid()) it.copy() else null
         }
+        filtersToSnapshot.forEach {
+            Log.e("TAG", "saveSnapshot filter: ${it.getQuery()}", )
+        }
+        snapshot = FilterSnapshot(
+            filters = filtersToSnapshot
+        )
+        Log.e("TAG", "saveSnapshot: ${snapshot?.whereClause}", )
     }
 
     /**
-     * Restores the filters to the last saved snapshot state. Use after [saveSnapshot] to revert changes.
+     * Restores the filters to the last saved snapshot state. Use after [saveSnapshot] to revert
+     * changes. If no snapshot exists, this does nothing.
      */
     fun restoreSnapshot() {
-        _filters.forEach {
-            it.restoreSnapshot()
-        }
-        // Restore where clause without notifying edits.
-        buildWhereClause(notifyEdits = false)
+        _filters.clear()
+        _filters.addAll(snapshot.filters)
     }
 }
 
 /**
- * A snapshot of a [FieldFilter]'s state for saving and restoring.
- */
-private data class FieldFilterSnapshot(
-    val field : Field?,
-    val operator : Operator?,
-    val value : String
-)
-
-/**
  * Class representing a filter on a [Field] with a [Operator] and value.
  */
-internal class FieldFilter(
-    private val onFilterChanged : () -> Unit
-) {
+internal class FieldFilter() {
 
     private var _field = mutableStateOf<Field?>(null)
 
@@ -191,15 +186,12 @@ internal class FieldFilter(
     val value: String
         get() = _value.value
 
-
-    private var snapshot : FieldFilterSnapshot? = null
-
     /**
      * Checks if the filter is valid and can be used to generate a query.
      *
      * @return true if the filter is valid, false otherwise
      */
-    private fun isValid(): Boolean {
+    fun isValid(): Boolean {
         val hasField = field != null
         val operator = operator ?: return false
         // For unary operators, value is not required
@@ -215,8 +207,6 @@ internal class FieldFilter(
         _field.value = value
         _operator.value = null // reset operator when field changes
         _value.value = "" // reset value when field changes
-        // Notify that the filter has changed
-        onFilterChanged()
     }
 
     /**
@@ -226,8 +216,6 @@ internal class FieldFilter(
      */
     fun setOperator(value: Operator) {
         _operator.value = value
-        // Notify that the filter has changed
-        onFilterChanged()
     }
 
     /**
@@ -237,8 +225,6 @@ internal class FieldFilter(
      */
     fun setValue(value: String) {
         _value.value = value
-        // Notify that the filter has changed
-        onFilterChanged()
     }
 
     /**
@@ -317,36 +303,15 @@ internal class FieldFilter(
      *
      * @return the copied filter
      */
-    fun copy(
-        onFilterChanged: () -> Unit
-    ): FieldFilter {
-        val newFilter = FieldFilter(onFilterChanged)
-        field?.let { newFilter.setField(it) }
-        operator?.let { newFilter.setOperator(it) }
+    fun copy(): FieldFilter {
+        val newFilter = FieldFilter()
+        _field.value?.let { newFilter.setField(it) }
+        _operator.value?.let { newFilter.setOperator(it) }
         newFilter.setValue(value)
+
+        Log.e("TAG", "copy: ${newFilter._value} - $_value", )
+
         return newFilter
-    }
-
-    /**
-     * Saves a snapshot of the current filter state.
-     */
-    fun saveSnapshot() {
-        snapshot = FieldFilterSnapshot(
-            field = field,
-            operator = operator,
-            value = value
-        )
-    }
-
-    /**
-     * Restores the filter state from the last saved snapshot, if available.
-     */
-    fun restoreSnapshot() {
-        snapshot?.let { snap ->
-            snap.field?.let { setField(it) }
-            snap.operator?.let { setOperator(it) }
-            setValue(snap.value)
-        }
     }
 }
 
@@ -433,3 +398,9 @@ private object FilterOperators {
  */
 internal val Field.fieldName: String
     get() = this.alias.ifEmpty { this.name }
+
+
+internal fun List<FieldFilter>.buildWhereClause(): String {
+    val queries = this.mapNotNull { it.getQuery() }
+    return queries.joinToString(separator = " AND ")
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.screens
 
-import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -78,6 +77,7 @@ import com.arcgismaps.data.Field
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.AddAssociationFromSourceViewModel
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.FieldFilter
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.Operator
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.fieldName
 import kotlinx.coroutines.launch
 
@@ -193,9 +193,8 @@ internal fun FeaturesFilterScreen(
             LazyColumn(state = lazyListState) {
                 itemsIndexed(
                     items = filters,
-                    key = { _, filter -> filter.hashCode() }
+                    key = { _, filter -> filter.id }
                 ) { idx, filter ->
-                    Log.e("TAG", "FeaturesFilterScreen: $filter, ${filter._value}", )
                     FilterItem(
                         name = context.getString(
                             R.string.condition_numbered,
@@ -211,6 +210,24 @@ internal fun FeaturesFilterScreen(
                                 filterStateManager.duplicateFilter(filter)
                                 lazyListState.requestScrollToItem(0)
                             }
+                        },
+                        onFieldChange = {
+                            filterStateManager.updateFilter(
+                                index = idx,
+                                newFilter = filter.withField(it)
+                            )
+                        },
+                        onOperatorChange = {
+                            filterStateManager.updateFilter(
+                                index = idx,
+                                newFilter = filter.withOperator(it)
+                            )
+                        },
+                        onValueChange = {
+                            filterStateManager.updateFilter(
+                                index = idx,
+                                newFilter = filter.withValue(it)
+                            )
                         },
                         modifier = Modifier
                             .fillMaxWidth()
@@ -243,6 +260,9 @@ private fun FilterItem(
     fields: List<Field>,
     onDelete: () -> Unit,
     onDuplicate: () -> Unit,
+    onFieldChange: (Field) -> Unit,
+    onOperatorChange: (Operator) -> Unit,
+    onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var fieldOptionsExpanded by remember { mutableStateOf(false) }
@@ -348,7 +368,7 @@ private fun FilterItem(
                                 DropdownMenuItem(
                                     text = { Text(field.fieldName) },
                                     onClick = {
-                                        filter.setField(field)
+                                        onFieldChange(field)
                                         fieldOptionsExpanded = false
                                     },
                                     leadingIcon = {
@@ -403,7 +423,7 @@ private fun FilterItem(
                                 DropdownMenuItem(
                                     text = { Text(operator.name) },
                                     onClick = {
-                                        filter.setOperator(operator)
+                                        onOperatorChange(operator)
                                         operatorsExpanded = false
                                     }
                                 )
@@ -426,9 +446,7 @@ private fun FilterItem(
                         )
                         TextField(
                             value = filter.value,
-                            onValueChange = {
-                                filter.setValue(it)
-                            },
+                            onValueChange = onValueChange,
                             enabled = filter.field != null,
                             placeholder = {
                                 Text(text = stringResource(R.string.enter_a_value))

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -79,6 +79,8 @@ import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.Ad
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.FieldFilter
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.Operator
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.fieldName
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.getKeyboardType
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.getOperators
 import kotlinx.coroutines.launch
 
 @Composable
@@ -203,7 +205,7 @@ internal fun FeaturesFilterScreen(
                         filter = filter,
                         fields = fields,
                         onDelete = {
-                            filterStateManager.removeFilter(filter)
+                            filterStateManager.removeFilter(idx)
                         },
                         onDuplicate = {
                             Snapshot.withMutableSnapshot {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -41,8 +41,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledTonalButton
@@ -58,11 +58,11 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
@@ -80,7 +80,6 @@ import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.Ad
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.FieldFilter
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.fieldName
 import kotlinx.coroutines.launch
-import java.util.Locale.getDefault
 
 @Composable
 internal fun FeaturesFilterScreen(
@@ -96,7 +95,7 @@ internal fun FeaturesFilterScreen(
     val fields = viewModel.fields
     val lazyListState = rememberLazyListState()
     val context = LocalContext.current
-    var showDiscardDialog by remember {
+    var showDiscardDialog by rememberSaveable {
         mutableStateOf(false)
     }
     Box(modifier = Modifier.fillMaxSize()) {
@@ -110,9 +109,10 @@ internal fun FeaturesFilterScreen(
                     title = stringResource(R.string.filter_features),
                     subTitle = "",
                     onBackPressed = {
-                        if (filterStateManager.hasEdits) {
+                        if (filterStateManager.hasEdits()) {
                             showDiscardDialog = true
                         } else {
+                            filterStateManager.restoreSnapshot()
                             onBackPressed()
                         }
                     },
@@ -134,7 +134,6 @@ internal fun FeaturesFilterScreen(
                         }
                     },
                     modifier = Modifier.padding(horizontal = 16.dp),
-                    enabled = filterStateManager.hasEdits
                 ) {
                     Text(text = stringResource(R.string.apply))
                 }
@@ -196,6 +195,7 @@ internal fun FeaturesFilterScreen(
                     items = filters,
                     key = { _, filter -> filter.hashCode() }
                 ) { idx, filter ->
+                    Log.e("TAG", "FeaturesFilterScreen: $filter, ${filter._value}", )
                     FilterItem(
                         name = context.getString(
                             R.string.condition_numbered,
@@ -346,7 +346,7 @@ private fun FilterItem(
                         ) {
                             fields.forEach { field ->
                                 DropdownMenuItem(
-                                    text = { Text(field.fieldName.uppercase(getDefault())) },
+                                    text = { Text(field.fieldName) },
                                     onClick = {
                                         filter.setField(field)
                                         fieldOptionsExpanded = false
@@ -473,11 +473,17 @@ private fun ConfirmationDialog(
                 Text(text = stringResource(R.string.cancel))
             }
         },
+        icon = {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = "filter icon",
+            )
+        },
         title = {
-            Text(text = "Filters have not been applied")
+            Text(text = stringResource(R.string.filters_not_applied))
         },
         text = {
-            Text(text = "Are you sure you want to discard the changes?")
+            Text(text = stringResource(R.string.discard_changes_confirmation))
         }
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.screens
 
+import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -40,6 +41,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledTonalButton
@@ -55,6 +58,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -68,14 +72,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.arcgismaps.data.Field
-import com.arcgismaps.data.FieldType
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.AddAssociationFromSourceViewModel
-import com.arcgismaps.toolkit.featureforms.internal.utils.isNumeric
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.FieldFilter
+import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.fieldName
 import kotlinx.coroutines.launch
 import java.util.Locale.getDefault
 
@@ -88,10 +91,14 @@ internal fun FeaturesFilterScreen(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     // get filters from the view model
-    val filters = viewModel.attributeFieldFilters
+    val filterStateManager = viewModel.attributeFilterStateManager
+    val filters = filterStateManager.filters
     val fields = viewModel.fields
     val lazyListState = rememberLazyListState()
     val context = LocalContext.current
+    var showDiscardDialog by remember {
+        mutableStateOf(false)
+    }
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = modifier,
@@ -102,7 +109,13 @@ internal fun FeaturesFilterScreen(
                 AddWorkflowTopBar(
                     title = stringResource(R.string.filter_features),
                     subTitle = "",
-                    onBackPressed = onBackPressed,
+                    onBackPressed = {
+                        if (filterStateManager.hasEdits) {
+                            showDiscardDialog = true
+                        } else {
+                            onBackPressed()
+                        }
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f),
@@ -110,7 +123,7 @@ internal fun FeaturesFilterScreen(
                 TextButton(
                     onClick = {
                         scope.launch {
-                            viewModel.applyAttributeFilters()
+                            filterStateManager.applyFilters()
                                 .onSuccess {
                                     onBackPressed()
                                 }.onFailure {
@@ -120,7 +133,8 @@ internal fun FeaturesFilterScreen(
                                 }
                         }
                     },
-                    modifier = Modifier.padding(horizontal = 16.dp)
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    enabled = filterStateManager.hasEdits
                 ) {
                     Text(text = stringResource(R.string.apply))
                 }
@@ -129,7 +143,7 @@ internal fun FeaturesFilterScreen(
             FilledTonalButton(
                 onClick = {
                     Snapshot.withMutableSnapshot {
-                        viewModel.addAttributeFieldFilter(FieldFilter())
+                        filterStateManager.createNewFilter()
                         lazyListState.requestScrollToItem(0)
                     }
                 },
@@ -190,11 +204,11 @@ internal fun FeaturesFilterScreen(
                         filter = filter,
                         fields = fields,
                         onDelete = {
-                            viewModel.deleteAttributeFieldFilter(filter)
+                            filterStateManager.removeFilter(filter)
                         },
                         onDuplicate = {
                             Snapshot.withMutableSnapshot {
-                                viewModel.addAttributeFieldFilter(filter.copy())
+                                filterStateManager.duplicateFilter(filter)
                                 lazyListState.requestScrollToItem(0)
                             }
                         },
@@ -209,6 +223,15 @@ internal fun FeaturesFilterScreen(
         SnackbarHost(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter)
+        )
+    }
+    if (showDiscardDialog) {
+        ConfirmationDialog(
+            onDismissRequest = { showDiscardDialog = false },
+            onConfirmRequest = {
+                filterStateManager.restoreSnapshot()
+                onBackPressed()
+            }
         )
     }
 }
@@ -305,7 +328,7 @@ private fun FilterItem(
                     )
                     Spacer(modifier = Modifier.height(5.dp))
                     Text(
-                        text = filter.field?.name ?: stringResource(R.string.not_set),
+                        text = filter.field?.fieldName ?: stringResource(R.string.not_set),
                         style = MaterialTheme.typography.bodyMedium,
                         color = if (filter.field == null) {
                             Color.Unspecified
@@ -323,7 +346,7 @@ private fun FilterItem(
                         ) {
                             fields.forEach { field ->
                                 DropdownMenuItem(
-                                    text = { Text(field.name.uppercase(getDefault())) },
+                                    text = { Text(field.fieldName.uppercase(getDefault())) },
                                     onClick = {
                                         filter.setField(field)
                                         fieldOptionsExpanded = false
@@ -433,232 +456,28 @@ private fun FilterItem(
     }
 }
 
-/**
- * Class representing a filter on a [Field] with a [Operator] and value.
- */
-internal class FieldFilter() {
-
-    private var _field = mutableStateOf<Field?>(null)
-
-    /**
-     * The field to filter on.
-     */
-    val field: Field?
-        get() = _field.value
-
-    private var _operator = mutableStateOf<Operator?>(null)
-
-    /**
-     * The operator to use for filtering.
-     */
-    val operator: Operator?
-        get() = _operator.value
-
-    private var _value = mutableStateOf("")
-
-    /**
-     * The value to filter on.
-     */
-    val value: String
-        get() = _value.value
-
-    /**
-     * Sets the field for this filter. Resets the operator and value.
-     *
-     * @param value the field to set
-     */
-    fun setField(value: Field) {
-        _field.value = value
-        _operator.value = null // reset operator when field changes
-        _value.value = "" // reset value when field changes
-    }
-
-    /**
-     * Sets the operator for this filter.
-     *
-     * @param value the operator to set
-     */
-    fun setOperator(value: Operator) {
-        _operator.value = value
-    }
-
-    /**
-     * Sets the value for this filter.
-     *
-     * @param value the value to set
-     */
-    fun setValue(value: String) {
-        _value.value = value
-    }
-
-    /**
-     * Gets the list of valid operators for the current field type.
-     *
-     * @return the list of valid operators
-     */
-    fun getOperators(): List<Operator> {
-        val fieldType = field?.fieldType ?: return emptyList()
-        return when {
-            fieldType.isNumeric || fieldType == FieldType.Oid -> FilterOperators.NUMERIC_OPERATORS
-            fieldType == FieldType.Text -> {
-                if (field!!.nullable) {
-                    FilterOperators.TEXT_OPERATORS
-                } else {
-                    FilterOperators.TEXT_OPERATORS + FilterOperators.NULLABLE_OPERATORS
-                }
-            }
-
-            else -> emptyList()
-        }
-    }
-
-    /**
-     * Gets the appropriate keyboard type for the current field type.
-     *
-     * @return the keyboard type
-     */
-    fun getKeyboardType(): KeyboardType {
-        val fieldType = field?.fieldType ?: return KeyboardType.Text
-
-        return when {
-            fieldType.isNumeric -> KeyboardType.Number
-            fieldType == FieldType.Oid -> KeyboardType.Number
-            else -> KeyboardType.Text
-        }
-    }
-
-    /**
-     * Generates the query string for this filter.
-     *
-     * @return the query string or null if the filter is not valid
-     */
-    fun getQuery(): String? {
-        if (isValid().not()) return null
-        val formattedValue = when (field!!.fieldType) {
-            is FieldType.Text -> "'${this.value}'"
-            else -> this.value
-        }
-        val field = this.field!!
-        return when (val operator = this.operator!!) {
-            is Operator.StartsWith -> {
-                "${field.name} ${operator.sign} '${value}%'"
-            }
-
-            is Operator.EndsWith -> {
-                "${field.name} ${operator.sign} '%${value}'"
-            }
-
-            Operator.Contains, Operator.DoesNotContain -> {
-                "${field.name} ${operator.sign} '%${value}%'"
-            }
-
-            is Operator.IsBlank, Operator.IsNotBlank, Operator.IsEmpty, Operator.IsNotEmpty -> {
-                "${field.name} ${operator.sign}"
-            }
-
-            else -> {
-                "${field.name} ${operator.sign} $formattedValue"
-            }
-        }
-    }
-
-    /**
-     * Checks if the filter is valid and can be used to generate a query.
-     *
-     * @return true if the filter is valid, false otherwise
-     */
-    fun isValid(): Boolean {
-        return field != null && operator != null && value.isNotEmpty()
-    }
-
-    /**
-     * Creates a copy of this filter.
-     *
-     * @return the copied filter
-     */
-    fun copy(): FieldFilter {
-        val newFilter = FieldFilter()
-        field?.let { newFilter.setField(it) }
-        operator?.let { newFilter.setOperator(it) }
-        newFilter.setValue(value)
-        return newFilter
-    }
-}
-
-/**
- * Represents an operator that can be used in a [FieldFilter].
- *
- * @param name the display name of the operator.
- * @param sign the sign of the operator used in queries.
- */
-internal sealed class Operator(
-    val name: String,
-    val sign: String
+@Composable
+private fun ConfirmationDialog(
+    onDismissRequest: () -> Unit,
+    onConfirmRequest: () -> Unit
 ) {
-    object Equal : Operator("=", "=")
-    object NotEqual : Operator("!=", "<>")
-    object Is : Operator("is", "=")
-    object IsNot : Operator("is not", "<>")
-    object GreaterThan : Operator(">", ">")
-    object GreaterThanOrEqual : Operator(">=", ">=")
-    object LessThan : Operator("<", "<")
-    object LessThanOrEqual : Operator("<=", "<=")
-    object StartsWith : Operator("starts with", "LIKE")
-    object EndsWith : Operator("ends with", "LIKE")
-    object Contains : Operator("contains the text", "LIKE")
-    object DoesNotContain : Operator("does not contain the text", "not LIKE")
-    object IsBlank : Operator("is blank", "IS NULL")
-    object IsNotBlank : Operator("is not blank", "IS NOT NULL")
-    object IsEmpty : Operator("is empty", "= ''")
-    object IsNotEmpty : Operator("is not empty", "<> ''")
-
-    override fun toString(): String {
-        return sign
-    }
-
-    /**
-     * Checks if the operator is unary (does not require a value).
-     *
-     * @return true if the operator is unary, false otherwise
-     */
-    fun isUnary(): Boolean {
-        return this is IsBlank || this is IsNotBlank || this is IsEmpty || this is IsNotEmpty
-    }
-}
-
-private object FilterOperators {
-
-    /**
-     * The list of operators applicable to numeric fields.
-     */
-    val NUMERIC_OPERATORS = listOf(
-        Operator.Equal,
-        Operator.NotEqual,
-        Operator.GreaterThan,
-        Operator.GreaterThanOrEqual,
-        Operator.LessThan,
-        Operator.LessThanOrEqual
-    )
-
-    /**
-     * The list of operators applicable to text fields.
-     */
-    val TEXT_OPERATORS = listOf(
-        Operator.Is,
-        Operator.IsNot,
-        Operator.StartsWith,
-        Operator.EndsWith,
-        Operator.Contains,
-        Operator.DoesNotContain,
-        Operator.IsEmpty,
-        Operator.IsNotEmpty
-    )
-
-    /**
-     * The list of operators applicable to nullable fields.
-     */
-    val NULLABLE_OPERATORS = listOf(
-        Operator.IsBlank,
-        Operator.IsNotBlank
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(onClick = onConfirmRequest) {
+                Text(text = stringResource(R.string.discard))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.cancel))
+            }
+        },
+        title = {
+            Text(text = "Filters have not been applied")
+        },
+        text = {
+            Text(text = "Are you sure you want to discard the changes?")
+        }
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/SelectAssociatedFeatureScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/SelectAssociatedFeatureScreen.kt
@@ -131,7 +131,10 @@ internal fun SelectAssociatedFeatureScreen(
                 modifier = Modifier.weight(1f)
             )
             IconButton(
-                onClick = onFilter,
+                onClick = {
+                    viewModel.attributeFilterStateManager.saveSnapshot()
+                    onFilter()
+                },
                 modifier = Modifier.padding(end = 16.dp),
                 colors = IconButtonDefaults.iconButtonColors(
                     containerColor = if (viewModel.areAttributeFiltersApplied) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UNAssociationsFilterResultScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/UNAssociationsFilterResultScreen.kt
@@ -144,9 +144,6 @@ internal fun UNAssociationsFilterResultScreen(
         AddActionSheet(
             onDismissRequest = { showAddAssociationAction = false },
             sheetState = sheetState,
-            onSelectFromMap = {
-                // Currently not supported
-            },
             onSelectFromNetworkDataSource = {
                 scope.launch { sheetState.hide() }.invokeOnCompletion {
                     if (!sheetState.isVisible) {
@@ -162,7 +159,6 @@ internal fun UNAssociationsFilterResultScreen(
 @Composable
 private fun AddActionSheet(
     onDismissRequest: () -> Unit,
-    onSelectFromMap: () -> Unit,
     onSelectFromNetworkDataSource: () -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState()
 ) {
@@ -171,29 +167,6 @@ private fun AddActionSheet(
         onDismissRequest = onDismissRequest
     ) {
         Column(modifier = Modifier.padding(vertical = 16.dp)) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(enabled = false) {
-                        onSelectFromMap()
-                    }
-                    .padding(horizontal = 32.dp)
-                    .height(52.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                CompositionLocalProvider(
-                    LocalContentColor provides MaterialTheme.colorScheme.onSurface.copy(
-                        alpha = 0.38f
-                    )
-                ) {
-                    Icon(Icons.Outlined.Map, contentDescription = "On Map")
-                    Spacer(modifier = Modifier.padding(horizontal = 8.dp))
-                    Text(
-                        text = stringResource(R.string.on_map),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                }
-            }
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -284,5 +257,5 @@ private fun PreviewAddActionSheet() {
         confirmValueChange = { true },
         initialValue = SheetValue.Expanded,
     )
-    AddActionSheet({}, {}, {}, sheetState = sheetState)
+    AddActionSheet({}, {}, sheetState = sheetState)
 }

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -177,4 +177,6 @@
     <string name="field">Field</string>
     <string name="not_set">Not Set</string>
     <string name="value">Value</string>
+    <string name="filters_not_applied">Filters have not been applied</string>
+    <string name="discard_changes_confirmation">Are you sure you want to discard the changes?</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/1580](https://devtopia.esri.com/runtime/apollo/issues/1580)

<!-- link to design, if applicable -->

### Description:

This PR refines the attribute filtering behavior to ensure the filters visible is always consistent with the list of feature candidates displayed. The updated behavior follows the description specified in the linked issue.

### Summary of changes:

- To ensure all the attribute filter management is encapsulated a new `FilterStateManager` class is introduced instead of adding more logic to the view model. This class is responsible for managing the filters, saving and restoring the edit state of the filters.
- `FieldFilter` is now immutable and any mutations are handled by the `FilterStateManager`. This ensures consistent state management (and in hindsight this should have been immutable to begin with).

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1108/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  