### PR TITLE
Add support for coded value domain to features filter

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -759,9 +759,6 @@ private fun List<Field>.getSupportedFields(): List<Field> {
     return filter { field ->
         field.fieldType == FieldType.Text ||
             field.fieldType == FieldType.Oid ||
-            field.fieldType.isNumeric &&
-            // Exclude fields with coded value domains until we support selection from coded values
-            field.domain !is CodedValueDomain
-
+            field.fieldType.isNumeric
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
@@ -71,6 +72,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.arcgismaps.data.CodedValue
 import com.arcgismaps.data.CodedValueDomain
 import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType
@@ -235,6 +237,7 @@ private fun FilterItem(
     val focusManager = LocalFocusManager.current
     // The value field is only visible if the operator is not unary or if no operator is selected yet
     val isFieldVisible = filter.operator?.isUnary()?.not() ?: true
+    var selectedName by rememberSaveable { mutableStateOf<String?>(null) }
 
     Column(modifier = modifier) {
         Row(
@@ -404,31 +407,14 @@ private fun FilterItem(
                         )
                         if (filter.field?.domain is CodedValueDomain) {
                             val domain = filter.field?.domain as CodedValueDomain
-                            var expanded by remember { mutableStateOf(false) }
-                            Box {
-                                Text(
-                                    text = domain.codedValues.find { it.code.toString() == filter.value }?.name
-                                        ?: stringResource(R.string.enter_a_value),
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable { expanded = true }
-                                        .padding(16.dp)
-                                )
-                                DropdownMenu(
-                                    expanded = expanded,
-                                    onDismissRequest = { expanded = false }
-                                ) {
-                                    domain.codedValues.forEach { codedValue ->
-                                        DropdownMenuItem(
-                                            text = { Text(codedValue.name) },
-                                            onClick = {
-                                                filter.setValue(codedValue.code.toString())
-                                                expanded = false
-                                            }
-                                        )
-                                    }
-                                }
-                            }
+                            CodedValueDropdownMenu(
+                                selectedName = selectedName,
+                                onSelectedNameChange = { selectedName = it },
+                                selectedValue = filter.value,
+                                onValueChange = { filter.setValue(it) },
+                                defaultLabel = stringResource(R.string.enter_a_value),
+                                items = domain.codedValues
+                            )
                         } else {
                             TextField(
                                 value = filter.value,
@@ -452,6 +438,51 @@ private fun FilterItem(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CodedValueDropdownMenu(
+    selectedName: String?,
+    onSelectedNameChange: (String) -> Unit,
+    selectedValue: String,
+    onValueChange: (String) -> Unit,
+    defaultLabel: String,
+    items: List<CodedValue>,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        Text(
+            text = selectedName ?: defaultLabel,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = true }
+                .padding(vertical = 14.dp),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            items.forEach { codedValue ->
+                DropdownMenuItem(
+                    text = { Text(codedValue.name) },
+                    onClick = {
+                        onValueChange(codedValue.code.toString())
+                        onSelectedNameChange(codedValue.name)
+                        expanded = false
+                    },
+                    leadingIcon = {
+                        if (selectedValue == codedValue.code.toString()) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = "selected"
+                            )
+                        }
+                    }
+                )
             }
         }
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.arcgismaps.data.CodedValueDomain
 import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.toolkit.featureforms.R
@@ -401,31 +402,54 @@ private fun FilterItem(
                             text = stringResource(R.string.value),
                             style = MaterialTheme.typography.bodyLarge
                         )
-                        TextField(
-                            value = filter.value,
-                            onValueChange = {
-                                filter.setValue(it)
-                            },
-                            enabled = filter.field != null,
-                            placeholder = {
-                                Text(text = stringResource(R.string.enter_a_value))
-                            },
-                            colors = TextFieldDefaults.colors(
-                                unfocusedContainerColor = Color.Transparent,
-                                focusedContainerColor = Color.Transparent,
-                                disabledContainerColor = Color.Transparent,
-                            ),
-                            modifier = Modifier.fillMaxWidth(),
-                            keyboardOptions = KeyboardOptions.Default.copy(
-                                keyboardType = keyboardType,
-                                imeAction = ImeAction.Done,
-                            ),
-                            keyboardActions = KeyboardActions(
-                                onDone = {
-                                    focusManager.clearFocus()
+                        if (filter.field?.domain is CodedValueDomain) {
+                            val domain = filter.field?.domain as CodedValueDomain
+                            var expanded by remember { mutableStateOf(false) }
+                            Box {
+                                Text(
+                                    text = domain.codedValues.find { it.code.toString() == filter.value }?.name
+                                        ?: stringResource(R.string.enter_a_value),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable { expanded = true }
+                                        .padding(16.dp)
+                                )
+                                DropdownMenu(
+                                    expanded = expanded,
+                                    onDismissRequest = { expanded = false }
+                                ) {
+                                    domain.codedValues.forEach { codedValue ->
+                                        DropdownMenuItem(
+                                            text = { Text(codedValue.name) },
+                                            onClick = {
+                                                filter.setValue(codedValue.code.toString())
+                                                expanded = false
+                                            }
+                                        )
+                                    }
                                 }
+                            }
+                        } else {
+                            TextField(
+                                value = filter.value,
+                                onValueChange = { filter.setValue(it) },
+                                enabled = filter.field != null,
+                                placeholder = { Text(text = stringResource(R.string.enter_a_value)) },
+                                colors = TextFieldDefaults.colors(
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedContainerColor = Color.Transparent,
+                                    disabledContainerColor = Color.Transparent,
+                                ),
+                                modifier = Modifier.fillMaxWidth(),
+                                keyboardOptions = KeyboardOptions.Default.copy(
+                                    keyboardType = keyboardType,
+                                    imeAction = ImeAction.Done,
+                                ),
+                                keyboardActions = KeyboardActions(
+                                    onDone = { focusManager.clearFocus() }
+                                )
                             )
-                        )
+                        }
                     }
                 }
             }
@@ -499,6 +523,7 @@ internal class FieldFilter() {
     fun getOperators(): List<Operator> {
         val fieldType = field?.fieldType ?: return emptyList()
         return when {
+            fieldType.isNumeric && field!!.domain is CodedValueDomain -> FilterOperators.EQUALITY_OPERATORS
             fieldType.isNumeric || fieldType == FieldType.Oid -> FilterOperators.NUMERIC_OPERATORS
             fieldType == FieldType.Text -> {
                 if (field!!.nullable) {
@@ -627,6 +652,15 @@ internal sealed class Operator(
 }
 
 private object FilterOperators {
+
+    /**
+     * The list of operators applicable to fields where we just need to check for equality.
+     * Ex. coded value domain fields.
+     */
+    val EQUALITY_OPERATORS = listOf(
+        Operator.Equal,
+        Operator.NotEqual,
+    )
 
     /**
      * The list of operators applicable to numeric fields.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -281,7 +281,6 @@ private fun FilterItem(
     val focusManager = LocalFocusManager.current
     // The value field is only visible if the operator is not unary or if no operator is selected yet
     val isFieldVisible = filter.operator?.isUnary()?.not() ?: true
-    var selectedName by rememberSaveable { mutableStateOf<String?>(null) }
 
     Column(modifier = modifier) {
         Row(
@@ -452,14 +451,11 @@ private fun FilterItem(
                         if (filter.field?.domain is CodedValueDomain) {
                             val domain = filter.field.domain as CodedValueDomain
                             CodedValueDropdownMenu(
-                                selectedName = selectedName,
-                                onSelectedNameChange = { selectedName = it },
                                 selectedValue = filter.value,
                                 onValueChange = onValueChange,
                                 defaultLabel = stringResource(R.string.enter_a_value),
                                 items = domain.codedValues
                             )
-
                         } else {
                             TextField(
                                 value = filter.value,
@@ -494,8 +490,6 @@ private fun FilterItem(
 
 @Composable
 private fun CodedValueDropdownMenu(
-    selectedName: String?,
-    onSelectedNameChange: (String) -> Unit,
     selectedValue: String,
     onValueChange: (String) -> Unit,
     defaultLabel: String,
@@ -504,7 +498,8 @@ private fun CodedValueDropdownMenu(
     var expanded by remember { mutableStateOf(false) }
     Box {
         Text(
-            text = selectedName ?: defaultLabel,
+            text = items.find { it.code.toString() == selectedValue }?.name
+                ?: defaultLabel,
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable { expanded = true }
@@ -520,7 +515,6 @@ private fun CodedValueDropdownMenu(
                     text = { Text(codedValue.name) },
                     onClick = {
                         onValueChange(codedValue.code.toString())
-                        onSelectedNameChange(codedValue.name)
                         expanded = false
                     },
                     leadingIcon = {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/apollo/issues/1579

<!-- link to design, if applicable -->

### Description:

Add support for filtering features based on fields of the type coded value domain

### Summary of changes:

- Add `DropdownMenu` for showing Coded valued domains

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1110/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  