### PR TITLE
Update logic to determine the domains based on feature subtypes

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork
 
+import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -26,6 +27,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.arcgismaps.data.ArcGISFeatureTable
 import com.arcgismaps.data.CodedValueDomain
 import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType
@@ -48,6 +50,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlin.text.get
 
 /**
  * A [ViewModel] that manages the state for adding utility associations from a selected feature
@@ -289,9 +292,31 @@ internal class AddAssociationFromSourceViewModel(
                         assetType = assetType
                     ).onSuccess { result ->
                         // Get the available fields from the table
-                        result.candidates.firstOrNull()?.feature?.featureTable?.fields?.let { fields ->
-                            _fields.value = fields.getSupportedFields()
+                        val featureTable = result.candidates.firstOrNull()?.feature?.featureTable
+                        val tempFields = mutableListOf<Field>()
+                        featureTable?.fields?.let { fields ->
+//                            _fields.value = fields.getSupportedFields()
+                            tempFields.addAll(fields.getSupportedFields())
                         }
+                        if (tempFields.isNotEmpty()) {
+                            var subtypes = (featureTable as ArcGISFeatureTable).featureSubtypes
+                            for (subtype in subtypes) {
+                                subtype.fieldOverrides.forEach { overrideField ->
+                                    val index = tempFields.indexOfFirst {
+                                        it.name.equals(overrideField.name, ignoreCase = true)
+                                    }
+                                    if (index != -1 && overrideField.domain != null) {
+                                        Log.d(
+                                            "AddAssocViewModel",
+                                            "Updating field: ${tempFields[index].name} with override: ${overrideField.name}"
+                                        )
+                                        tempFields[index] = overrideField
+                                    }
+                                }
+                            }
+                        }
+                        _fields.value = tempFields
+
                         _featureCandidatesUiState.value = FeatureCandidatesUiState(
                             isLoading = false,
                             candidates = result.candidates,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -291,7 +291,7 @@ internal class AddAssociationFromSourceViewModel(
                         // Get the first feature from the results to extract the fields and the subtype
                         val firstFeature = result.candidates.firstOrNull()?.feature
                         // Get the available fields from the table
-                        _fields.value = firstFeature?.featureTable?.fields?.getSupportedFields(firstFeature) ?: emptyList()
+                        _fields.value = firstFeature?.getSupportedFields() ?: emptyList()
 
                         _featureCandidatesUiState.value = FeatureCandidatesUiState(
                             isLoading = false,
@@ -724,13 +724,14 @@ internal fun UtilityTerminalConfiguration?.getTerminalById(id: Int): UtilityTerm
 }
 
 /**
- * Filters the list of [Field] objects to include only those that are supported for attribute
- * filtering.
+ * Gets the list of [Field] objects associated with the feature and filters it to include only those
+ * that are supported for attribute filtering.
  * Supported fields are those of type Text, Oid, or Numeric. Additionally, if the feature has a
  * feature subtype with field overrides, those overrides are applied to the corresponding fields.
  */
-private fun List<Field>.getSupportedFields(feature: ArcGISFeature): List<Field> {
-    val fieldMap = filterNot {
+private fun ArcGISFeature.getSupportedFields(): List<Field> {
+    val fields = this.featureTable?.fields ?: return emptyList()
+    val fieldMap = fields.filterNot {
         // Exclude ASSETGROUP and ASSETTYPE fields from filtering as the features are already
         // filtered by the selected asset type
         it.name.equals("ASSETGROUP", ignoreCase = true) || it.name.equals("ASSETTYPE", ignoreCase = true)
@@ -743,7 +744,7 @@ private fun List<Field>.getSupportedFields(feature: ArcGISFeature): List<Field> 
         .toMutableMap()
 
     // Apply any subtype overrides to the fields
-    feature.getFeatureSubtype()?.fieldOverrides?.forEach { overrideField ->
+    this.getFeatureSubtype()?.fieldOverrides?.forEach { overrideField ->
         val key = overrideField.name.lowercase()
         if (fieldMap.containsKey(key) && overrideField.domain != null) {
             fieldMap[key] = overrideField

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -655,6 +655,8 @@ internal class AddAssociationFromSourceViewModel(
     }
 
     private fun filterFieldsAndApplySubtypeOverrides(fields: List<Field>, subtype: FeatureSubtype): List<Field> {
+        // Exclude ASSETGROUP and ASSETTYPE fields from filtering as the features are already
+        // filtered by the selected asset type
         val filteredFields = fields.filterNot {
             it.name.equals("ASSETGROUP", ignoreCase = true) ||
                     it.name.equals("ASSETTYPE", ignoreCase = true)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -27,8 +27,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.arcgismaps.data.ArcGISFeatureTable
 import com.arcgismaps.data.CodedValueDomain
+import com.arcgismaps.data.FeatureSubtype
 import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.data.QueryParameters
@@ -50,7 +50,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlin.text.get
 
 /**
  * A [ViewModel] that manages the state for adding utility associations from a selected feature
@@ -291,31 +290,16 @@ internal class AddAssociationFromSourceViewModel(
                     source.queryFeatures(
                         assetType = assetType
                     ).onSuccess { result ->
+                        // Get the first feature from the results to extract the fields and the subtype
+                        val firstFeature = result.candidates.firstOrNull()?.feature
                         // Get the available fields from the table
-                        val featureTable = result.candidates.firstOrNull()?.feature?.featureTable
-                        val tempFields = mutableListOf<Field>()
-                        featureTable?.fields?.let { fields ->
-//                            _fields.value = fields.getSupportedFields()
-                            tempFields.addAll(fields.getSupportedFields())
-                        }
-                        if (tempFields.isNotEmpty()) {
-                            var subtypes = (featureTable as ArcGISFeatureTable).featureSubtypes
-                            for (subtype in subtypes) {
-                                subtype.fieldOverrides.forEach { overrideField ->
-                                    val index = tempFields.indexOfFirst {
-                                        it.name.equals(overrideField.name, ignoreCase = true)
-                                    }
-                                    if (index != -1 && overrideField.domain != null) {
-                                        Log.d(
-                                            "AddAssocViewModel",
-                                            "Updating field: ${tempFields[index].name} with override: ${overrideField.name}"
-                                        )
-                                        tempFields[index] = overrideField
-                                    }
-                                }
-                            }
-                        }
-                        _fields.value = tempFields
+                        val supportedFields = firstFeature?.featureTable?.fields?.getSupportedFields() ?: emptyList()
+                        // Apply any subtype overrides to the fields
+                        val subtype = firstFeature?.getFeatureSubtype()
+                        _fields.value = if (subtype != null)
+                            filterFieldsAndApplySubtypeOverrides(supportedFields, subtype)
+                        else
+                            supportedFields
 
                         _featureCandidatesUiState.value = FeatureCandidatesUiState(
                             isLoading = false,
@@ -670,6 +654,21 @@ internal class AddAssociationFromSourceViewModel(
                 result.exceptionOrNull() ?: Exception("Unknown error")
             )
         }
+    }
+
+    private fun filterFieldsAndApplySubtypeOverrides(fields: List<Field>, subtype: FeatureSubtype): List<Field> {
+        val filteredFields = fields.filterNot {
+            it.name.equals("ASSETGROUP", ignoreCase = true) ||
+                    it.name.equals("ASSETTYPE", ignoreCase = true)
+        }.toMutableList()
+
+        subtype.fieldOverrides.forEach { overrideField ->
+            val index = filteredFields.indexOfFirst { it.name.equals(overrideField.name, ignoreCase = true) }
+            if (index != -1 && overrideField.domain != null) {
+                filteredFields[index] = overrideField
+            }
+        }
+        return filteredFields
     }
 
     companion object {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork
 
-import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -27,7 +26,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.arcgismaps.data.CodedValueDomain
 import com.arcgismaps.data.FeatureSubtype
 import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -731,13 +731,13 @@ internal fun UtilityTerminalConfiguration?.getTerminalById(id: Int): UtilityTerm
  */
 private fun ArcGISFeature.getSupportedFields(): List<Field> {
     val fields = this.featureTable?.fields ?: return emptyList()
-    val fieldMap = fields.filterNot {
-        // Exclude ASSETGROUP and ASSETTYPE fields from filtering as the features are already
-        // filtered by the selected asset type
-        it.name.equals("ASSETGROUP", ignoreCase = true) || it.name.equals("ASSETTYPE", ignoreCase = true)
-        }
+    val fieldMap = fields
         .filter {
-            it.fieldType == FieldType.Text || it.fieldType == FieldType.Oid || it.fieldType.isNumeric
+            (it.fieldType == FieldType.Text ||
+                    it.fieldType == FieldType.Oid ||
+                    it.fieldType.isNumeric) &&
+                    !it.name.equals("ASSETGROUP", ignoreCase = true) &&
+                    !it.name.equals("ASSETTYPE", ignoreCase = true)
         }
         .associateBy { it.name.lowercase() }
         // Convert list to map for efficient lookup and replacement

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -26,7 +26,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.arcgismaps.data.FeatureSubtype
+import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.data.QueryParameters
@@ -291,13 +291,7 @@ internal class AddAssociationFromSourceViewModel(
                         // Get the first feature from the results to extract the fields and the subtype
                         val firstFeature = result.candidates.firstOrNull()?.feature
                         // Get the available fields from the table
-                        val supportedFields = firstFeature?.featureTable?.fields?.getSupportedFields() ?: emptyList()
-                        // Apply any subtype overrides to the fields
-                        val subtype = firstFeature?.getFeatureSubtype()
-                        _fields.value = if (subtype != null)
-                            filterFieldsAndApplySubtypeOverrides(supportedFields, subtype)
-                        else
-                            supportedFields
+                        _fields.value = firstFeature?.featureTable?.fields?.getSupportedFields(firstFeature) ?: emptyList()
 
                         _featureCandidatesUiState.value = FeatureCandidatesUiState(
                             isLoading = false,
@@ -654,23 +648,6 @@ internal class AddAssociationFromSourceViewModel(
         }
     }
 
-    private fun filterFieldsAndApplySubtypeOverrides(fields: List<Field>, subtype: FeatureSubtype): List<Field> {
-        // Exclude ASSETGROUP and ASSETTYPE fields from filtering as the features are already
-        // filtered by the selected asset type
-        val filteredFields = fields.filterNot {
-            it.name.equals("ASSETGROUP", ignoreCase = true) ||
-                    it.name.equals("ASSETTYPE", ignoreCase = true)
-        }.toMutableList()
-
-        subtype.fieldOverrides.forEach { overrideField ->
-            val index = filteredFields.indexOfFirst { it.name.equals(overrideField.name, ignoreCase = true) }
-            if (index != -1 && overrideField.domain != null) {
-                filteredFields[index] = overrideField
-            }
-        }
-        return filteredFields
-    }
-
     companion object {
         fun Factory(
             featureForm: FeatureForm,
@@ -749,11 +726,28 @@ internal fun UtilityTerminalConfiguration?.getTerminalById(id: Int): UtilityTerm
 /**
  * Filters the list of [Field] objects to include only those that are supported for attribute
  * filtering.
+ * Supported fields are those of type Text, Oid, or Numeric. Additionally, if the feature has a
+ * feature subtype with field overrides, those overrides are applied to the corresponding fields.
  */
-private fun List<Field>.getSupportedFields(): List<Field> {
-    return filter { field ->
-        field.fieldType == FieldType.Text ||
-            field.fieldType == FieldType.Oid ||
-            field.fieldType.isNumeric
+private fun List<Field>.getSupportedFields(feature: ArcGISFeature): List<Field> {
+    val fieldMap = filterNot {
+        // Exclude ASSETGROUP and ASSETTYPE fields from filtering as the features are already
+        // filtered by the selected asset type
+        it.name.equals("ASSETGROUP", ignoreCase = true) || it.name.equals("ASSETTYPE", ignoreCase = true)
+        }
+        .filter {
+            it.fieldType == FieldType.Text || it.fieldType == FieldType.Oid || it.fieldType.isNumeric
+        }
+        .associateBy { it.name.lowercase() }
+        // Convert list to map for efficient lookup and replacement
+        .toMutableMap()
+
+    // Apply any subtype overrides to the fields
+    feature.getFeatureSubtype()?.fieldOverrides?.forEach { overrideField ->
+        val key = overrideField.name.lowercase()
+        if (fieldMap.containsKey(key) && overrideField.domain != null) {
+            fieldMap[key] = overrideField
+        }
     }
+    return fieldMap.values.toList()
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/apollo/issues/1579

<!-- link to design, if applicable -->

### Description:

Adds logic to update the field list based on the feature subtype overrides

### Summary of changes:

- Exclude `AssetGroup` and `AssetType` from the field list 
- Add logic to determine the subtype from the query result feature and override the field list with the field overrides provided by the subtype

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1119/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  