### PR TITLE
Wire test fixtures into geoviewcompose

### DIFF
--- a/toolkit/geoview-compose/build.gradle.kts
+++ b/toolkit/geoview-compose/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("artifact-deploy")
+    id("grant-test-permissions")
     alias(libs.plugins.binary.compatibility.validator) apply true
 }
 kotlin {
@@ -33,7 +34,7 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-
+        testApplicationId = "com.arcgismaps.toolkit.geoviewcompose.test"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
@@ -73,6 +74,34 @@ android {
             // This is the default variant.
         }
     }
+
+    val toolkitTests = project.findProperty("toolkitTestDir") as String
+    sourceSets.getByName("androidTest") {
+        var file = file("$toolkitTests/${project.name}/androidTest")
+        if (file.exists()) {
+            java.setSrcDirs(java.srcDirs.plus(file))
+        }
+    }
+
+    sourceSets.getByName("test") {
+        var file = file("$toolkitTests/${project.name}/test")
+        if (file.exists()) {
+            java.setSrcDirs(java.srcDirs.plus(file))
+        }
+    }
+}
+
+grantTestPermissionsConfig {
+    packageName.set(android.defaultConfig.testApplicationId)
+    adbPath.set(android.adbExecutable.absoluteFile)
+    permissions.set(
+        listOf(
+            "android.permission.CAMERA",
+            "android.permission.WRITE_EXTERNAL_STORAGE",
+            "android.permission.READ_EXTERNAL_STORAGE",
+            "android.permission.MANAGE_EXTERNAL_STORAGE"
+        )
+    )
 }
 
 dependencies {
@@ -85,4 +114,9 @@ dependencies {
     androidTestImplementation(libs.bundles.composeTest)
     androidTestImplementation(libs.androidx.uiautomator)
     debugImplementation(libs.bundles.debug)
+
+    // Include only if internal tests are required
+    if (file(project.findProperty("toolkitTestDir") as String).exists()) {
+        androidTestImplementation(arcgis.mapsSdkTestFixtures)
+    }
 }

--- a/toolkit/geoview-compose/src/androidTest/AndroidManifest.xml
+++ b/toolkit/geoview-compose/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Note: this manifest is only applied to instrumented tests -->
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+
+</manifest>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#7188](https://devtopia.esri.com/runtime/kotlin/issues/7188)

<!-- link to design, if applicable -->

### Description:

Update `build.gradle.kts (:geoview-compose)` to consume `testFixtures` and grant test permissions

### Summary of changes:

- Update `build.gradle.kts (:geoview-compose)`
- Create `AndroidManifes.xml`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  