### PR TITLE
Add support for date fields to features filter

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateUtil.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateUtil.kt
@@ -19,6 +19,8 @@
 package com.arcgismaps.toolkit.featureforms.internal.components.datetime
 
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -79,6 +81,25 @@ internal fun Instant.formattedDateTime(includeTime: Boolean): String {
         DateTimeFormatter.ofPattern("MMM dd, yyyy")
     }
     return atZone(TimeZone.getDefault().toZoneId()).format(formatter)
+}
+
+/**
+ * Parses a string to an Instant
+ *
+ * @param includeTime whether the time component is included in the string
+ * @return the parsed Instant or null if the string is blank
+ * @since 300.0.0
+ */
+internal fun String.toInstant(includeTime: Boolean): Instant? {
+    if (this.isBlank())
+        return null
+    val formatter = if (includeTime) {
+        DateTimeFormatter.ofPattern("MMM dd, yyyy h:mm a")
+    } else {
+        DateTimeFormatter.ofPattern("MMM dd, yyyy")
+    }
+    val localDate = LocalDate.parse(this, formatter)
+    return localDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
 }
 
 /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateUtil.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateUtil.kt
@@ -98,8 +98,12 @@ internal fun String.toInstant(includeTime: Boolean): Instant? {
     } else {
         DateTimeFormatter.ofPattern("MMM dd, yyyy")
     }
-    val localDate = LocalDate.parse(this, formatter)
-    return localDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
+    return try {
+        val localDate = LocalDate.parse(this, formatter)
+        localDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
+    } catch (e: Exception) {
+        null
+    }
 }
 
 /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -26,7 +26,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.arcgismaps.data.CodedValueDomain
 import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.data.QueryParameters
@@ -731,7 +730,7 @@ private fun List<Field>.getSupportedFields(): List<Field> {
         field.fieldType == FieldType.Text ||
                 field.fieldType == FieldType.Oid ||
                 field.fieldType.isNumeric ||
-            field.fieldType == FieldType.Date
-//            field.fieldType == FieldType.DateOnly
+                field.fieldType == FieldType.Date ||
+                field.fieldType == FieldType.DateOnly
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -729,7 +729,9 @@ internal fun UtilityTerminalConfiguration?.getTerminalById(id: Int): UtilityTerm
 private fun List<Field>.getSupportedFields(): List<Field> {
     return filter { field ->
         field.fieldType == FieldType.Text ||
-            field.fieldType == FieldType.Oid ||
-            field.fieldType.isNumeric
+                field.fieldType == FieldType.Oid ||
+                field.fieldType.isNumeric ||
+            field.fieldType == FieldType.Date
+//            field.fieldType == FieldType.DateOnly
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -236,6 +236,7 @@ internal fun FieldFilter.getOperators(): List<Operator> {
                 FilterOperators.TEXT_OPERATORS + FilterOperators.NULLABLE_OPERATORS
             }
         }
+        fieldType == FieldType.Date -> FilterOperators.EQUALITY_OPERATORS
 
         else -> emptyList()
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -266,6 +266,8 @@ internal fun FieldFilter.getQuery(): String? {
     if (isValid().not()) return null
     val formattedValue = when (field!!.fieldType) {
         is FieldType.Text -> "'${this.value}'"
+        is FieldType.Date -> "TIMESTAMP '${this.value}'"
+        is FieldType.DateOnly -> "DATE '${this.value}'"
         else -> this.value
     }
     return when (val operator = this.operator!!) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -236,7 +236,7 @@ internal fun FieldFilter.getOperators(): List<Operator> {
                 FilterOperators.TEXT_OPERATORS + FilterOperators.NULLABLE_OPERATORS
             }
         }
-        fieldType == FieldType.Date -> FilterOperators.EQUALITY_OPERATORS
+        fieldType == FieldType.Date || fieldType == FieldType.DateOnly -> FilterOperators.EQUALITY_OPERATORS
 
         else -> emptyList()
     }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -266,8 +266,8 @@ internal fun FieldFilter.getQuery(): String? {
     if (isValid().not()) return null
     val formattedValue = when (field!!.fieldType) {
         is FieldType.Text -> "'${this.value}'"
-        is FieldType.Date -> "TIMESTAMP '${this.value}'"
-        is FieldType.DateOnly -> "DATE '${this.value}'"
+        is FieldType.Date -> "timestamp '${this.value}'"
+        is FieldType.DateOnly -> "date '${this.value}'"
         else -> this.value
     }
     return when (val operator = this.operator!!) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -18,6 +18,9 @@ package com.arcgismaps.toolkit.featureforms.internal.screens
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,10 +41,14 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DisplayMode
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledTonalButton
@@ -56,6 +63,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -67,6 +75,8 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -76,7 +86,13 @@ import androidx.compose.ui.unit.dp
 import com.arcgismaps.data.CodedValue
 import com.arcgismaps.data.CodedValueDomain
 import com.arcgismaps.data.Field
+import com.arcgismaps.data.FieldType
 import com.arcgismaps.toolkit.featureforms.R
+import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
+import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePicker
+import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerInput
+import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerStyle
+import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.rememberDateTimePickerState
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.AddAssociationFromSourceViewModel
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.FieldFilter
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.Operator
@@ -84,6 +100,10 @@ import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.fi
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.getKeyboardType
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.getOperators
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.time.Instant
+import java.util.Date
+import java.util.Locale
 
 @Composable
 internal fun FeaturesFilterScreen(
@@ -281,6 +301,9 @@ private fun FilterItem(
     val focusManager = LocalFocusManager.current
     // The value field is only visible if the operator is not unary or if no operator is selected yet
     val isFieldVisible = filter.operator?.isUnary()?.not() ?: true
+    var showDatePicker by rememberSaveable {
+        mutableStateOf(false)
+    }
 
     Column(modifier = modifier) {
         Row(
@@ -456,7 +479,96 @@ private fun FilterItem(
                                 defaultLabel = stringResource(R.string.enter_a_value),
                                 items = domain.codedValues
                             )
-                        } else {
+                        } else if (filter.field?.fieldType == FieldType.Date) {
+//                            if (showDatePicker) {
+//                                DatePickerModalInput(
+//                                    onDateSelected = { epochMillis ->
+//                                        val valueString = epochMillis?.toString() ?: ""
+//                                        onValueChange(valueString)
+//                                        showDatePicker = false
+//                                    },
+//                                    onDismiss = {
+//                                        // no-op
+//                                        showDatePicker = false
+//                                    }
+//                                )
+//                            }
+                            var selectedDate by remember { mutableStateOf<Long?>(null) }
+                            var showModal by remember { mutableStateOf(false) }
+                            val pickerState = rememberDateTimePickerState(
+                                DateTimePickerStyle.Date,
+                                label = filter.field.alias,
+                                pickerInput = DateTimePickerInput.Date,
+                                initialError = ValidationErrorState.NoError
+                            )
+
+                            TextField(
+//                                value = selectedDate?.let { convertMillisToDate(it) } ?: "",
+//                                value = if (filter.value.isNotEmpty()) convertMillisToDate(filter.value.toLong()) else "",
+                                value = filter.value,
+                                onValueChange = onValueChange,
+                                label = { Text("Enter a date") },
+                                placeholder = { Text("MM/DD/YYYY") },
+                                colors = TextFieldDefaults.colors(
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedContainerColor = Color.Transparent,
+                                    disabledContainerColor = Color.Transparent,
+                                ),
+                                trailingIcon = {
+                                    Icon(Icons.Default.DateRange, contentDescription = "Select date")
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+//                                    .clickable { showModal = true }
+                                    .pointerInput(selectedDate) {
+                                        awaitEachGesture {
+                                            // Modifier.clickable doesn't work for text fields, so we use Modifier.pointerInput
+                                            // in the Initial pass to observe events before the text field consumes them
+                                            // in the Main pass.
+                                            awaitFirstDown(pass = PointerEventPass.Initial)
+                                            val upEvent =
+                                                waitForUpOrCancellation(pass = PointerEventPass.Initial)
+                                            if (upEvent != null) {
+                                                showModal = true
+                                            }
+                                        }
+                                    }
+                            )
+
+                            if (showModal) {
+//                                DatePickerModal(
+//                                    onDateSelected = { selectedDate = it },
+//                                    onDismiss = { showModal = false }
+//                                )
+
+                                DateTimePicker(
+                                    pickerState,
+                                    { showModal = false},
+                                    { showModal = false },
+                                    onConfirmed = {
+//                                        onValueChange(pickerState.selectedDateTimeMillis?.let {
+//                                            Instant.ofEpochMilli(it).toEpochMilli().
+//                                        })
+
+//                                            val valueString = it?.let { convertMillisToDate(it) } ?: ""
+////                                            onValueChange(valueString)
+                                        val valueString = pickerState.selectedDateTimeMillis?.let {
+                                            Instant.ofEpochMilli(it)
+                                        }
+                                        onValueChange(valueString?.toString() ?: "")
+
+
+//                                        selectedDate = pickerState.selectedDateTimeMillis?.let {
+//                                            Instant.ofEpochMilli(it).toEpochMilli()
+//                                        }
+                                        showModal = false
+                                    }
+                                )
+
+                            }
+
+                        }
+                        else {
                             TextField(
                                 value = filter.value,
                                 onValueChange = onValueChange,
@@ -560,4 +672,63 @@ private fun ConfirmationDialog(
             Text(text = stringResource(R.string.discard_changes_confirmation))
         }
     )
+}
+
+@Composable
+private fun DatePickerModal(
+    onDateSelected: (Long?) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val datePickerState = rememberDatePickerState()
+
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = {
+                onDateSelected(datePickerState.selectedDateMillis)
+                onDismiss()
+            }) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    ) {
+        DatePicker(state = datePickerState)
+    }
+}
+
+@Composable
+private fun DatePickerModalInput(
+    onDateSelected: (Long?) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val datePickerState = rememberDatePickerState(initialDisplayMode = DisplayMode.Input)
+
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = {
+                onDateSelected(datePickerState.selectedDateMillis)
+                onDismiss()
+            }) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    ) {
+        DatePicker(state = datePickerState)
+    }
+}
+
+private fun convertMillisToDate(millis: Long): String {
+    val formatter = SimpleDateFormat("MM/dd/yyyy", Locale.getDefault())
+    return formatter.format(Date(millis))
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -70,7 +70,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -553,7 +553,8 @@ private fun FilterItem(
 //                                            val valueString = it?.let { convertMillisToDate(it) } ?: ""
 ////                                            onValueChange(valueString)
                                         val valueString = pickerState.selectedDateTimeMillis?.let {
-                                            Instant.ofEpochMilli(it)
+//                                            Instant.ofEpochMilli(it)
+                                            convertMillisToDate(it)
                                         }
                                         onValueChange(valueString?.toString() ?: "")
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -473,7 +473,11 @@ private fun FilterItem(
                                 items = domain.codedValues
                             )
                         } else if (filter.field?.fieldType == FieldType.Date || filter.field?.fieldType == FieldType.DateOnly) {
-                            DatePickerModalInput(filter, focusManager, onValueChange = onValueChange)
+                            DatePickerModalInput(
+                                filter,
+                                filter.field,
+                                onValueChange = onValueChange
+                            )
                         }
                         else {
                             TextField(
@@ -510,22 +514,20 @@ private fun FilterItem(
 @Composable
 private fun DatePickerModalInput(
     filter: FieldFilter,
-    focusManager: FocusManager,
+    field: Field,
     onValueChange: (String) -> Unit,
 ) {
-    if (filter.field == null) {
-        return
-    }
+    val focusManager = LocalFocusManager.current
     var showDatePicker by remember { mutableStateOf(false) }
-    val pickerStyle = if (filter.field.fieldType == FieldType.Date) {
+    val pickerStyle = if (field.fieldType == FieldType.Date) {
         DateTimePickerStyle.DateTime
     } else {
         DateTimePickerStyle.Date
     }
     val pickerState = rememberDateTimePickerState(
         pickerStyle,
-        label = filter.field.alias,
-        initialValue = filter.value.toInstant(filter.field.fieldType == FieldType.Date),
+        label = field.alias,
+        initialValue = filter.value.toInstant(field.fieldType == FieldType.Date),
         pickerInput = DateTimePickerInput.Date,
         initialError = ValidationErrorState.NoError
     )
@@ -573,7 +575,7 @@ private fun DatePickerModalInput(
             },
             onConfirmed = {
                 val valueString = pickerState.selectedDateTimeMillis?.let {
-                    val isDateField = filter.field.fieldType == FieldType.Date
+                    val isDateField = field.fieldType == FieldType.Date
                     Instant.ofEpochMilli(it).formattedDateTime(
                         includeTime = isDateField
                     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -46,9 +46,6 @@ import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.DisplayMode
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledTonalButton
@@ -63,7 +60,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -74,6 +70,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
@@ -89,10 +86,12 @@ import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
+import com.arcgismaps.toolkit.featureforms.internal.components.datetime.formattedDateTime
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePicker
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerInput
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerStyle
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.rememberDateTimePickerState
+import com.arcgismaps.toolkit.featureforms.internal.components.datetime.toInstant
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.AddAssociationFromSourceViewModel
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.FieldFilter
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.Operator
@@ -100,10 +99,7 @@ import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.fi
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.getKeyboardType
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.getOperators
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
 import java.time.Instant
-import java.util.Date
-import java.util.Locale
 
 @Composable
 internal fun FeaturesFilterScreen(
@@ -301,9 +297,6 @@ private fun FilterItem(
     val focusManager = LocalFocusManager.current
     // The value field is only visible if the operator is not unary or if no operator is selected yet
     val isFieldVisible = filter.operator?.isUnary()?.not() ?: true
-    var showDatePicker by rememberSaveable {
-        mutableStateOf(false)
-    }
 
     Column(modifier = modifier) {
         Row(
@@ -479,95 +472,8 @@ private fun FilterItem(
                                 defaultLabel = stringResource(R.string.enter_a_value),
                                 items = domain.codedValues
                             )
-                        } else if (filter.field?.fieldType == FieldType.Date) {
-//                            if (showDatePicker) {
-//                                DatePickerModalInput(
-//                                    onDateSelected = { epochMillis ->
-//                                        val valueString = epochMillis?.toString() ?: ""
-//                                        onValueChange(valueString)
-//                                        showDatePicker = false
-//                                    },
-//                                    onDismiss = {
-//                                        // no-op
-//                                        showDatePicker = false
-//                                    }
-//                                )
-//                            }
-                            var selectedDate by remember { mutableStateOf<Long?>(null) }
-                            var showModal by remember { mutableStateOf(false) }
-                            val pickerState = rememberDateTimePickerState(
-                                DateTimePickerStyle.Date,
-                                label = filter.field.alias,
-                                pickerInput = DateTimePickerInput.Date,
-                                initialError = ValidationErrorState.NoError
-                            )
-
-                            TextField(
-//                                value = selectedDate?.let { convertMillisToDate(it) } ?: "",
-//                                value = if (filter.value.isNotEmpty()) convertMillisToDate(filter.value.toLong()) else "",
-                                value = filter.value,
-                                onValueChange = onValueChange,
-                                label = { Text("Enter a date") },
-                                placeholder = { Text("MM/DD/YYYY") },
-                                colors = TextFieldDefaults.colors(
-                                    unfocusedContainerColor = Color.Transparent,
-                                    focusedContainerColor = Color.Transparent,
-                                    disabledContainerColor = Color.Transparent,
-                                ),
-                                trailingIcon = {
-                                    Icon(Icons.Default.DateRange, contentDescription = "Select date")
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-//                                    .clickable { showModal = true }
-                                    .pointerInput(selectedDate) {
-                                        awaitEachGesture {
-                                            // Modifier.clickable doesn't work for text fields, so we use Modifier.pointerInput
-                                            // in the Initial pass to observe events before the text field consumes them
-                                            // in the Main pass.
-                                            awaitFirstDown(pass = PointerEventPass.Initial)
-                                            val upEvent =
-                                                waitForUpOrCancellation(pass = PointerEventPass.Initial)
-                                            if (upEvent != null) {
-                                                showModal = true
-                                            }
-                                        }
-                                    }
-                            )
-
-                            if (showModal) {
-//                                DatePickerModal(
-//                                    onDateSelected = { selectedDate = it },
-//                                    onDismiss = { showModal = false }
-//                                )
-
-                                DateTimePicker(
-                                    pickerState,
-                                    { showModal = false},
-                                    { showModal = false },
-                                    onConfirmed = {
-//                                        onValueChange(pickerState.selectedDateTimeMillis?.let {
-//                                            Instant.ofEpochMilli(it).toEpochMilli().
-//                                        })
-
-//                                            val valueString = it?.let { convertMillisToDate(it) } ?: ""
-////                                            onValueChange(valueString)
-                                        val valueString = pickerState.selectedDateTimeMillis?.let {
-//                                            Instant.ofEpochMilli(it)
-                                            convertMillisToDate(it)
-                                        }
-                                        onValueChange(valueString?.toString() ?: "")
-
-
-//                                        selectedDate = pickerState.selectedDateTimeMillis?.let {
-//                                            Instant.ofEpochMilli(it).toEpochMilli()
-//                                        }
-                                        showModal = false
-                                    }
-                                )
-
-                            }
-
+                        } else if (filter.field?.fieldType == FieldType.Date || filter.field?.fieldType == FieldType.DateOnly) {
+                            DatePickerModalInput(filter, focusManager, onValueChange = onValueChange)
                         }
                         else {
                             TextField(
@@ -598,6 +504,80 @@ private fun FilterItem(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun DatePickerModalInput(
+    filter: FieldFilter,
+    focusManager: FocusManager,
+    onValueChange: (String) -> Unit,
+) {
+    if (filter.field == null) {
+        return
+    }
+    var showDatePicker by remember { mutableStateOf(false) }
+    val pickerState = rememberDateTimePickerState(
+        DateTimePickerStyle.Date,
+        label = filter.field.alias,
+        initialValue = filter.value.toInstant(filter.field.fieldType == FieldType.Date),
+        pickerInput = DateTimePickerInput.Date,
+        initialError = ValidationErrorState.NoError
+    )
+
+    TextField(
+        value = filter.value,
+        onValueChange = onValueChange,
+        label = { Text(stringResource(R.string.enter_a_value)) },
+        placeholder = { Text(stringResource(R.string.not_set)) },
+        colors = TextFieldDefaults.colors(
+            unfocusedContainerColor = Color.Transparent,
+            focusedContainerColor = Color.Transparent,
+            disabledContainerColor = Color.Transparent,
+        ),
+        trailingIcon = {
+            Icon(Icons.Default.DateRange, contentDescription = "Select date")
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .pointerInput(filter.value) {
+                awaitEachGesture {
+                    // Modifier.clickable doesn't work for text fields, so we use Modifier.pointerInput
+                    // in the Initial pass to observe events before the text field consumes them
+                    // in the Main pass.
+                    awaitFirstDown(pass = PointerEventPass.Initial)
+                    val upEvent =
+                        waitForUpOrCancellation(pass = PointerEventPass.Initial)
+                    if (upEvent != null) {
+                        showDatePicker = true
+                    }
+                }
+            }
+    )
+
+    if (showDatePicker) {
+        DateTimePicker(
+            pickerState,
+            {
+                showDatePicker = false
+                focusManager.clearFocus()
+            },
+            {
+                showDatePicker = false
+                focusManager.clearFocus()
+            },
+            onConfirmed = {
+                val valueString = pickerState.selectedDateTimeMillis?.let {
+                    val isDateField = filter.field.fieldType == FieldType.Date
+                    Instant.ofEpochMilli(it).formattedDateTime(
+                        includeTime = isDateField
+                    )
+                }
+                onValueChange(valueString ?: "")
+                showDatePicker = false
+                focusManager.clearFocus()
+            }
+        )
     }
 }
 
@@ -673,63 +653,4 @@ private fun ConfirmationDialog(
             Text(text = stringResource(R.string.discard_changes_confirmation))
         }
     )
-}
-
-@Composable
-private fun DatePickerModal(
-    onDateSelected: (Long?) -> Unit,
-    onDismiss: () -> Unit
-) {
-    val datePickerState = rememberDatePickerState()
-
-    DatePickerDialog(
-        onDismissRequest = onDismiss,
-        confirmButton = {
-            TextButton(onClick = {
-                onDateSelected(datePickerState.selectedDateMillis)
-                onDismiss()
-            }) {
-                Text("OK")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Cancel")
-            }
-        }
-    ) {
-        DatePicker(state = datePickerState)
-    }
-}
-
-@Composable
-private fun DatePickerModalInput(
-    onDateSelected: (Long?) -> Unit,
-    onDismiss: () -> Unit
-) {
-    val datePickerState = rememberDatePickerState(initialDisplayMode = DisplayMode.Input)
-
-    DatePickerDialog(
-        onDismissRequest = onDismiss,
-        confirmButton = {
-            TextButton(onClick = {
-                onDateSelected(datePickerState.selectedDateMillis)
-                onDismiss()
-            }) {
-                Text("OK")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Cancel")
-            }
-        }
-    ) {
-        DatePicker(state = datePickerState)
-    }
-}
-
-private fun convertMillisToDate(millis: Long): String {
-    val formatter = SimpleDateFormat("MM/dd/yyyy", Locale.getDefault())
-    return formatter.format(Date(millis))
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -473,7 +473,7 @@ private fun FilterItem(
                             )
                         } else if (filter.field?.fieldType == FieldType.Date || filter.field?.fieldType == FieldType.DateOnly) {
                             DatePickerModalInput(
-                                filter,
+                                filter.value,
                                 filter.field,
                                 onValueChange = onValueChange
                             )
@@ -512,7 +512,7 @@ private fun FilterItem(
 
 @Composable
 private fun DatePickerModalInput(
-    filter: FieldFilter,
+    value: String,
     field: Field,
     onValueChange: (String) -> Unit,
 ) {
@@ -526,13 +526,13 @@ private fun DatePickerModalInput(
     val pickerState = rememberDateTimePickerState(
         pickerStyle,
         label = field.alias,
-        initialValue = filter.value.toInstant(field.fieldType == FieldType.Date),
+        initialValue = value.toInstant(field.fieldType == FieldType.Date),
         pickerInput = DateTimePickerInput.Date,
         initialError = ValidationErrorState.NoError
     )
 
     TextField(
-        value = filter.value,
+        value = value,
         onValueChange = onValueChange,
         label = { Text(stringResource(R.string.enter_a_value)) },
         placeholder = { Text(stringResource(R.string.not_set)) },
@@ -546,7 +546,7 @@ private fun DatePickerModalInput(
         },
         modifier = Modifier
             .fillMaxWidth()
-            .pointerInput(filter.value) {
+            .pointerInput(value) {
                 awaitEachGesture {
                     // Modifier.clickable doesn't work for text fields, so we use Modifier.pointerInput
                     // in the Initial pass to observe events before the text field consumes them
@@ -558,7 +558,8 @@ private fun DatePickerModalInput(
                         showDatePicker = true
                     }
                 }
-            }
+            },
+        readOnly = true
     )
 
     if (showDatePicker) {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/apollo/issues/1573

<!-- link to design, if applicable -->

### Description:

Add support for filtering features based on fields of the type `Date` and `DateOnly`

### Summary of changes:

- Add composable `DatePickerModalInput` that displays DateTime picker in a dialog for fields of the type `Date` and `DateOnly`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1122/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  