### PR TITLE
`FeatureForm` : Fix copying a FieldFilter

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/FilterStateManager.kt
@@ -192,12 +192,13 @@ internal data class FieldFilter(
     }
 
     /**
-     * Creates a copy of this [FieldFilter] with the given new field.
+     * Creates a copy of this [FieldFilter] with the given new field. This also resets the operator
+     * and value to their default states since they may not be valid for the new field.
      */
     fun withField(newField: Field): FieldFilter = copy(
         field = newField,
-        operator = operator,
-        value = value
+        operator = null,
+        value = ""
     )
 
     /**


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

When the `Field` of a `FieldFilter` changes, its `Operator` and `Value` must be reset since they might not be valid anymore for the field type.

### Summary of changes:

- Fix the `withField` copy method to reset the operator and value.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1124/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  