### PR TITLE
Update logic to filterSupported fields

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/AddAssociationFromSourceViewModel.kt
@@ -772,9 +772,9 @@ private fun List<Field>.filterSupportedFields(): List<Field> {
     return filter { field ->
         (field.fieldType == FieldType.Text ||
             field.fieldType == FieldType.Oid ||
-            field.fieldType.isNumeric) ||
+            field.fieldType.isNumeric ||
             field.fieldType == FieldType.Date ||
-            field.fieldType == FieldType.DateOnly &&
+            field.fieldType == FieldType.DateOnly) &&
             !field.name.equals("ASSETGROUP", ignoreCase = true) &&
             !field.name.equals("ASSETTYPE", ignoreCase = true)
     }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

The logic to filter supported fields got disrupted when adding support for Date and DateOnly fields. Currently it is not filtering out `assettype` and `assetgroup` fields as expected.

### Summary of changes:

- Update the brackets to filter Date and DateOnly fields before looking for `assettype` and `assetgroup` and filtering them out.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1146/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  