### PR TITLE
`FeatureForm`: Add support for adding attachments from file

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -454,18 +454,18 @@ class MapViewModel @Inject constructor(
      *
      * If there are no errors, the feature is refreshed and the UI state is set to not editing.
      */
-    private suspend fun applyEditsToService(featureForm: FeatureForm) {
+    private suspend fun applyEditsToService(featureForm: FeatureForm) = withContext(Dispatchers.IO) {
         val serviceFeatureTable = featureForm.feature.featureTable as? ServiceFeatureTable ?: run {
             _error.value = Error(
                 title = "Failed to sync edits with the service",
                 details = "Cannot save edits without a ServiceFeatureTable"
             )
-            return
+            return@withContext
         }
         if (serviceFeatureTable.serviceGeodatabase?.hasLocalEdits() == false) {
             // if there are no local edits across all the tables in the service geodatabase
             // then return as there is nothing to sync
-            return
+            return@withContext
         }
         // check if the service supports applyEdits using the service geodatabase
         val canUseServiceGeodatabaseApplyEdits =

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -498,8 +498,7 @@ internal fun AttachmentElementState.getNewAttachmentNameForContentType(
 }
 
 /**
- * Adds an attachment to the [AttachmentElementState] from the specified [uri]. Since the data from
- * the uri is read into memory, there is a limit of 50 MB for the size of the attachment.
+ * Adds an attachment to the [AttachmentElementState] from the specified [uri].
  *
  * @param uri The uri of the attachment.
  * @param context The context.
@@ -575,7 +574,8 @@ internal suspend fun AttachmentElementState.addAttachmentFromUri(
 
 
 /**
- * Copies the content from the specified [uri] to a file in the cache directory.
+ * Copies the content from the specified [uri] to a file in the cache directory given by
+ * [Context.getCacheDir].
  *
  * @param uri The uri of the file to copy.
  * @param fileName The name of the file to create in the cache directory.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -70,7 +70,7 @@ internal const val maxAttachmentUploadSize = 999_000_000L
 /**
  * The maximum attachment size in bytes that can be downloaded.
  */
-internal const val maxAttachmentsDownloadSize = 999_999_999L
+internal const val maxAttachmentsDownloadSize = 999_000_000L
 
 /**
  * Represents the state of an [AttachmentFormElement]

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -65,7 +65,7 @@ import java.util.Objects
 /**
  * The maximum attachment size in bytes that can be added.
  */
-internal const val maxAttachmentUploadSize = 999_999_999L
+internal const val maxAttachmentUploadSize = 999_000_000L
 
 /**
  * The maximum attachment size in bytes that can be downloaded.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -58,7 +58,7 @@ import java.util.Objects
 /**
  * The maximum attachment size in bytes that can be added.
  */
-internal const val maxAttachmentUploadSize = 50_000_000L
+internal const val maxAttachmentUploadSize = 999_999_999L
 
 /**
  * The maximum attachment size in bytes that can be downloaded.
@@ -93,7 +93,7 @@ internal class AttachmentElementState(
      * The attachments associated with the form element. This list is observable and will update
      * the UI when attachments are added or removed.
      */
-    val attachments : List<FormAttachmentState>
+    val attachments: List<FormAttachmentState>
         get() = _attachments
 
     /**
@@ -148,35 +148,36 @@ internal class AttachmentElementState(
     }
 
     /**
-     * Adds an attachment with the given [name], [contentType], and [data].
+     * Adds an attachment with the given [name], [contentType], and [filePath].
      */
-    fun addAttachment(name: String, contentType: String, data: ByteArray): Result<Unit> {
-        val formAttachment = formElement.addAttachmentOrNull(name, contentType, data)
-            ?: return Result.failure(Exception("Failed to add attachment"))
-        // create a new state
-        val state = FormAttachmentState(
-            name = formAttachment.name,
-            size = formAttachment.size,
-            contentType = formAttachment.contentType,
-            type = formAttachment.type,
-            elementStateId = id,
-            deleteAttachment = { deleteAttachment(formAttachment) },
-            scope = scope,
-            formAttachment = formAttachment
-        )
-        // add the new state to the beginning of the list and scroll to the new attachment in
-        // one atomic operation
-        Snapshot.withMutableSnapshot {
-            _attachments.add(0, state)
-            lazyListState.requestScrollToItem(0)
-        }
-        // load the new attachment
-        state.loadWithParentScope()
-        // scroll to the new attachment after a delay to allow the recomposition to complete
-        scope.launch {
-            evaluateExpressions()
-        }
-        return Result.success(Unit)
+    suspend fun addAttachment(name: String, contentType: String, filePath: String): Result<Unit> {
+        return formElement.addAttachment(
+            name = name,
+            contentType = contentType,
+            filePath = filePath
+        ).onSuccess { formAttachment ->
+            // create a new state
+            val attachment = FormAttachmentState(
+                name = formAttachment.name,
+                size = formAttachment.size,
+                contentType = formAttachment.contentType,
+                type = formAttachment.type,
+                elementStateId = id,
+                deleteAttachment = { deleteAttachment(formAttachment) },
+                scope = scope,
+                formAttachment = formAttachment
+            )
+            // add the new state to the beginning of the list and scroll to the new attachment in
+            // one atomic operation
+            Snapshot.withMutableSnapshot {
+                _attachments.add(0, attachment)
+                lazyListState.requestScrollToItem(0)
+            }
+            // load the new attachment
+            attachment.loadWithParentScope()
+            // evaluate expressions after the attachment is added
+            scope.launch { evaluateExpressions() }
+        }.map {}
     }
 
     /**
@@ -283,7 +284,7 @@ internal class FormAttachmentState(
     /**
      * A callback that is invoked when the attachment fails to load.
      */
-    private var onLoadErrorCallback : ((Throwable) -> Unit)? = null
+    private var onLoadErrorCallback: ((Throwable) -> Unit)? = null
 
     /**
      * Loads the attachment and its thumbnail in the coroutine scope of the state object that
@@ -316,7 +317,10 @@ internal class FormAttachmentState(
             result = when {
                 formAttachment == null -> Result.failure(IllegalStateException("Form attachment is null"))
                 formAttachment.size == 0L -> Result.failure(EmptyAttachmentException())
-                formAttachment.size > maxAttachmentsDownloadSize -> Result.failure(AttachmentSizeLimitExceededException(maxAttachmentsDownloadSize))
+                formAttachment.size > maxAttachmentsDownloadSize -> Result.failure(
+                    AttachmentSizeLimitExceededException(maxAttachmentsDownloadSize)
+                )
+
                 else -> formAttachment.retryLoad().onSuccess {
                     createThumbnail()
                 }
@@ -492,7 +496,7 @@ internal fun AttachmentElementState.getNewAttachmentNameForContentType(
  * @param limit The attachment size limit in bytes.
  */
 internal class AttachmentSizeLimitExceededException(val limit: Long) : Exception(
-    "Attachment size exceeds the limit of ${limit/1_000_000} MB"
+    "Attachment size exceeds the limit of ${limit / 1_000_000} MB"
 )
 
 /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -21,8 +21,12 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.media.ThumbnailUtils
+import android.net.Uri
 import android.os.Build
+import android.provider.OpenableColumns
+import android.util.Log
 import android.util.Size
+import android.webkit.MimeTypeMap
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AudioFile
@@ -39,11 +43,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.core.content.ContextCompat
+import androidx.core.database.getLongOrNull
+import androidx.core.database.getStringOrNull
 import com.arcgismaps.LoadStatus
 import com.arcgismaps.Loadable
 import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
 import com.arcgismaps.mapping.featureforms.FormAttachment
 import com.arcgismaps.mapping.featureforms.FormAttachmentType
+import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.base.FormElementState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -488,6 +495,111 @@ internal fun AttachmentElementState.getNewAttachmentNameForContentType(
         count++
     }
     return "${prefix}$count.$extension"
+}
+
+/**
+ * Adds an attachment to the [AttachmentElementState] from the specified [uri]. Since the data from
+ * the uri is read into memory, there is a limit of 50 MB for the size of the attachment.
+ *
+ * @param uri The uri of the attachment.
+ * @param context The context.
+ * @param useDefaultName Whether to use the default name from the uri. If false, a new name will be generated
+ * based on the content type of the attachment.
+ */
+internal suspend fun AttachmentElementState.addAttachmentFromUri(
+    uri: Uri,
+    context: Context,
+    useDefaultName: Boolean
+): Result<Unit> = withContext(Dispatchers.IO) {
+    // get the content type of the uri
+    val contentType = context.contentResolver.getType(uri) ?: run {
+        return@withContext Result.failure(Exception(context.getString(R.string.attachment_error)))
+    }
+    // get the file extension from the content type
+    val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(contentType) ?: run {
+        return@withContext Result.failure(Exception(context.getString(R.string.attachment_error)))
+    }
+    // generate a name for the attachment
+    var name = getNewAttachmentNameForContentType(contentType, extension)
+    // size of the attachment
+    var size = 0L
+    // get the name and size of the attachment
+    context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+        cursor.moveToFirst()
+        val nameIndex =
+            cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+        val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+        // use the default file name from the uri if available
+        if (useDefaultName) {
+            cursor.getStringOrNull(nameIndex)?.let {
+                name = it
+            }
+        }
+        // update the size
+        cursor.getLongOrNull(sizeIndex)?.let {
+            size = it
+        }
+    }
+
+    // Add the attachment if it passes all the checks
+    return@withContext when {
+        size == 0L -> Result.failure(EmptyAttachmentException())
+        size > maxAttachmentUploadSize -> Result.failure(
+            exception = AttachmentSizeLimitExceededException(maxAttachmentUploadSize)
+        )
+
+        else -> {
+            // Cache the file from the URI and get the cached file reference. This is required to get a file
+            // path that can be accessed by the toolkit/app.
+            context.cacheFile(uri, name).fold(
+                onSuccess = { cachedFile ->
+                    addAttachment(name, contentType, cachedFile.absolutePath).also {
+                        // delete the cached file after attempting to add the attachment since it's
+                        // no longer needed
+                        try {
+                            cachedFile.delete()
+                        } catch (ex: Exception) {
+                            Log.w(
+                                "FeatureFormToolkit",
+                                "Unable to clear cached attachment data",
+                                ex
+                            )
+                        }
+                    }
+                },
+                onFailure = { ex -> Result.failure(ex) }
+            )
+        }
+    }
+}
+
+
+/**
+ * Copies the content from the specified [uri] to a file in the cache directory.
+ *
+ * @param uri The uri of the file to copy.
+ * @param fileName The name of the file to create in the cache directory.
+ * @return The file in the cache directory that contains the copied content.
+ */
+internal suspend fun Context.cacheFile(
+    uri: Uri,
+    fileName: String
+): Result<File> = runCatching {
+    withContext(Dispatchers.IO) {
+        val outFile = cacheDir.resolve(fileName)
+        // Delete the file if it already exists
+        if (outFile.exists()) {
+            outFile.delete()
+        }
+        // Copy the content from the uri to a file in the cache directory that the toolkit/app
+        // controls, so that it can be accessed.
+        contentResolver.openInputStream(uri)?.use { inputStream ->
+            outFile.outputStream().use { outputStream ->
+                inputStream.copyTo(outputStream)
+            }
+        }
+        return@withContext outFile
+    }
 }
 
 /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -93,7 +93,7 @@ internal fun AttachmentTile(
     modifier: Modifier = Modifier
 ) {
     val loadStatus by state.loadStatus.collectAsState()
-    val interactionSource = remember { MutableInteractionSource() }
+    val interactionSource = remember(state) { MutableInteractionSource() }
     val thumbnail by state.thumbnail
     val configuration = LocalViewConfiguration.current
     val haptic = LocalHapticFeedback.current
@@ -178,7 +178,7 @@ internal fun AttachmentTile(
             }
         }
     }
-    LaunchedEffect(interactionSource) {
+    LaunchedEffect(interactionSource, state) {
         var wasALongPress = false
         interactionSource.interactions.collectLatest {
             when (it) {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @file:Suppress("DEPRECATION")
+
 package com.arcgismaps.toolkit.featureforms.internal.utils
 
 import android.content.Context
@@ -61,16 +62,15 @@ import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.D
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerStyle
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.rememberDateTimePickerState
 import com.arcgismaps.toolkit.featureforms.internal.components.dialogs.ErrorDialog
-import com.arcgismaps.toolkit.featureforms.internal.components.dialogs.SaveEditsDialog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
 import java.io.FileNotFoundException
 import java.time.Instant
-import kotlin.math.max
 
 /**
  * Local containing the default [DialogRequester] for providing the same instance in the
@@ -425,18 +425,33 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
     }
 }
 
-internal suspend fun Context.readBytes(uri: Uri): Result<ByteArray> = withContext(Dispatchers.IO) {
+/**
+ * Copies the content from the specified [uri] to a file in the cache directory.
+ *
+ * @param uri The uri of the file to copy.
+ * @param fileName The name of the file to create in the cache directory.
+ * @return The file in the cache directory that contains the copied content.
+ */
+internal suspend fun Context.cacheFile(
+    uri: Uri,
+    fileName: String
+): Result<File> = withContext(Dispatchers.IO) {
     return@withContext try {
-        val bytes = contentResolver.openInputStream(uri)?.use { it.buffered().readBytes() }
-        if (bytes == null) {
-            Result.failure(Exception("Failed to read data from file: $uri"))
-        } else {
-            Result.success(bytes)
+        val outFile = cacheDir.resolve(fileName)
+        // Delete the file if it already exists
+        if (outFile.exists()) {
+            outFile.delete()
         }
-    } catch (e: FileNotFoundException) {
-        Result.failure(Exception("File not found: $uri"))
-    } catch (e: OutOfMemoryError) {
-        Result.failure(Exception("File too large: $uri"))
+        // Copy the content from the uri to a file in the cache directory that the toolkit/app
+        // controls, so that it can be accessed.
+        contentResolver.openInputStream(uri)?.use { inputStream ->
+            outFile.outputStream().use { outputStream ->
+                inputStream.copyTo(outputStream)
+            }
+        }
+        Result.success(outFile)
+    } catch (ex : FileNotFoundException) {
+        Result.failure(ex)
     }
 }
 
@@ -506,18 +521,19 @@ private suspend fun AttachmentElementState.addAttachmentFromUri(
             size = it
         }
     }
-    // check if the size is within the limits
-    return@withContext if (size == 0L) {
-        Result.failure(EmptyAttachmentException())
-    } else if (size > maxAttachmentUploadSize) {
-        Result.failure(AttachmentSizeLimitExceededException(maxAttachmentUploadSize))
-    } else {
-        var result = Result.success(Unit)
-        context.readBytes(uri).onFailure {
-            result = Result.failure(it)
-        }.onSuccess { data ->
-            result = addAttachment(name, contentType, data)
-        }
-        result
+    // Cache the file from the URI and get the cached file reference. This is required to get a file
+    // path that can be accessed by the toolkit/app.
+    val cachedFile = context.cacheFile(uri, name).getOrNull()
+    // Add the attachment if it passes all the checks
+    return@withContext when {
+        size == 0L -> Result.failure(EmptyAttachmentException())
+        size > maxAttachmentUploadSize -> Result.failure(
+            exception = AttachmentSizeLimitExceededException(maxAttachmentUploadSize)
+        )
+        cachedFile == null -> Result.failure(
+            exception = Exception(context.getString(R.string.attachment_error))
+        )
+
+        else -> addAttachment(name, contentType, cachedFile.absolutePath)
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -18,9 +18,6 @@
 package com.arcgismaps.toolkit.featureforms.internal.utils
 
 import android.content.Context
-import android.net.Uri
-import android.provider.OpenableColumns
-import android.webkit.MimeTypeMap
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
@@ -34,23 +31,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.core.database.getLongOrNull
-import androidx.core.database.getStringOrNull
 import androidx.window.core.layout.WindowSizeClass
 import androidx.window.layout.WindowMetricsCalculator
 import com.arcgismaps.mapping.featureforms.FormAttachment
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentElementState
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentErrorDialog
-import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentSizeLimitExceededException
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.DeleteAttachmentDialog
-import com.arcgismaps.toolkit.featureforms.internal.components.attachment.EmptyAttachmentException
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.FilePicker
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.GalleryPicker
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.ImageCapture
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.RenameAttachmentDialog
-import com.arcgismaps.toolkit.featureforms.internal.components.attachment.getNewAttachmentNameForContentType
-import com.arcgismaps.toolkit.featureforms.internal.components.attachment.maxAttachmentUploadSize
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.addAttachmentFromUri
 import com.arcgismaps.toolkit.featureforms.internal.components.barcode.BarcodeScanner
 import com.arcgismaps.toolkit.featureforms.internal.components.barcode.BarcodeTextFieldState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.FormStateCollection
@@ -62,14 +54,10 @@ import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.D
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerStyle
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.rememberDateTimePickerState
 import com.arcgismaps.toolkit.featureforms.internal.components.dialogs.ErrorDialog
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.io.File
-import java.io.FileNotFoundException
 import java.time.Instant
 
 /**
@@ -426,36 +414,6 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
 }
 
 /**
- * Copies the content from the specified [uri] to a file in the cache directory.
- *
- * @param uri The uri of the file to copy.
- * @param fileName The name of the file to create in the cache directory.
- * @return The file in the cache directory that contains the copied content.
- */
-internal suspend fun Context.cacheFile(
-    uri: Uri,
-    fileName: String
-): Result<File> = withContext(Dispatchers.IO) {
-    return@withContext try {
-        val outFile = cacheDir.resolve(fileName)
-        // Delete the file if it already exists
-        if (outFile.exists()) {
-            outFile.delete()
-        }
-        // Copy the content from the uri to a file in the cache directory that the toolkit/app
-        // controls, so that it can be accessed.
-        contentResolver.openInputStream(uri)?.use { inputStream ->
-            outFile.outputStream().use { outputStream ->
-                inputStream.copyTo(outputStream)
-            }
-        }
-        Result.success(outFile)
-    } catch (ex : FileNotFoundException) {
-        Result.failure(ex)
-    }
-}
-
-/**
  * Computes the [WindowSizeClass] of the device.
  */
 internal fun computeWindowSizeClasses(context: Context): WindowSizeClass {
@@ -476,64 +434,4 @@ internal fun computeWindowSizeClasses(context: Context): WindowSizeClass {
 
 internal fun showError(context: Context, message: String) {
     Toast.makeText(context, message, Toast.LENGTH_LONG).show()
-}
-
-/**
- * Adds an attachment to the [AttachmentElementState] from the specified [uri]. Since the data from
- * the uri is read into memory, there is a limit of 50 MB for the size of the attachment.
- *
- * @param uri The uri of the attachment.
- * @param context The context.
- * @param useDefaultName Whether to use the default name from the uri. If false, a new name will be generated
- * based on the content type of the attachment.
- */
-private suspend fun AttachmentElementState.addAttachmentFromUri(
-    uri: Uri,
-    context: Context,
-    useDefaultName: Boolean
-): Result<Unit> = withContext(Dispatchers.IO) {
-    // get the content type of the uri
-    val contentType = context.contentResolver.getType(uri) ?: run {
-        return@withContext Result.failure(Exception(context.getString(R.string.attachment_error)))
-    }
-    // get the file extension from the content type
-    val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(contentType) ?: run {
-        return@withContext Result.failure(Exception(context.getString(R.string.attachment_error)))
-    }
-    // generate a name for the attachment
-    var name = getNewAttachmentNameForContentType(contentType, extension)
-    // size of the attachment
-    var size = 0L
-    // get the name and size of the attachment
-    context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-        cursor.moveToFirst()
-        val nameIndex =
-            cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-        val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
-        // use the default file name from the uri if available
-        if (useDefaultName) {
-            cursor.getStringOrNull(nameIndex)?.let {
-                name = it
-            }
-        }
-        // update the size
-        cursor.getLongOrNull(sizeIndex)?.let {
-            size = it
-        }
-    }
-    // Cache the file from the URI and get the cached file reference. This is required to get a file
-    // path that can be accessed by the toolkit/app.
-    val cachedFile = context.cacheFile(uri, name).getOrNull()
-    // Add the attachment if it passes all the checks
-    return@withContext when {
-        size == 0L -> Result.failure(EmptyAttachmentException())
-        size > maxAttachmentUploadSize -> Result.failure(
-            exception = AttachmentSizeLimitExceededException(maxAttachmentUploadSize)
-        )
-        cachedFile == null -> Result.failure(
-            exception = Exception(context.getString(R.string.attachment_error))
-        )
-
-        else -> addAttachment(name, contentType, cachedFile.absolutePath)
-    }
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#1591](https://devtopia.esri.com/runtime/apollo/issues/1591)

<!-- link to design, if applicable -->

### Description:

This PR updates the toolkit to use the new addFromFile attachment APIs.

### Summary of changes:

- The `AttachmentElementState.addAttachmentFromUri` is moved to the `AttachmentElementState` file and now uses the new overload to add an attachment via a filepath.
- Increased the `maxAttachmentUploadSize` to 999MB.
- The `AttachmentTile.LaunchedEffect` is now also keyed on the state to fix any stale references to the state and `FormAttachment`.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1159/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  