### PR TITLE
Update DateTime formatting for Query operations

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateUtil.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateUtil.kt
@@ -84,6 +84,23 @@ internal fun Instant.formattedDateTime(includeTime: Boolean): String {
 }
 
 /**
+ * Formats an Instant in SQL‑92 / RFC‑3339 format for the current timezone as required for date
+ * and date only queries.
+ *
+ * @param includeTime format the time if true
+ * @return a string formatted for the value in epoch milliseconds
+ * @since 300.0.0
+ */
+internal fun Instant.formattedDateTimeForQuery(includeTime: Boolean): String {
+    val formatter = if (includeTime) {
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    } else {
+        DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    }
+    return atZone(TimeZone.getDefault().toZoneId()).format(formatter)
+}
+
+/**
  * Parses a string to an Instant
  *
  * @param includeTime whether the time component is included in the string

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateUtil.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/datetime/DateUtil.kt
@@ -84,8 +84,8 @@ internal fun Instant.formattedDateTime(includeTime: Boolean): String {
 }
 
 /**
- * Formats an Instant in SQL‑92 / RFC‑3339 format for the current timezone as required for date
- * and date only queries.
+ * Formats an Instant in SQL‑92 / RFC‑3339 compliant syntax for the current timezone as required
+ * for date and date only queries.
  *
  * @param includeTime format the time if true
  * @return a string formatted for the value in epoch milliseconds

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -85,7 +85,7 @@ import com.arcgismaps.data.Field
 import com.arcgismaps.data.FieldType
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
-import com.arcgismaps.toolkit.featureforms.internal.components.datetime.formattedDateTime
+import com.arcgismaps.toolkit.featureforms.internal.components.datetime.formattedDateTimeForQuery
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePicker
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerInput
 import com.arcgismaps.toolkit.featureforms.internal.components.datetime.picker.DateTimePickerStyle
@@ -576,7 +576,7 @@ private fun DatePickerModalInput(
             onConfirmed = {
                 val valueString = pickerState.selectedDateTimeMillis?.let {
                     val isDateField = field.fieldType == FieldType.Date
-                    Instant.ofEpochMilli(it).formattedDateTime(
+                    Instant.ofEpochMilli(it).formattedDateTimeForQuery(
                         includeTime = isDateField
                     )
                 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/apollo/issues/1611

<!-- link to design, if applicable -->

### Description:

Update DateTime formatting  to SQL-92 compliant syntax for Query operations

### Summary of changes:

- Add `DateUtil.Instant.formattedDateTimeForQuery` extension function

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1163/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  