### PR TITLE
Support callout for LSV

### DIFF
--- a/microapps/CalloutApp/README.md
+++ b/microapps/CalloutApp/README.md
@@ -1,6 +1,6 @@
 # Callout Micro-app
 
-This micro-app demonstrates the use of `Callout` with a composable `MapView` or `SceneView`. `Callout` is a composable function which renders an empty composable Box placed at a given point or GeoElement on a Map. The content of the composable Box is customizable, while the container of the Box is a stylable rectangular shape with a leader line positioned at the point of the tap or GeoElement passed into the `Callout` composable functions. The default `LeaderPosition` is set to `Automatic` which dynamically positions the leader to keep the callout as much as possible within the bounds of the `GeoView`.
+This micro-app demonstrates the use of `Callout` with a composable `MapView`,`SceneView` or `LocalSceneView`. `Callout` is a composable function which renders an empty composable Box placed at a given point or GeoElement on a Map. The content of the composable Box is customizable, while the container of the Box is a stylable rectangular shape with a leader line positioned at the point of the tap or GeoElement passed into the `Callout` composable functions. The default `LeaderPosition` is set to `Automatic` which dynamically positions the leader to keep the callout as much as possible within the bounds of the `GeoView`.
 
 ## Usage
 

--- a/microapps/CalloutApp/app/src/main/java/com/arcgismaps/toolkit/calloutapp/screens/GeoViewModel.kt
+++ b/microapps/CalloutApp/app/src/main/java/com/arcgismaps/toolkit/calloutapp/screens/GeoViewModel.kt
@@ -28,11 +28,10 @@ import com.arcgismaps.geometry.Point
 import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.ArcGISScene
-import com.arcgismaps.mapping.ArcGISTiledElevationSource
 import com.arcgismaps.mapping.BasemapStyle
+import com.arcgismaps.mapping.ElevationSource
 import com.arcgismaps.mapping.GeoElement
 import com.arcgismaps.mapping.Viewpoint
-import com.arcgismaps.mapping.layers.ArcGISSceneLayer
 import com.arcgismaps.mapping.symbology.SimpleMarkerSymbol
 import com.arcgismaps.mapping.symbology.SimpleMarkerSymbolStyle
 import com.arcgismaps.mapping.view.Camera
@@ -76,8 +75,7 @@ class GeoViewModel : ViewModel() {
             viewingMode = SceneViewingMode.Local,
             basemapStyle = BasemapStyle.ArcGISTopographic
         ).apply {
-            operationalLayers.add(ArcGISSceneLayer("https://www.arcgis.com/home/item.html?id=61da8dc1a7bc4eea901c20ffb3f8b7af"))
-            baseSurface.elevationSources.add(ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"))
+            baseSurface.elevationSources.add(ElevationSource.fromTerrain3dService())
 
             initialViewpoint = Viewpoint(
                 center = Point(
@@ -164,8 +162,14 @@ class GeoViewModel : ViewModel() {
             }
 
             GeoViewType.LocalSceneViewType -> {
-                _point.value =
-                    localSceneViewProxy.screenToBaseSurface(singleTapConfirmedEvent.screenCoordinate)
+                viewModelScope.launch {
+                    _point.value =
+                        localSceneViewProxy.screenToLocation(singleTapConfirmedEvent.screenCoordinate)
+                            .getOrNull()?.let {
+                                // get the highest resolution elevation for the tapped point
+                                localScene.baseSurface.applyElevation(it).getOrNull() as Point?
+                            }
+                }
             }
         }
 

--- a/microapps/CalloutApp/app/src/main/java/com/arcgismaps/toolkit/calloutapp/screens/GeoViewModel.kt
+++ b/microapps/CalloutApp/app/src/main/java/com/arcgismaps/toolkit/calloutapp/screens/GeoViewModel.kt
@@ -23,17 +23,24 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arcgismaps.Color
+import com.arcgismaps.geometry.Envelope
 import com.arcgismaps.geometry.Point
+import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.ArcGISScene
+import com.arcgismaps.mapping.ArcGISTiledElevationSource
 import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.mapping.GeoElement
 import com.arcgismaps.mapping.Viewpoint
+import com.arcgismaps.mapping.layers.ArcGISSceneLayer
 import com.arcgismaps.mapping.symbology.SimpleMarkerSymbol
 import com.arcgismaps.mapping.symbology.SimpleMarkerSymbolStyle
+import com.arcgismaps.mapping.view.Camera
 import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
+import com.arcgismaps.mapping.view.SceneViewingMode
 import com.arcgismaps.mapping.view.SingleTapConfirmedEvent
+import com.arcgismaps.toolkit.geoviewcompose.LocalSceneViewProxy
 import com.arcgismaps.toolkit.geoviewcompose.MapViewProxy
 import com.arcgismaps.toolkit.geoviewcompose.SceneViewProxy
 import kotlinx.coroutines.Job
@@ -46,6 +53,7 @@ class GeoViewModel : ViewModel() {
 
     val mapViewProxy = MapViewProxy()
     val sceneViewProxy = SceneViewProxy()
+    val localSceneViewProxy = LocalSceneViewProxy()
 
     val arcGISMap = ArcGISMap(BasemapStyle.ArcGISTopographic).apply {
         initialViewpoint = Viewpoint(
@@ -62,6 +70,43 @@ class GeoViewModel : ViewModel() {
             scale = 10e7
         )
     }
+
+    val localScene =
+        ArcGISScene(
+            viewingMode = SceneViewingMode.Local,
+            basemapStyle = BasemapStyle.ArcGISTopographic
+        ).apply {
+            operationalLayers.add(ArcGISSceneLayer("https://www.arcgis.com/home/item.html?id=61da8dc1a7bc4eea901c20ffb3f8b7af"))
+            baseSurface.elevationSources.add(ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"))
+
+            initialViewpoint = Viewpoint(
+                center = Point(
+                    x = 19455026.8116,
+                    y = -5054995.7415,
+                    spatialReference = SpatialReference.webMercator()
+                ),
+                scale = 8314.6991,
+                camera = Camera(
+                    locationPoint = Point(
+                        x = 19455578.6821,
+                        y = -5056336.2227,
+                        z = 1699.3366,
+                        spatialReference = SpatialReference.webMercator()
+                    ),
+                    heading = 338.7410,
+                    pitch = 40.3763,
+                    roll = 0.0,
+                )
+            )
+            clippingArea = Envelope(
+                xMin = 19454578.8235,
+                yMin = -5055381.4798,
+                xMax = 19455518.8814,
+                yMax = -5054888.4150,
+                spatialReference = SpatialReference.webMercator()
+            )
+            isClippingEnabled = true
+        }
 
     val arcGISMapWithFeatureLayer = ArcGISMap(
         uri = "https://www.arcgis.com/home/item.html?id=16f1b8ba37b44dc3884afc8d5f454dd2"
@@ -92,7 +137,8 @@ class GeoViewModel : ViewModel() {
     val offset: StateFlow<Offset> = _offset
 
     private val _tapLocationGraphicsOverlay = MutableStateFlow(GraphicsOverlay())
-    val tapLocationGraphicsOverlay: StateFlow<GraphicsOverlay> = _tapLocationGraphicsOverlay.asStateFlow()
+    val tapLocationGraphicsOverlay: StateFlow<GraphicsOverlay> =
+        _tapLocationGraphicsOverlay.asStateFlow()
 
     private var currentIdentifyJob: Job? = null
 
@@ -107,10 +153,21 @@ class GeoViewModel : ViewModel() {
     }
 
     fun setPoint(singleTapConfirmedEvent: SingleTapConfirmedEvent) {
-        if (_geoViewType.value == GeoViewType.MapViewType)
-            _point.value = singleTapConfirmedEvent.mapPoint
-        else
-            _point.value = sceneViewProxy.screenToBaseSurface(singleTapConfirmedEvent.screenCoordinate)
+        when (_geoViewType.value) {
+            GeoViewType.MapViewType -> {
+                _point.value = singleTapConfirmedEvent.mapPoint
+            }
+
+            GeoViewType.SceneViewType -> {
+                _point.value =
+                    sceneViewProxy.screenToBaseSurface(singleTapConfirmedEvent.screenCoordinate)
+            }
+
+            GeoViewType.LocalSceneViewType -> {
+                _point.value =
+                    localSceneViewProxy.screenToBaseSurface(singleTapConfirmedEvent.screenCoordinate)
+            }
+        }
 
         _tapLocationGraphicsOverlay.value.graphics.clear()
         _tapLocationGraphicsOverlay.value.graphics.add(
@@ -121,12 +178,9 @@ class GeoViewModel : ViewModel() {
         )
     }
 
-    fun toggleGeoView() {
+    fun toggleGeoView(geoViewType: GeoViewType) {
         clearPoint()
-        _geoViewType.value = if (_geoViewType.value == GeoViewType.MapViewType)
-            GeoViewType.SceneViewType
-        else
-            GeoViewType.MapViewType
+        _geoViewType.value = geoViewType
     }
 
     fun clearTapLocationAndGraphic() {
@@ -174,7 +228,9 @@ class GeoViewModel : ViewModel() {
         }
     }
 }
+
 sealed class GeoViewType {
     object MapViewType : GeoViewType()
     object SceneViewType : GeoViewType()
+    object LocalSceneViewType : GeoViewType()
 }

--- a/microapps/CalloutApp/app/src/main/java/com/arcgismaps/toolkit/calloutapp/screens/TapLocationScreen.kt
+++ b/microapps/CalloutApp/app/src/main/java/com/arcgismaps/toolkit/calloutapp/screens/TapLocationScreen.kt
@@ -73,6 +73,7 @@ import androidx.core.text.HtmlCompat
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.toolkit.geoviewcompose.GeoViewScope
 import com.arcgismaps.toolkit.geoviewcompose.LeaderPosition
+import com.arcgismaps.toolkit.geoviewcompose.LocalSceneView
 import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.arcgismaps.toolkit.geoviewcompose.SceneView
 import kotlin.math.roundToInt
@@ -118,42 +119,65 @@ fun TapLocationScreen(
             }
         }
     ) { contentPadding ->
-        if (geoViewType == GeoViewType.MapViewType) {
-            MapView(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(contentPadding),
-                arcGISMap = viewModel.arcGISMap,
-                mapViewProxy = viewModel.mapViewProxy,
-                graphicsOverlays = listOf(tapLocationGraphicsOverlay),
-                onSingleTapConfirmed = viewModel::setPoint,
-                content = {
-                    GeoViewScopeContent(
-                        mapPoint = point,
-                        calloutVisibleState = calloutVisibleState,
-                        rotateOffsetWithGeoView = rotateOffsetWithGeoView,
-                        offset = offset
-                    )
-                }
-            )
-        } else {
-            SceneView(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(contentPadding),
-                arcGISScene = viewModel.arcGISScene,
-                sceneViewProxy = viewModel.sceneViewProxy,
-                graphicsOverlays = listOf(tapLocationGraphicsOverlay),
-                onSingleTapConfirmed = viewModel::setPoint,
-                content = {
-                    GeoViewScopeContent(
-                        mapPoint = point,
-                        calloutVisibleState = calloutVisibleState,
-                        rotateOffsetWithGeoView = rotateOffsetWithGeoView,
-                        offset = offset
-                    )
-                }
-            )
+        when (geoViewType) {
+            is GeoViewType.MapViewType -> {
+                MapView(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(contentPadding),
+                    arcGISMap = viewModel.arcGISMap,
+                    mapViewProxy = viewModel.mapViewProxy,
+                    graphicsOverlays = listOf(tapLocationGraphicsOverlay),
+                    onSingleTapConfirmed = viewModel::setPoint,
+                    content = {
+                        GeoViewScopeContent(
+                            mapPoint = point,
+                            calloutVisibleState = calloutVisibleState,
+                            rotateOffsetWithGeoView = rotateOffsetWithGeoView,
+                            offset = offset
+                        )
+                    }
+                )
+            }
+
+            is GeoViewType.SceneViewType -> {
+                SceneView(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(contentPadding),
+                    arcGISScene = viewModel.arcGISScene,
+                    sceneViewProxy = viewModel.sceneViewProxy,
+                    graphicsOverlays = listOf(tapLocationGraphicsOverlay),
+                    onSingleTapConfirmed = viewModel::setPoint,
+                    content = {
+                        GeoViewScopeContent(
+                            mapPoint = point,
+                            calloutVisibleState = calloutVisibleState,
+                            rotateOffsetWithGeoView = rotateOffsetWithGeoView,
+                            offset = offset
+                        )
+                    }
+                )
+            }
+
+            is GeoViewType.LocalSceneViewType -> {
+                LocalSceneView(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(contentPadding),
+                    scene = viewModel.localScene,
+                    localSceneViewProxy = viewModel.localSceneViewProxy,
+                    onSingleTapConfirmed = viewModel::setPoint,
+                    content = {
+                        GeoViewScopeContent(
+                            mapPoint = point,
+                            calloutVisibleState = calloutVisibleState,
+                            rotateOffsetWithGeoView = rotateOffsetWithGeoView,
+                            offset = offset
+                        )
+                    }
+                )
+            }
         }
 
         if (showBottomSheet) {
@@ -164,13 +188,24 @@ fun TapLocationScreen(
             ) {
                 Box(Modifier.navigationBarsPadding()) {
                     CalloutOptions(
-                        isGeoViewMapView = geoViewType == GeoViewType.MapViewType,
+                        selectedType = geoViewType,
                         calloutVisibility = calloutVisibility,
                         isCalloutRotationEnabled = rotateOffsetWithGeoView,
                         offset = offset,
                         mapPoint = point,
                         onOffsetChange = { viewModel.setOffset(it) },
-                        onGeoViewToggled = { viewModel.toggleGeoView() },
+                        onGeoViewToggled = {
+                            viewModel.toggleGeoView(
+                                when (it) {
+                                    0 -> GeoViewType.MapViewType
+                                    1 -> GeoViewType.SceneViewType
+                                    2 -> GeoViewType.LocalSceneViewType
+                                    else -> {
+                                        GeoViewType.SceneViewType
+                                    }
+                                }
+                            )
+                        },
                         onVisibilityToggled = { calloutVisibility = !calloutVisibility },
                         onClearMapPointRequest = { viewModel.clearPoint() },
                         onCalloutOffsetRotationToggled = {
@@ -249,40 +284,49 @@ fun HtmlText(modifier: Modifier = Modifier, html: String, htmlFlag: Int, textCol
  */
 @Composable
 fun CalloutOptions(
-    isGeoViewMapView: Boolean,
+    selectedType: GeoViewType,
     calloutVisibility: Boolean,
     isCalloutRotationEnabled: Boolean,
     offset: Offset,
     mapPoint: Point?,
-    onGeoViewToggled: () -> Unit,
+    onGeoViewToggled: (Int) -> Unit,
     onVisibilityToggled: () -> Unit,
     onOffsetChange: (Offset) -> Unit,
     onCalloutOffsetRotationToggled: () -> Unit,
     onClearMapPointRequest: () -> Unit,
 ) {
     Column(Modifier.padding(8.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = "Select GeoView")
         Row(
             modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(text = "Select GeoView")
             SingleChoiceSegmentedButtonRow {
                 SegmentedButton(
-                    onClick = onGeoViewToggled,
-                    selected = isGeoViewMapView,
+                    onClick = { onGeoViewToggled(0) },
+                    selected = GeoViewType.MapViewType == selectedType,
                     label = { Text("MapView") },
                     shape = SegmentedButtonDefaults.itemShape(
                         index = 0,
-                        count = 2
+                        count = 3
                     )
                 )
                 SegmentedButton(
-                    onClick = onGeoViewToggled,
-                    selected = !isGeoViewMapView,
+                    onClick = { onGeoViewToggled(1) },
+                    selected = GeoViewType.SceneViewType == selectedType,
                     label = { Text("SceneView") },
                     shape = SegmentedButtonDefaults.itemShape(
                         index = 1,
-                        count = 2
+                        count = 3
+                    )
+                )
+                SegmentedButton(
+                    onClick = { onGeoViewToggled(2) },
+                    selected = GeoViewType.LocalSceneViewType == selectedType,
+                    label = { Text("LocalSceneView") },
+                    shape = SegmentedButtonDefaults.itemShape(
+                        index = 2,
+                        count = 3
                     )
                 )
             }

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -452,6 +452,10 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
         offset: Offset,
         rotateOffsetWithGeoView: Boolean
     ): ScreenCoordinate? {
+        if (location.isEmpty) {
+            return null
+        }
+
         val geoViewRotation = geoView.rotation()
         val locationToScreen = when (geoView) {
             is MapView -> geoView.locationToScreen(location).takeIf {

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/GeoViewScope.kt
@@ -457,10 +457,14 @@ public sealed class GeoViewScope protected constructor(private val geoView: GeoV
             is MapView -> geoView.locationToScreen(location).takeIf {
                 !it.x.isNaN() && !it.y.isNaN()
             }
+
             is SceneView -> geoView.locationToScreen(location)?.takeIf {
                 it.visibility == SceneLocationVisibility.Visible
             }?.screenPoint
-            is LocalSceneView -> TODO("Pending implementation support")
+
+            is LocalSceneView -> geoView.locationToScreen(location)?.takeIf {
+                it.visibility == SceneLocationVisibility.Visible
+            }?.screenPoint
         }
         return locationToScreen?.let { screenCoordinate ->
             if (rotateOffsetWithGeoView && geoViewRotation != 0.0) {
@@ -770,9 +774,10 @@ internal class LeaderPointOffset internal constructor(
 }
 
 private fun GeoView.rotation(): Double = when (this) {
-    is SceneView -> getCurrentViewpoint(ViewpointType.CenterAndScale)?.rotation ?: 0.0
+    is SceneView, is LocalSceneView -> getCurrentViewpoint(ViewpointType.CenterAndScale)?.rotation
+        ?: 0.0
+
     is MapView -> mapRotation.value
-    is LocalSceneView -> TODO("Pending implementation support")
 }
 
 /**


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Implements the missing code paths LSV requires to show a callout

### Summary of changes:

- implements the two missing code paths
- guards against empty locations being used for a callout

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1179/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  