### PR TITLE
add fix for crash in test on backpress

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/FeaturesFilterScreen.kt
@@ -97,7 +97,9 @@ import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.Op
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.fieldName
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.getKeyboardType
 import com.arcgismaps.toolkit.featureforms.internal.components.utilitynetwork.getOperators
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.Instant
 
 @Composable
@@ -144,7 +146,9 @@ internal fun FeaturesFilterScreen(
                         scope.launch {
                             filterStateManager.applyFilters()
                                 .onSuccess {
-                                    onBackPressed()
+                                    withContext(Dispatchers.Main) {
+                                        onBackPressed()
+                                    }
                                 }.onFailure {
                                     snackbarHostState.showSnackbar(
                                         message = it.message ?: "Failed to apply filters"


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # https://devtopia.esri.com/runtime/apollo/issues/1620

<!-- link to design, if applicable -->

### Description:

add fix for crash in test onBackpress

### Summary of changes:

- execute `onBackPressed()` on `Dispatchers.Main`

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1173/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  