### PR TITLE
`FeatureForm` : Add Assetgroup to asset type selection screen

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/SelectAssetTypeScreen.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/screens/SelectAssetTypeScreen.kt
@@ -104,6 +104,12 @@ internal fun SelectAssetTypeScreen(
                                 modifier = Modifier.padding(start = 16.dp)
                             )
                         },
+                        supportingContent = {
+                            Text(
+                                text = assetType.assetGroup.name,
+                                modifier = Modifier.padding(start = 16.dp)
+                            )
+                        },
                         colors = ListItemDefaults.colors(
                             containerColor = MaterialTheme.colorScheme.surfaceBright,
                         )


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/1654](https://devtopia.esri.com/runtime/apollo/issues/1654)

<!-- link to design, if applicable -->

### Description:

This PR updates the asset type selection screen to also show its assetGroup.

<img width="216" height="322" alt="Screenshot 2026-03-04 at 2 02 04 PM" src="https://github.com/user-attachments/assets/cff6aca5-2469-46cd-8087-432aa9c98502" />


### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1183/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  