### PR TITLE
Add network security config to Auth App

### DIFF
--- a/microapps/AuthenticationApp/app/src/main/AndroidManifest.xml
+++ b/microapps/AuthenticationApp/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AuthenticationApp"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/microapps/AuthenticationApp/app/src/main/res/xml/network_security_config.xml
+++ b/microapps/AuthenticationApp/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+    <base-config>
+        <trust-anchors>
+<!--            Let the app trust the system and user certificates. -->
+<!--            This is required to allow the app to connect to servers with self-signed certificates, -->
+<!--            which is common in enterprise environments. The user certificates are only trusted if -->
+<!--            the user has explicitly added them to their device, which is a reasonable requirement -->
+<!--            for trusting user certificates.-->
+            <certificates src="system" />
+            <certificates src="user"
+                    tools:ignore="AcceptsUserCertificates" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION


<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: `7277`

<!-- link to design, if applicable -->

### Description:

Modifying the Authentication micro app to connect to a PKI secured portal causes a Server Trust prompt to appear, similar to the following:

<img width="336" height="321" alt="image" src="https://github.com/user-attachments/assets/173fc2c2-7c92-4b77-98a7-150bdc5deb21" />


That's because the app does not trust user-installed self-signed certificates. The prompt can be avoided by adding a network security config to the app, which trusts system and user-installed client certificates by default.

### Summary of changes:

- Add a network security config to the app, which trusts system and user-installed client certificates by default.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1206/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  