### PR TITLE
`FeatureForm` : Remove and fix deprecated API usages

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/navigation/Navigator.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/navigation/Navigator.kt
@@ -22,7 +22,7 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -69,7 +69,6 @@ sealed class NavigationRoute {
 }
 
 @Composable
-@Suppress("DEPRECATION")
 fun AppNavigation(
     navController: NavHostController,
     navigator: Navigator,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/FolderContentScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/FolderContentScreen.kt
@@ -53,7 +53,6 @@ import kotlinx.serialization.json.Json
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Suppress("DEPRECATION")
 fun FolderContentScreen(
     viewModel: FolderContentViewModel = hiltViewModel(),
     onItemSelected: () -> Unit,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/FolderContentScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/FolderContentScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.datastore.preferences.core.edit
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arcgismaps.toolkit.featureformsapp.data.CURRENT_FOLDER
 import com.arcgismaps.toolkit.featureformsapp.data.datastore
 import kotlinx.serialization.json.Json

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentScreen.kt
@@ -60,7 +60,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.datastore.preferences.core.edit
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arcgismaps.portal.PortalFolder
 import com.arcgismaps.toolkit.featureformsapp.AnimatedLoading
 import com.arcgismaps.toolkit.featureformsapp.R

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/browse/PortalContentScreen.kt
@@ -76,7 +76,6 @@ import java.time.format.DateTimeFormatter
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Suppress("DEPRECATION")
 fun PortalContentScreen(
     modifier: Modifier = Modifier,
     onFolderClick: (PortalFolder) -> Unit,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
@@ -101,7 +101,6 @@ import com.arcgismaps.toolkit.featureformsapp.AnimatedLoading
 import com.arcgismaps.toolkit.featureformsapp.R
 
 @Composable
-@Suppress("DEPRECATION")
 fun LoginScreen(
     viewModel: LoginViewModel = hiltViewModel(),
     onSuccessfulLogin: () -> Unit = {}

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/login/LoginScreen.kt
@@ -95,7 +95,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arcgismaps.toolkit.authentication.Authenticator
 import com.arcgismaps.toolkit.featureformsapp.AnimatedLoading
 import com.arcgismaps.toolkit.featureformsapp.R

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -124,7 +124,6 @@ import com.arcgismaps.toolkit.geoviewcompose.MapView
 import kotlinx.coroutines.launch
 
 @Composable
-@Suppress("DEPRECATION")
 fun MapScreen(
     mapViewModel: MapViewModel,
     onBackPressed: () -> Unit = {}

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchScreen.kt
@@ -51,7 +51,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arcgismaps.toolkit.featureformsapp.R
 import com.arcgismaps.toolkit.featureformsapp.screens.browse.MapListItem
 import java.util.Locale

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/search/SearchScreen.kt
@@ -58,7 +58,6 @@ import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Suppress("DEPRECATION")
 fun SearchScreen(
     viewModel: SearchViewModel = hiltViewModel(),
     onItemSelected: () -> Unit,

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/ui/theme/Theme.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/ui/theme/Theme.kt
@@ -51,7 +51,6 @@ private val LightColorScheme = lightColorScheme(
 )
 
 @Composable
-@Suppress("DEPRECATION")
 fun FeatureFormsAppTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/BarcodeTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/BarcodeTests.kt
@@ -102,12 +102,12 @@ class BarcodeTests : FeatureFormTestRunner(
         // Check the custom barcode click action is triggered
         assertThat(fieldFormElement).isNotNull()
         assertThat(fieldFormElement!!.label).isEqualTo("Barcode")
-        assertThat(fieldFormElement!!.input).isInstanceOf(BarcodeScannerFormInput::class.java)
-        val barcodeScannerFormInput = fieldFormElement!!.input as BarcodeScannerFormInput
+        assertThat(fieldFormElement.input).isInstanceOf(BarcodeScannerFormInput::class.java)
+        val barcodeScannerFormInput = fieldFormElement.input as BarcodeScannerFormInput
         assertThat(barcodeScannerFormInput.maxLength).isEqualTo(50)
         // set a value to the barcode field
         var barcodeValue = "0123456789"
-        fieldFormElement!!.updateValue(barcodeValue)
+        fieldFormElement.updateValue(barcodeValue)
         firstBarcodeElement.assertEditableTextEquals(barcodeValue)
 
         val secondBarcodeElement = composeTestRule.onNodeWithText("Model Number")
@@ -119,13 +119,13 @@ class BarcodeTests : FeatureFormTestRunner(
         secondScanIcon.performClick()
         // Check the custom barcode click action is triggered
         assertThat(fieldFormElement).isNotNull()
-        assertThat(fieldFormElement!!.label).isEqualTo("Model Number")
-        assertThat(fieldFormElement!!.input).isInstanceOf(BarcodeScannerFormInput::class.java)
-        val secondBarcodeScannerFormInput = fieldFormElement!!.input as BarcodeScannerFormInput
+        assertThat(fieldFormElement.label).isEqualTo("Model Number")
+        assertThat(fieldFormElement.input).isInstanceOf(BarcodeScannerFormInput::class.java)
+        val secondBarcodeScannerFormInput = fieldFormElement.input as BarcodeScannerFormInput
         assertThat(secondBarcodeScannerFormInput.maxLength).isEqualTo(10)
         // set a value to the barcode field
         barcodeValue = "9876543210"
-        fieldFormElement!!.updateValue(barcodeValue)
+        fieldFormElement.updateValue(barcodeValue)
         secondBarcodeElement.assertEditableTextEquals(barcodeValue)
     }
 
@@ -161,12 +161,12 @@ class BarcodeTests : FeatureFormTestRunner(
         // Check the custom barcode click action is triggered
         assertThat(fieldFormElement).isNotNull()
         assertThat(fieldFormElement!!.label).isEqualTo("Barcode in Group")
-        assertThat(fieldFormElement!!.input).isInstanceOf(BarcodeScannerFormInput::class.java)
-        val barcodeScannerFormInput = fieldFormElement!!.input as BarcodeScannerFormInput
+        assertThat(fieldFormElement.input).isInstanceOf(BarcodeScannerFormInput::class.java)
+        val barcodeScannerFormInput = fieldFormElement.input as BarcodeScannerFormInput
         assertThat(barcodeScannerFormInput.maxLength).isEqualTo(25)
         assertThat(barcodeScannerFormInput.minLength).isEqualTo(10)
         val barcodeValue = "0123456789"
-        fieldFormElement!!.updateValue(barcodeValue)
+        fieldFormElement.updateValue(barcodeValue)
         barcodeElement.assertEditableTextEquals(barcodeValue)
     }
 

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
@@ -58,6 +58,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -161,7 +162,6 @@ internal fun UtilityAssociationGroupResult(
  *
  */
 @Composable
-@Suppress("DEPRECATION")
 private fun AssociationItem(
     title: String,
     association: UtilityAssociation,
@@ -189,17 +189,6 @@ private fun AssociationItem(
     val swipeToDismissBoxState = remember(association) {
         SwipeToDismissBoxState(
             initialValue = SwipeToDismissBoxValue.Settled,
-            density = density,
-            confirmValueChange = { value ->
-                if (value == SwipeToDismissBoxValue.EndToStart) {
-                    showDeleteDialog = true
-                    // Set a pending value instead of confirming the value change directly. There
-                    // is a bug/limitation in SwipeToDismissBox that causes the swipe behavior to
-                    // not work after the first swipe, if we confirm the value change directly here.
-                    pendingSwipeValue = value
-                }
-                false
-            },
             positionalThreshold = {
                 with(density) { 56.dp.toPx() }
             }
@@ -286,7 +275,16 @@ private fun AssociationItem(
         },
         modifier = modifier
             .clickable(enabled = enabled, onClick = onClick)
-            .fillMaxWidth()
+            .fillMaxWidth(),
+        onDismiss = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
+                showDeleteDialog = true
+                // Set a pending value instead of confirming the value change directly. There
+                // is a bug/limitation in SwipeToDismissBox that causes the swipe behavior to
+                // not work after the first swipe, if we confirm the value change directly here.
+                pendingSwipeValue = value
+            }
+        }
     ) {
         Row(
             modifier = Modifier
@@ -370,8 +368,10 @@ private fun AssociationItem(
         // Confirmation dialog to delete the association
         RemoveAssociationConfirmationDialog(
             onDismiss = {
-                showDeleteDialog = false
-                pendingSwipeValue = SwipeToDismissBoxValue.Settled
+                Snapshot.withMutableSnapshot {
+                    showDeleteDialog = false
+                    pendingSwipeValue = SwipeToDismissBoxValue.Settled
+                }
             },
             onRemove = {
                 showDeleteDialog = false

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/utilitynetwork/UtilityAssociationGroupResult.kt
@@ -277,11 +277,11 @@ private fun AssociationItem(
             .clickable(enabled = enabled, onClick = onClick)
             .fillMaxWidth(),
         onDismiss = { value ->
+            // Show the delete confirmation dialog when a swipe to delete is performed.
             if (value == SwipeToDismissBoxValue.EndToStart) {
                 showDeleteDialog = true
-                // Set a pending value instead of confirming the value change directly. There
-                // is a bug/limitation in SwipeToDismissBox that causes the swipe behavior to
-                // not work after the first swipe, if we confirm the value change directly here.
+                // The actual swipe value will be set in a LaunchedEffect when the user confirms the
+                // deletion.
                 pendingSwipeValue = value
             }
         }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #https://devtopia.esri.com/runtime/apollo/issues/1574

<!-- link to design, if applicable -->

### Description:

This PR removes deprecation suppressions in the micro-app and the toolkit and updates the deprecated usages.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1217/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  