### PR TITLE
Handle getCurrentViewpointCamera returning null in SceneView & LocalSceneView

### DIFF
--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/LocalSceneView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/LocalSceneView.kt
@@ -444,20 +444,25 @@ private fun ViewpointHandler(
 
     LaunchedEffect(Unit) {
         // if there is a persisted viewpoint, restore it when the LocalSceneView enters the composition
+        // TODO: use Camera for persistence (like SceneView does) once issues with Camera matrix
+        //  are fixed for LSV (issues 3893 and 6878)
         persistedViewpoint?.let { localSceneView.setViewpoint(it) }
         launch {
             localSceneView.viewpointChanged.collect {
                 val currentViewpointCenterAndScale =
                     localSceneView.getCurrentViewpoint(ViewpointType.CenterAndScale)
                 persistedViewpoint = currentViewpointCenterAndScale
-                currentOnCurrentViewpointCameraChanged?.invoke(localSceneView.getCurrentViewpointCamera())
+
+                localSceneView.getCurrentViewpointCamera()?.let { currentViewpointCamera ->
+                    currentOnCurrentViewpointCameraChanged?.invoke(currentViewpointCamera)
+                }
                 currentOnViewpointChangedForCenterAndScale?.let { callback ->
                     currentViewpointCenterAndScale?.let(callback)
                 }
                 currentOnViewpointChangedForBoundingGeometry?.let { callback ->
-                    val currentViewpoint =
-                        localSceneView.getCurrentViewpoint(ViewpointType.BoundingGeometry)
-                    currentViewpoint?.let(callback)
+                    localSceneView.getCurrentViewpoint(ViewpointType.BoundingGeometry)?.let { currentViewpointBoundingGeometry ->
+                        callback.invoke(currentViewpointBoundingGeometry)
+                    }
                 }
             }
         }

--- a/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/SceneView.kt
+++ b/toolkit/geoview-compose/src/main/java/com/arcgismaps/toolkit/geoviewcompose/SceneView.kt
@@ -669,18 +669,20 @@ private fun ViewpointHandler(
         persistedCamera?.let { sceneView.setViewpointCamera(it) }
         launch {
             sceneView.viewpointChanged.collect {
-                val currentViewpointCamera = sceneView.getCurrentViewpointCamera()
-                persistedCamera = currentViewpointCamera
-                currentOnCurrentViewpointCameraChanged?.invoke(currentViewpointCamera)
+                sceneView.getCurrentViewpointCamera()?.let { currentViewpointCamera ->
+                    // update persistedCamera regardless of whether we need to invoke currentOnCurrentViewpointCameraChanged
+                    persistedCamera = currentViewpointCamera
+                    currentOnCurrentViewpointCameraChanged?.invoke(currentViewpointCamera)
+                }
                 currentOnViewpointChangedForCenterAndScale?.let { callback ->
-                    val currentViewpoint =
-                        sceneView.getCurrentViewpoint(ViewpointType.CenterAndScale)
-                    currentViewpoint?.let(callback)
+                    sceneView.getCurrentViewpoint(ViewpointType.CenterAndScale)?.let { currentViewpointCenterAndScale ->
+                        callback.invoke(currentViewpointCenterAndScale)
+                    }
                 }
                 currentOnViewpointChangedForBoundingGeometry?.let { callback ->
-                    val currentViewpoint =
-                        sceneView.getCurrentViewpoint(ViewpointType.BoundingGeometry)
-                    currentViewpoint?.let(callback)
+                    sceneView.getCurrentViewpoint(ViewpointType.BoundingGeometry)?.let { currentViewpointBoundingGeometry ->
+                        callback.invoke(currentViewpointBoundingGeometry)
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: `6874`

<!-- link to design, if applicable -->

### Description:

For a detailed description see PR in kotlin repo: `7465`

### Summary of changes:
- update internal code of composable SceneView & LocalSceneView to handle null being returned from `getCurrentViewpointCamera`
- clean up code to avoid unnecessary local variables
- this has been tested ad-hoc

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/300.0.0/job/vtest/job/toolkit/3/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  