### PR TITLE
use function setter, property setter is deprecated.

### DIFF
--- a/toolkit/ar/src/androidTest/java/com/arcgismaps/toolkit/ar/PeDataTests.kt
+++ b/toolkit/ar/src/androidTest/java/com/arcgismaps/toolkit/ar/PeDataTests.kt
@@ -45,7 +45,7 @@ class PeDataTests {
     @Before
     fun setup() {
         initialPeDirectory = TransformationCatalog.projectionEngineDirectory
-        TransformationCatalog.projectionEngineDirectory = ""
+        TransformationCatalog.setProjectionEngineDirectory("")
         if (gridFile.exists()) {
             gridFile.delete()
         }
@@ -54,7 +54,7 @@ class PeDataTests {
     @After
     fun tearDown() {
         // restore initial state
-        TransformationCatalog.projectionEngineDirectory = initialPeDirectory
+        TransformationCatalog.setProjectionEngineDirectory(initialPeDirectory!!)
     }
 
     /**
@@ -101,7 +101,7 @@ class PeDataTests {
         assertThat(TransformationCatalog.projectionEngineDirectory).isEmpty()
         assertThat(gridFile.exists()).isFalse()
         val somePath = InstrumentationRegistry.getInstrumentation().context.getExternalFilesDir(null)?.canonicalPath
-        TransformationCatalog.projectionEngineDirectory = somePath
+        TransformationCatalog.setProjectionEngineDirectory(somePath!!)
 
         val context = InstrumentationRegistry.getInstrumentation().context
         assertThat(PeData.configure(context).isSuccess).isTrue()

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/PeData.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/PeData.kt
@@ -72,7 +72,7 @@ internal object PeData {
 
             if (result.isSuccess) {
                 // set the projection engine directory
-                TransformationCatalog.projectionEngineDirectory = destinationPath
+                TransformationCatalog.setProjectionEngineDirectory(destinationPath)
             }
             result
         }

--- a/toolkit/geoview-compose/src/androidTest/java/com/arcgismaps/toolkit/geoviewcompose/callout/CalloutTests.kt
+++ b/toolkit/geoview-compose/src/androidTest/java/com/arcgismaps/toolkit/geoviewcompose/callout/CalloutTests.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.arcgismaps.toolkit.geoviewcompose.GeoViewScope
@@ -224,7 +225,7 @@ class CalloutTests {
         )
 
         val calloutContainerNodeInteraction = composeTestRule
-            .onNodeWithContentDescription(calloutContainerLabel)
+            .onNodeWithTag(calloutContainerLabel)
 
         val calloutBitmap = calloutContainerNodeInteraction.captureToImage().asAndroidBitmap()
         // test if the Callout contains a Red background Color


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #7401

<!-- link to design, if applicable -->

### Description:

make setters of TransformationCatalog.proejectionEngineDirectory use `setProjectionEngineDirectory(..)`

### Summary of changes:

- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/Release/job/300.0.0/job/vtest/job/toolkit/10/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  