### PR TITLE
Updates test to verify behavior when Location properties return `NaN`

### DIFF
--- a/toolkit/ar/src/androidTest/java/com/arcgismaps/toolkit/ar/LocationFilteringTests.kt
+++ b/toolkit/ar/src/androidTest/java/com/arcgismaps/toolkit/ar/LocationFilteringTests.kt
@@ -96,6 +96,32 @@ class LocationFilteringTests {
         )
         assertThat(shouldUpdateCamera(recentLocationWithNoAccuracy, nullIslandEGM96Vertical)).isFalse()
 
+        val recentLocationWithNoHorizontalAccuracy = Location.create(
+            nullIslandWgs84,
+            Double.NaN,
+            1.0,
+            0.0,
+            0.0,
+            false,
+            Instant.now().minusMillis(50)
+        )
+        assertThat(
+            shouldUpdateCamera(recentLocationWithNoHorizontalAccuracy, nullIslandEGM96Vertical)
+        ).isFalse()
+
+        val recentLocationWithNoVerticalAccuracy = Location.create(
+            nullIslandWgs84,
+            1.0,
+            Double.NaN,
+            0.0,
+            0.0,
+            false,
+            Instant.now().minusMillis(50)
+        )
+        assertThat(
+            shouldUpdateCamera(recentLocationWithNoVerticalAccuracy, nullIslandEGM96Vertical)
+        ).isFalse()
+
         val recentLocationWithBadAccuracy = Location.create(
             nullIslandWgs84,
             10.0,
@@ -110,5 +136,9 @@ class LocationFilteringTests {
         val recentLocationFarFarAway =
             Location.create(farFarAwayWgs84, 1.0, 1.0, 0.0, 0.0, true, Instant.now())
         assertThat(shouldUpdateCamera(recentLocationFarFarAway, nullIslandEGM96Vertical)).isTrue()
+
+        val recentLocationFarFarAwayWithNoSpeed =
+            Location.create(farFarAwayWgs84, 1.0, 1.0, Double.NaN, 0.0, true, Instant.now())
+        assertThat(shouldUpdateCamera(recentLocationFarFarAwayWithNoSpeed, nullIslandEGM96Vertical)).isTrue()
     }
 }

--- a/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/WorldTrackingCameraController.kt
+++ b/toolkit/ar/src/main/java/com/arcgismaps/toolkit/ar/internal/WorldTrackingCameraController.kt
@@ -234,7 +234,7 @@ internal class WorldTrackingCameraController(
  * Evaluates a location to determine if the camera should be updated.
  *
  * Returns false if the location timestamp is older than a threshold,
- * if the horizontal or vertical accuracy is negative,
+ * if the horizontal or vertical accuracy is negative or unavailable (`NaN`),
  * or if the distance between the location and the current camera is less than a threshold.
  * Otherwise, returns true.
  *


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/7536

<!-- link to design, if applicable -->

### Description:



### Summary of changes:

- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  