### PR TITLE
`FeatureForm` : Micro-app add ability to rollback local edits

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -52,8 +52,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Info
@@ -61,6 +59,7 @@ import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
@@ -92,8 +91,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -105,7 +104,6 @@ import androidx.window.core.layout.WindowSizeClass
 import androidx.window.core.layout.computeWindowSizeClass
 import androidx.window.layout.WindowMetricsCalculator
 import com.arcgismaps.data.ArcGISFeature
-import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.layers.ArcGISSublayer
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.layers.SubtypeFeatureLayer
@@ -627,7 +625,12 @@ fun MessageDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
             if (message.actionText != null) {
-                Button(onClick = message.action) {
+                Button(
+                    onClick = message.action,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
                     Text(text = message.actionText)
                 }
             }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -626,6 +626,13 @@ fun MessageDialog(
     AlertDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
+            if (message.actionText != null) {
+                Button(onClick = message.action) {
+                    Text(text = message.actionText)
+                }
+            }
+        },
+        dismissButton = {
             Button(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.okay))
             }

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -35,6 +35,7 @@ import com.arcgismaps.data.ArcGISFeatureTable
 import com.arcgismaps.data.FeatureEditResult
 import com.arcgismaps.data.FeatureTemplate
 import com.arcgismaps.data.ServiceFeatureTable
+import com.arcgismaps.data.ServiceGeodatabase
 import com.arcgismaps.geometry.GeometryType
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.mapping.ArcGISMap
@@ -160,13 +161,15 @@ data class DefaultFeatureRow(
 
 
 /**
- * Indicates an error state with the given [error].
+ * Represents a message to be shown in the UI with a title, details, and an optional action.
  */
 data class UIMessage(
     val kind: Kind,
     val title: String,
     val details: String,
-    val subTitle: String = ""
+    val subTitle: String = "",
+    val actionText: String? = null,
+    val action: () -> Unit = {}
 ) {
     enum class Kind {
         Error,
@@ -602,7 +605,7 @@ class MapViewModel @Inject constructor(
         }
         if (serviceFeatureTable.serviceGeodatabase?.hasLocalEdits() == false) {
             _uiMessage.value = UIMessage(
-                kind = UIMessage.Kind.Success,
+                kind = UIMessage.Kind.Info,
                 title = application.getString(R.string.already_up_to_date),
                 details = application.getString(R.string.no_local_edits)
             )
@@ -640,7 +643,14 @@ class MapViewModel @Inject constructor(
             _uiMessage.value = UIMessage(
                 kind = UIMessage.Kind.Error,
                 title = application.getString(R.string.failed_to_apply_edits),
-                details = errorText
+                details = errorText,
+                actionText = application.getString(R.string.undo_all_edits),
+                action = {
+                    viewModelScope.launch {
+                        // rollback the edits if user confirms the action through the UI message
+                        rollbackLocalEdits(serviceFeatureTable.serviceGeodatabase!!)
+                    }
+                }
             )
         } else {
             _uiMessage.value = UIMessage(
@@ -708,6 +718,34 @@ class MapViewModel @Inject constructor(
                 details = application.getString(R.string.map_is_in_sync_with_service)
             )
         }
+    }
+
+    /**
+     * Rolls back any local edits in the service geodatabase and refreshes the feature in the map
+     * if there is an active feature form.
+     */
+    private suspend fun rollbackLocalEdits(serviceGeodatabase: ServiceGeodatabase) {
+        // set to busy
+        _isBusy.value = true
+        serviceGeodatabase.undoLocalEdits().onSuccess {
+            // refresh the feature in the map if there is an active feature form
+            if (uiState.value is UIState.Editing) {
+                val featureFormState = (uiState.value as UIState.Editing).featureFormState
+                featureFormState.activeFeatureForm.feature.refresh()
+            }
+            _uiMessage.value = UIMessage(
+                kind = UIMessage.Kind.Success,
+                title = application.getString(R.string.success),
+                details = application.getString(R.string.edits_rolled_back)
+            )
+        }.onFailure {
+            _uiMessage.value = UIMessage(
+                kind = UIMessage.Kind.Error,
+                title = application.getString(R.string.failed_to_rollback_edits),
+                details = application.getString(R.string.no_servicefeaturetable)
+            )
+        }
+        _isBusy.value = false
     }
 }
 

--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapViewModel.kt
@@ -732,6 +732,9 @@ class MapViewModel @Inject constructor(
             if (uiState.value is UIState.Editing) {
                 val featureFormState = (uiState.value as UIState.Editing).featureFormState
                 featureFormState.activeFeatureForm.feature.refresh()
+                // discard edits needed to reset the state of the form including its attachments and
+                // associations to match the refreshed feature
+                featureFormState.discardEdits()
             }
             _uiMessage.value = UIMessage(
                 kind = UIMessage.Kind.Success,

--- a/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
+++ b/microapps/FeatureFormsApp/app/src/main/res/values/strings.xml
@@ -80,4 +80,7 @@
     <string name="map_is_in_sync_with_service">The Map is in sync with the service</string>
     <string name="failed_to_sync_with_the_service">Failed to sync with the service</string>
     <string name="failed_to_create_sync_parameters">Failed to create sync parameters</string>
+    <string name="undo_all_edits">Undo all edits</string>
+    <string name="failed_to_rollback_edits">Failed to rollback local edits</string>
+    <string name="edits_rolled_back">All local edits have been rolled back</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #https://devtopia.esri.com/runtime/apollo/issues/1518

<!-- link to design, if applicable -->

### Description:

This PR adds the ability to roll back local geodatabase edits when commiting edits to the server fails.

### Summary of changes:

- Added an action to the UIMessage that can be invoked by the UI and defined by the MapViewModel.
- Provided such an action to rollback local edits when committing edits fails in a connected scenario.
- Data to test is in the linked issue.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  