### PR TITLE
`FeatureForm`: Fix back navigation in the micro-app

### DIFF
--- a/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
+++ b/microapps/FeatureFormsApp/app/src/main/java/com/arcgismaps/toolkit/featureformsapp/screens/map/MapScreen.kt
@@ -301,8 +301,11 @@ fun MapScreen(
             }
         )
     }
-    BackHandler(enabled = uiState !is UIState.Editing) {
-        onBackPressed()
+    BackHandler {
+        // Only allow back navigation when in the default state and not performing a task
+        if (uiState is UIState.NotEditing && isBusy.not()) {
+            onBackPressed()
+        }
     }
 }
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #https://devtopia.esri.com/runtime/apollo/issues/1466

<!-- link to design, if applicable -->

### Description:

This PR fixes a bug in the micro-app, where when the form is open and the system back gesture/button is triggered, the micro-app goes back one screen.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  