### PR TITLE
`FeatureForm`: Add additional properties to AttachmentsFormElement

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureFormState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureFormState.kt
@@ -169,11 +169,11 @@ public class FeatureFormState private constructor(
      *
      * @since 200.8.0
      */
-    public suspend fun discardEdits() :  Result<List<FormExpressionEvaluationError>> {
+    public suspend fun discardEdits(): Result<List<FormExpressionEvaluationError>> {
         val formData = getActiveFormStateData()
         formData.featureForm.discardEdits()
         formData.stateCollection.forEach {
-            when(it.state) {
+            when (it.state) {
                 is AttachmentElementState -> {
                     (it.state as AttachmentElementState).refreshAttachments()
                 }
@@ -249,7 +249,7 @@ public class FeatureFormState private constructor(
      * @param feature the [ArcGISFeature] to create the [FeatureForm] for.
      */
     @MainThread
-    internal fun navigateTo(backStackEntry: NavBackStackEntry, feature: ArcGISFeature, ): Boolean {
+    internal fun navigateTo(backStackEntry: NavBackStackEntry, feature: ArcGISFeature): Boolean {
         val navigateTo = navigateToRoute ?: return false
         // Check if the backStackEntry is in the resumed state.
         if (backStackEntry.lifecycleIsResumed().not()) return false
@@ -317,15 +317,24 @@ public class FeatureFormState private constructor(
     internal fun validateAllFields() {
         // Force validation of all the states in the current form.
         getActiveFormStateData().stateCollection.forEach { entry ->
-            // validate all fields
-            if (entry.formElement is FieldFormElement) {
-                entry.getState<BaseFieldState<*>>().forceValidation()
-            }
-            // validate any fields that are within a group
-            if (entry.formElement is GroupFormElement) {
-                entry.getState<BaseGroupState>().fieldStates.forEach { childEntry ->
-                    childEntry.getState<BaseFieldState<*>>().forceValidation()
+            when (entry.formElement) {
+                // validate attachments
+                is AttachmentsFormElement -> {
+                    (entry.getState<AttachmentElementState>()).forceValidation()
                 }
+                // validate all fields
+                is FieldFormElement -> {
+                    entry.getState<BaseFieldState<*>>().forceValidation()
+                }
+
+                // validate any fields that are within a group
+                is GroupFormElement -> {
+                    entry.getState<BaseGroupState>().fieldStates.forEach { childEntry ->
+                        childEntry.getState<BaseFieldState<*>>().forceValidation()
+                    }
+                }
+
+                else -> {}
             }
         }
     }
@@ -347,7 +356,7 @@ internal data class FormStateData(
     /**
      * Indicates if the expressions for the [featureForm] have been evaluated at least once.
      */
-    var initialEvaluation : Boolean by mutableStateOf(false)
+    var initialEvaluation: Boolean by mutableStateOf(false)
         private set
 
     /**
@@ -361,7 +370,7 @@ internal data class FormStateData(
      * evaluation, the [initialEvaluation] is set to true. While this function is running, the
      * [isEvaluatingExpressions] will be true.
      */
-    suspend fun evaluateExpressions() : Result<List<FormExpressionEvaluationError>> {
+    suspend fun evaluateExpressions(): Result<List<FormExpressionEvaluationError>> {
         try {
             isEvaluatingExpressions = true
             return featureForm.evaluateExpressions().onSuccess {

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.core.content.ContextCompat
@@ -52,11 +53,14 @@ import com.arcgismaps.mapping.featureforms.FormAttachment
 import com.arcgismaps.mapping.featureforms.FormAttachmentType
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.base.FormElementState
+import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -106,7 +110,7 @@ internal class AttachmentElementState(
     /**
      * Indicates whether renaming an attachment is allowed.
      */
-    val allowUserRename : Boolean = true
+    val allowUserRename: Boolean = true
 
     /**
      * Indicates whether the attachment form element is editable.
@@ -116,13 +120,13 @@ internal class AttachmentElementState(
     /**
      * Indicates whether the filename of the attachment should be displayed.
      */
-    val displayFilename : Boolean = true
+    val displayFilename: Boolean = true
 
     /**
      * The input type for the attachment form element. This is determined based on the allowed
      * attachment types specified by the form element.
      */
-    val inputType = ImageAttachmentsFormInput (
+    val inputType = ImageAttachmentsFormInput(
         inputMethod = ImageAttachmentsFormInput.InputMethod.Capture
     ) // formElement.input
 
@@ -134,19 +138,69 @@ internal class AttachmentElementState(
     /**
      * The maximum number of attachments that can be added.
      */
-    val maxAttachmentCount : Int = Int.MAX_VALUE
+    val maxAttachmentCount: Int = Int.MAX_VALUE
 
     /**
      * The minimum number of attachments that must be added.
      */
-    val minAttachmentCount : Int = 0
+    val minAttachmentCount: Int = 0
 
     /**
      * Indicates whether to use the original filename of the attachment when adding an attachment.
      */
-    val useOriginalFilename : Boolean = true
+    val useOriginalFilename: Boolean = true
+
+    /**
+     * A validation error for the attachment form element.
+     */
+    val validationError: ValidationErrorState
+        get() = _validationError.value
+
+    /**
+     * Backing mutable state for the [validationError] property.
+     */
+    private var _validationError: MutableState<ValidationErrorState> = mutableStateOf(
+        ValidationErrorState.NoError
+    )
+
+    /**
+     * Indicates whether the attachment form element has ever been focused.
+     */
+    val wasFocused: Boolean
+        get() = _wasFocused.value
+
+    /**
+     * Backing mutable state for the [wasFocused] property.
+     */
+    private var _wasFocused = mutableStateOf(false)
+
+    /**
+     * A list of validation errors for the attachments.
+     */
+    private val validationErrors: StateFlow<List<ValidationErrorState>> = MutableStateFlow(
+        listOf(
+            ValidationErrorState.NullNotAllowed
+        )
+    )
 
     init {
+        scope.launch {
+            // Produce a validation error based on the current state of the errors and the focused
+            // state. The error is only shown when the element is focused.
+            combine(
+                snapshotFlow { _wasFocused.value },
+                validationErrors
+            ) { focused, errors ->
+                Pair(focused, errors)
+            }.collect {
+                val (focused, errors) = it
+                _validationError.value = if (focused) {
+                    errors.firstOrNull() ?: ValidationErrorState.NoError
+                } else {
+                    ValidationErrorState.NoError
+                }
+            }
+        }
         refreshAttachments()
     }
 
@@ -191,11 +245,21 @@ internal class AttachmentElementState(
      * Adds an attachment with the given [name], [contentType], and [filePath].
      */
     suspend fun addAttachment(name: String, contentType: String, filePath: String): Result<Unit> {
-        return formElement.addAttachment(
-            name = name,
-            contentType = contentType,
-            filePath = filePath
-        ).onSuccess { formAttachment ->
+        return if (useOriginalFilename) {
+            formElement.addAttachment(
+                name = name,
+                contentType = contentType,
+                filePath = filePath
+            )
+        } else {
+            // Replace this with an overload of addAttachment that does not require the name parameter
+            // once it is available. This API would generate a name based on a specified arcade expression
+            formElement.addAttachment(
+                name = name,
+                contentType = contentType,
+                filePath = filePath
+            )
+        }.onSuccess { formAttachment ->
             // create a new state
             val attachment = FormAttachmentState(
                 name = formAttachment.name,
@@ -241,6 +305,19 @@ internal class AttachmentElementState(
             state.formAttachment == formAttachment
         }?.name = newName
         scope.launch { evaluateExpressions() }
+    }
+
+    /**
+     * Changes the current focus state for the element.
+     */
+    fun onFocusChanged(focus: Boolean) {
+        if (focus) {
+            _wasFocused.value = true
+        }
+    }
+
+    fun forceValidation() {
+        _wasFocused.value = true
     }
 
     /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -104,9 +104,19 @@ internal class AttachmentElementState(
         get() = _attachments
 
     /**
+     * Indicates whether renaming an attachment is allowed.
+     */
+    val allowUserRename : Boolean = true
+
+    /**
      * Indicates whether the attachment form element is editable.
      */
     val isEditable = formElement.isEditable
+
+    /**
+     * Indicates whether the filename of the attachment should be displayed.
+     */
+    val displayFilename : Boolean = true
 
     /**
      * The input type for the attachment form element. This is determined based on the allowed
@@ -120,6 +130,21 @@ internal class AttachmentElementState(
      * The state of the lazy list that displays the [attachments].
      */
     val lazyListState = LazyListState()
+
+    /**
+     * The maximum number of attachments that can be added.
+     */
+    val maxAttachmentCount : Int = Int.MAX_VALUE
+
+    /**
+     * The minimum number of attachments that must be added.
+     */
+    val minAttachmentCount : Int = 0
+
+    /**
+     * Indicates whether to use the original filename of the attachment when adding an attachment.
+     */
+    val useOriginalFilename : Boolean = true
 
     init {
         refreshAttachments()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -104,7 +104,7 @@ internal fun AttachmentFormElement(
     AttachmentFormElement(
         label = state.label,
         description = state.description,
-        editable = editable,
+        isEditable = editable,
         captureOptions = CaptureOptions.Any,
         inputType = inputType,
         hasCameraPermission = state.hasCameraPermissions(context),
@@ -126,7 +126,7 @@ internal fun AttachmentFormElement(
 internal fun AttachmentFormElement(
     label: String,
     description: String,
-    editable: Boolean,
+    isEditable: Boolean,
     captureOptions: CaptureOptions,
     inputType: ImageAttachmentsFormInput,
     hasCameraPermission: Boolean,
@@ -142,7 +142,7 @@ internal fun AttachmentFormElement(
     colors: AttachmentsElementColors = LocalColorScheme.current.attachmentsElementColors,
     typography: AttachmentsElementTypography = LocalTypography.current.attachmentsElementTypography
 ) {
-    val canAddAttachments = attachments.size < maxAttachmentCount && editable
+    val canAddAttachments = attachments.size < maxAttachmentCount && isEditable
     val isError = error !is ValidationErrorState.NoError
     val supportingText = if (isError) {
         error.getString()
@@ -650,7 +650,7 @@ private fun AttachmentFormElementPreview() {
     AttachmentFormElement(
         label = "Attachments",
         description = "Add attachments",
-        editable = true,
+        isEditable = true,
         captureOptions = CaptureOptions.Any,
         inputType = ImageAttachmentsFormInput(
             inputMethod = ImageAttachmentsFormInput.InputMethod.Capture

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
@@ -105,10 +106,13 @@ internal fun AttachmentFormElement(
         editable = editable,
         captureOptions = CaptureOptions.Any,
         inputType = inputType,
+        hasCameraPermission = state.hasCameraPermissions(context),
+        allowUserRename = state.allowUserRename,
+        displayFilename = state.displayFilename,
+        maxAttachmentCount = state.maxAttachmentCount,
         stateId = state.id,
         attachments = state.attachments,
         lazyListState = state.lazyListState,
-        hasCameraPermission = state.hasCameraPermissions(context),
         modifier = modifier
     )
 }
@@ -120,14 +124,18 @@ internal fun AttachmentFormElement(
     editable: Boolean,
     captureOptions: CaptureOptions,
     inputType: ImageAttachmentsFormInput,
+    hasCameraPermission: Boolean,
+    allowUserRename: Boolean,
+    displayFilename: Boolean,
+    maxAttachmentCount: Int,
     stateId: Int,
     attachments: List<FormAttachmentState>,
     lazyListState: LazyListState,
-    hasCameraPermission: Boolean,
     modifier: Modifier = Modifier,
     colors: AttachmentsElementColors = LocalColorScheme.current.attachmentsElementColors,
     typography: AttachmentsElementTypography = LocalTypography.current.attachmentsElementTypography
 ) {
+    val canAddAttachments = attachments.size < maxAttachmentCount && editable
     Surface (
         modifier = modifier.semantics(mergeDescendants = true) {},
         color = colors.containerColor
@@ -145,7 +153,7 @@ internal fun AttachmentFormElement(
                     descriptionTextStyle = typography.supportingTextStyle
                 )
                 Spacer(modifier = Modifier.weight(1f))
-                if (editable) {
+                if (canAddAttachments) {
                     // Add attachment button
                     AddAttachment(
                         stateId = stateId,
@@ -156,7 +164,13 @@ internal fun AttachmentFormElement(
                 }
             }
             Spacer(modifier = Modifier.height(20.dp))
-            Carousel(lazyListState, attachments, colors.scrollBarColor)
+            Carousel(
+                state = lazyListState,
+                attachments = attachments,
+                allowUserRename = allowUserRename,
+                displayFilename = displayFilename,
+                scrollBarColor = colors.scrollBarColor
+            )
         }
     }
 }
@@ -165,6 +179,8 @@ internal fun AttachmentFormElement(
 private fun Carousel(
     state: LazyListState,
     attachments: List<FormAttachmentState>,
+    allowUserRename: Boolean,
+    displayFilename: Boolean,
     scrollBarColor: Color,
 ) {
     var initialSize by remember(state) {
@@ -193,7 +209,12 @@ private fun Carousel(
         state = state,
     ) {
         items(attachments) { attachment ->
-            AttachmentTile(state = attachment, modifier = Modifier.padding(end = 8.dp))
+            AttachmentTile(
+                state = attachment,
+                allowUserRename = allowUserRename,
+                displayFilename = displayFilename,
+                modifier = Modifier.padding(end = 8.dp)
+            )
         }
     }
 }
@@ -562,7 +583,7 @@ internal fun Modifier.horizontalScrollbar(
                 drawRoundRect(
                     color = trackColor,
                     topLeft = Offset(0f, scrollBarOffsetY),
-                    size = androidx.compose.ui.geometry.Size(size.width, height.toPx()),
+                    size = Size(size.width, height.toPx()),
                     cornerRadius = CornerRadius(10f, 10f),
                     alpha = alpha
                 )
@@ -570,7 +591,7 @@ internal fun Modifier.horizontalScrollbar(
                 drawRoundRect(
                     color = color,
                     topLeft = Offset(scrollBarOffsetX, scrollBarOffsetY),
-                    size = androidx.compose.ui.geometry.Size(scrollbarWidth, height.toPx()),
+                    size = Size(scrollbarWidth, height.toPx()),
                     cornerRadius = CornerRadius(10f, 10f),
                     alpha = alpha
                 )
@@ -600,9 +621,12 @@ private fun AttachmentFormElementPreview() {
         inputType = ImageAttachmentsFormInput(
             inputMethod = ImageAttachmentsFormInput.InputMethod.Capture
         ),
+        hasCameraPermission = true,
+        allowUserRename = true,
+        displayFilename = true,
+        maxAttachmentCount = 5,
         stateId = 1,
         attachments = list + list + list + list,
         lazyListState = LazyListState(),
-        hasCameraPermission = true,
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -91,6 +91,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import java.time.Instant
 import androidx.core.net.toUri
+import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
 
 @Composable
 internal fun AttachmentFormElement(
@@ -112,7 +113,11 @@ internal fun AttachmentFormElement(
         maxAttachmentCount = state.maxAttachmentCount,
         stateId = state.id,
         attachments = state.attachments,
+        error = state.validationError,
         lazyListState = state.lazyListState,
+        onFocused = {
+            state.onFocusChanged(true)
+        },
         modifier = modifier
     )
 }
@@ -130,13 +135,21 @@ internal fun AttachmentFormElement(
     maxAttachmentCount: Int,
     stateId: Int,
     attachments: List<FormAttachmentState>,
+    error: ValidationErrorState,
     lazyListState: LazyListState,
+    onFocused: () -> Unit,
     modifier: Modifier = Modifier,
     colors: AttachmentsElementColors = LocalColorScheme.current.attachmentsElementColors,
     typography: AttachmentsElementTypography = LocalTypography.current.attachmentsElementTypography
 ) {
     val canAddAttachments = attachments.size < maxAttachmentCount && editable
-    Surface (
+    val isError = error !is ValidationErrorState.NoError
+    val supportingText = if (isError) {
+        error.getString()
+    } else {
+        description
+    }
+    Surface(
         modifier = modifier.semantics(mergeDescendants = true) {},
         color = colors.containerColor
     ) {
@@ -146,7 +159,8 @@ internal fun AttachmentFormElement(
             ) {
                 Header(
                     title = label,
-                    description = description,
+                    supportingText = supportingText,
+                    isError = isError,
                     titleColor = colors.labelColor,
                     titleTextStyle = typography.labelStyle,
                     descriptionColor = colors.supportingTextColor,
@@ -156,6 +170,7 @@ internal fun AttachmentFormElement(
                 if (canAddAttachments) {
                     // Add attachment button
                     AddAttachment(
+                        onFocused = onFocused,
                         stateId = stateId,
                         captureOptions = captureOptions,
                         inputType = inputType,
@@ -167,10 +182,17 @@ internal fun AttachmentFormElement(
             Carousel(
                 state = lazyListState,
                 attachments = attachments,
+                onItemFocused = onFocused,
                 allowUserRename = allowUserRename,
                 displayFilename = displayFilename,
                 scrollBarColor = colors.scrollBarColor
             )
+        }
+    }
+    LaunchedEffect(lazyListState.isScrollInProgress) {
+        // if the user is scrolling and an item is focused, clear the focus to hide the keyboard
+        if (lazyListState.isScrollInProgress) {
+            onFocused()
         }
     }
 }
@@ -179,6 +201,7 @@ internal fun AttachmentFormElement(
 private fun Carousel(
     state: LazyListState,
     attachments: List<FormAttachmentState>,
+    onItemFocused: () -> Unit,
     allowUserRename: Boolean,
     displayFilename: Boolean,
     scrollBarColor: Color,
@@ -210,6 +233,7 @@ private fun Carousel(
     ) {
         items(attachments) { attachment ->
             AttachmentTile(
+                onFocused = onItemFocused,
                 state = attachment,
                 allowUserRename = allowUserRename,
                 displayFilename = displayFilename,
@@ -222,13 +246,19 @@ private fun Carousel(
 @Composable
 private fun Header(
     title: String,
-    description: String,
+    supportingText: String,
+    isError: Boolean,
     titleColor: Color,
     titleTextStyle: TextStyle,
     descriptionColor: Color,
     descriptionTextStyle: TextStyle,
     modifier: Modifier = Modifier
 ) {
+    val supportingTextColor = if (isError) {
+        MaterialTheme.colorScheme.error
+    } else {
+        descriptionColor
+    }
     Row(
         modifier = modifier.wrapContentHeight(),
         verticalAlignment = Alignment.CenterVertically
@@ -241,10 +271,10 @@ private fun Header(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            if (description.isNotEmpty()) {
+            if (supportingText.isNotEmpty()) {
                 Text(
-                    text = description,
-                    color = descriptionColor,
+                    text = supportingText,
+                    color = supportingTextColor,
                     style = descriptionTextStyle,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
@@ -256,6 +286,7 @@ private fun Header(
 
 @Composable
 private fun AddAttachment(
+    onFocused: () -> Unit,
     stateId: Int,
     captureOptions: CaptureOptions,
     inputType: ImageAttachmentsFormInput,
@@ -268,17 +299,20 @@ private fun AddAttachment(
     val inputMethod = inputType.inputMethod
     val supportsCapture = remember(inputMethod) {
         inputMethod == ImageAttachmentsFormInput.InputMethod.Capture ||
-                inputMethod == ImageAttachmentsFormInput.InputMethod.Any
+            inputMethod == ImageAttachmentsFormInput.InputMethod.Any
     }
 
     val supportsUpload = remember(inputMethod) {
         inputMethod == ImageAttachmentsFormInput.InputMethod.Upload ||
-                inputMethod == ImageAttachmentsFormInput.InputMethod.Any
+            inputMethod == ImageAttachmentsFormInput.InputMethod.Any
     }
 
     Box {
         IconButton(
-            onClick = { showMenu = true },
+            onClick = {
+                onFocused()
+                showMenu = true
+            },
         ) {
             Icon(
                 Icons.Rounded.Add,
@@ -627,6 +661,8 @@ private fun AttachmentFormElementPreview() {
         maxAttachmentCount = 5,
         stateId = 1,
         attachments = list + list + list + list,
+        error = ValidationErrorState.NullNotAllowed,
         lazyListState = LazyListState(),
+        onFocused = {}
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -90,8 +90,20 @@ import java.io.File
 @Composable
 internal fun AttachmentTile(
     state: FormAttachmentState,
+    allowUserRename: Boolean,
+    displayFilename: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val name = remember(state.name) {
+        if (displayFilename) {
+            state.name
+        } else {
+            ""
+        }
+    }
+    val isRenameEnabled = remember(state) {
+        allowUserRename && state.size <= maxAttachmentUploadSize
+    }
     val loadStatus by state.loadStatus.collectAsState()
     val interactionSource = remember(state) { MutableInteractionSource() }
     val thumbnail by state.thumbnail
@@ -115,14 +127,14 @@ internal fun AttachmentTile(
         Box(modifier = Modifier) {
             when (loadStatus) {
                 LoadStatus.Loaded -> LoadedView(
-                    title = state.name,
+                    title = name,
                     size = state.size,
                     type = state.type,
                     thumbnail = thumbnail
                 )
 
                 else -> DefaultView(
-                    title = state.name,
+                    title = name,
                     size = state.size,
                     type = state.type,
                     loadStatus = loadStatus
@@ -152,7 +164,7 @@ internal fun AttachmentTile(
                             )
                         }
                     },
-                    enabled = state.size <= maxAttachmentUploadSize
+                    enabled = isRenameEnabled
                 )
                 DropdownMenuItem(
                     text = { Text(text = stringResource(R.string.delete)) },
@@ -282,7 +294,9 @@ private fun IconView(
     ) {
         icon()
         Spacer(modifier = Modifier.height(4.dp))
-        Title(text = title, modifier = Modifier)
+        if (title.isNotEmpty()) {
+            Title(text = title, modifier = Modifier)
+        }
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center
@@ -315,21 +329,23 @@ private fun LoadedView(
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize()
             )
-            Column(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth()
-                    .height(20.dp)
-                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Title(
-                    text = title,
+            if (title.isNotEmpty()) {
+                Column(
                     modifier = Modifier
+                        .align(Alignment.BottomCenter)
                         .fillMaxWidth()
-                        .padding(horizontal = 5.dp),
-                )
+                        .height(20.dp)
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Title(
+                        text = title,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 5.dp),
+                    )
+                }
             }
         } else {
             IconView(
@@ -433,7 +449,7 @@ private fun Size(
 @Composable
 private fun AttachmentTilePreview() {
     AttachmentTile(
-        FormAttachmentState(
+        state = FormAttachmentState(
             "Photo 1.jpg",
             2024,
             "image/jpeg",
@@ -441,6 +457,8 @@ private fun AttachmentTilePreview() {
             1,
             {},
             scope = rememberCoroutineScope()
-        )
+        ),
+        allowUserRename = true,
+        displayFilename = false
     )
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -89,6 +89,7 @@ import java.io.File
 
 @Composable
 internal fun AttachmentTile(
+    onFocused: () -> Unit,
     state: FormAttachmentState,
     allowUserRename: Boolean,
     displayFilename: Boolean,
@@ -193,6 +194,7 @@ internal fun AttachmentTile(
     LaunchedEffect(interactionSource, state) {
         var wasALongPress = false
         interactionSource.interactions.collectLatest {
+            onFocused()
             when (it) {
                 is PressInteraction.Press -> {
                     wasALongPress = false
@@ -449,6 +451,7 @@ private fun Size(
 @Composable
 private fun AttachmentTilePreview() {
     AttachmentTile(
+        onFocused = {},
         state = FormAttachmentState(
             "Photo 1.jpg",
             2024,


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: [#apollo/1719](https://devtopia.esri.com/runtime/apollo/issues/1719)

<!-- link to design, if applicable -->

### Description:

This PR provides prototyped behavior for the new properties being introduced for the `AttachmentsFormElement`.

### Summary of changes:

- Added new properties to the `AttachmentElementState` class and consumed by the `AttachmentFormElement` composable.
- Added validation behavior for the element. Validation errors are shown when the element receives focus or based on the `validationErrorVisibility`.
- Please see the linked issue for more information on the details.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  