### PR TITLE
Remove eager afterEvaluate usages

### DIFF
--- a/build-logic-internal/convention/src/main/kotlin/AndroidIntegrationTestingConventionPlugin.kt
+++ b/build-logic-internal/convention/src/main/kotlin/AndroidIntegrationTestingConventionPlugin.kt
@@ -49,50 +49,44 @@ class AndroidIntegrationTestingConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             pluginManager.withPlugin("com.android.library") {
-                afterEvaluate {
-                    val androidDsl = extensions.getByType(LibraryExtension::class.java)
-                    val androidComponents = extensions.getByType(LibraryAndroidComponentsExtension::class.java)
-                    val adbPath = androidComponents.sdkComponents.adb.get().asFile
-
+                val androidDsl = extensions.getByType(LibraryExtension::class.java)
+                val androidComponents =
+                    extensions.getByType(LibraryAndroidComponentsExtension::class.java)
+                val grantDevicePermissionsTask =
                     tasks.register<GrantDevicePermissions>("grantDevicePermissions") {
-                        if (adbPath.exists()) {
-                            adbExe.set(adbPath.absoluteFile)
-                        }
-                        val testAppId = androidDsl.defaultConfig.testApplicationId
-                        if (!testAppId.isNullOrBlank()) {
-                            testApplicationId.set(testAppId)
-                        }
+                        adbExe.set(androidComponents.sdkComponents.adb.map { it.asFile.absoluteFile })
+                        testApplicationId.set(project.provider {
+                            androidDsl.defaultConfig.testApplicationId.orEmpty()
+                        })
                     }
 
-                    val syncTestDataBeforeInstrumentedTests =
-                        project.findProperty("syncTestDataBeforeInstrumentedTests")
-                            ?.toString()?.toBoolean() ?: false
+                val syncTestDataBeforeInstrumentedTests =
+                    project.findProperty("syncTestDataBeforeInstrumentedTests")
+                        ?.toString()?.toBoolean() ?: false
 
-                    tasks.forEach { task ->
-                        if (task.name.startsWith("connected") && task.name.endsWith("AndroidTest")) {
-                            task.dependsOn("grantDevicePermissions")
-                            if (syncTestDataBeforeInstrumentedTests) {
-                                task.dependsOn(
-                                    gradle.includedBuild("build-logic-internal")
-                                        .task(":syncTestData")
-                                )
-                            }
-
-                            task.dependsOn(
-                                gradle.includedBuild("build-logic-internal")
-                                    .task(":deleteICOutput")
-                            )
-
-                        }
+                tasks.matching {
+                    it.name.startsWith("connected") && it.name.endsWith("AndroidTest")
+                }.configureEach {
+                    dependsOn(grantDevicePermissionsTask)
+                    if (syncTestDataBeforeInstrumentedTests) {
+                        dependsOn(
+                            gradle.includedBuild("build-logic-internal")
+                                .task(":syncTestData")
+                        )
                     }
 
-                    // Wire the grantDevicePermissions task to depend on install*AndroidTest tasks
-                    tasks.forEach { task ->
-                        if (task.name.startsWith("install") && task.name.endsWith("AndroidTest")) {
-                            tasks.named("grantDevicePermissions").configure {
-                                dependsOn(task.name)
-                            }
-                        }
+                    dependsOn(
+                        gradle.includedBuild("build-logic-internal")
+                            .task(":deleteICOutput")
+                    )
+                }
+
+                // Wire the grantDevicePermissions task to depend on install*AndroidTest tasks
+                tasks.matching {
+                    it.name.startsWith("install") && it.name.endsWith("AndroidTest")
+                }.configureEach {
+                    grantDevicePermissionsTask.configure {
+                        dependsOn(this@configureEach)
                     }
                 }
             }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -26,6 +26,13 @@ plugins {
     `maven-publish`
 }
 
+tasks {
+    validatePlugins {
+        enableStricterValidation = true
+        failOnWarning = true
+    }
+}
+
 version = "1.0"
 
 gradlePlugin {

--- a/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
+++ b/buildSrc/src/main/kotlin/deploy/ArtifactPublisher.kt
@@ -23,9 +23,7 @@ import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
-import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.provideDelegate
 import java.net.URI
 
@@ -55,37 +53,41 @@ class ArtifactPublisher : Plugin<Project> {
         } else {
             "$versionNumber-$buildNumber"
         }
-        val artifactoryArtifactId: String = "$artifactoryArtifactBaseId-${project.name}"
+        val artifactoryArtifactId = "$artifactoryArtifactBaseId-${project.name}"
         
         project.pluginManager.apply(MavenPublishPlugin::class.java)
-        project.afterEvaluate {
-            project.extensions.configure<PublishingExtension> {
-                repositories {
-                    repositories.maven {
-                        url = URI.create(artifactoryUrl)
-                        credentials {
-                            username = artifactoryUsername
-                            password = artifactoryPassword
-                        }
-                    }
-                }
-                publications {
-                    publications.create(
-                        project.name,
-                        MavenPublication::class.java
-                    ) {
-                        groupId = artifactoryGroupId
-                        artifactId = artifactoryArtifactId
-                        version = artifactVersion
-                        
-                        from(project.components["release"])
+        project.extensions.configure<PublishingExtension> {
+            repositories {
+                repositories.maven {
+                    url = URI.create(artifactoryUrl)
+                    credentials {
+                        username = artifactoryUsername
+                        password = artifactoryPassword
                     }
                 }
             }
 
-            tasks.findByName("publish${project.name.replaceFirstChar { it.uppercase() }}PublicationToMavenRepository")
-                ?.dependsOn("assembleRelease")
-            tasks.findByName("publishToMavenLocal")?.dependsOn("assembleRelease")
+            project.components.configureEach releaseComponent@{
+                if (name != "release") return@releaseComponent
+
+                publications.create(
+                    project.name,
+                    MavenPublication::class.java
+                ) {
+                    groupId = artifactoryGroupId
+                    artifactId = artifactoryArtifactId
+                    version = artifactVersion
+
+                    from(this@releaseComponent)
+                }
+            }
+        }
+
+        project.tasks.matching { task ->
+            task.name == "publish${project.name.replaceFirstChar { it.uppercase() }}PublicationToMavenRepository"
+                    || task.name == "publishToMavenLocal"
+        }.configureEach {
+            dependsOn("assembleRelease")
         }
     }
 }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Review suggestion to use 9.x API patterns to ensure project does not depended on evaluation timing and direct component lookup. 


### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1257