### PR TITLE
`FeatureForm`: Add `GenericAttachmentFormInput`

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
@@ -358,44 +358,45 @@ private fun AttachmentsFormInput.getCaptureOptions(): List<CaptureOptions> {
         }
 
         is GenericAttachmentFormInput -> {
-            val options = mutableListOf<CaptureOptions>()
-            val types = mutableListOf<VisualMediaType>()
-            val mimeTypes = mutableListOf<String>()
-            inputTypes.forEach { type ->
-                when (type) {
-                    is ImageAttachmentsFormInput -> {
-                        when (type.inputMethod) {
-                            ImageAttachmentsFormInput.InputMethod.Capture -> {
-                                options.add(CaptureOptions.CaptureImage)
-                            }
-
-                            ImageAttachmentsFormInput.InputMethod.Upload -> {
-                                types.add(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                                mimeTypes.add("image/*")
-                            }
-
-                            ImageAttachmentsFormInput.InputMethod.Any -> {
-                                options.add(CaptureOptions.CaptureImage)
-                                types.add(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                                mimeTypes.add("image/*")
-                            }
-                        }
-                    }
-
-                    else -> {}
-                }
-            }
-            if (types.isNotEmpty()) {
-                options.add(CaptureOptions.Gallery(mediaType = types.toPickerMediaType()))
-            }
-            if (mimeTypes.isNotEmpty()) {
-                options.add(CaptureOptions.File(allowedMimeTypes = mimeTypes))
-            }
-            options
+            inputTypes.flatMap { type ->
+                type.getCaptureOptions()
+            }.merge()
         }
     }
 }
 
+/**
+ * Merges a list of [CaptureOptions] by combining multiple gallery options into one with multiple
+ * media types and combining multiple file options into one with multiple allowed MIME types.
+ */
+private fun List<CaptureOptions>.merge(): List<CaptureOptions> {
+    val options = mutableListOf<CaptureOptions>()
+    // Add explicit capture options first
+    options.addAll(
+        this.filter {
+            it is CaptureOptions.CaptureAudio
+                || it is CaptureOptions.CaptureImage
+                || it is CaptureOptions.CaptureVideo
+        }
+    )
+    // Find gallery options and merge them into one if there are multiples
+    val galleryOptions = this.filterIsInstance<CaptureOptions.Gallery>()
+    if (galleryOptions.isNotEmpty()) {
+        val mediaTypes = galleryOptions.map { it.mediaType }
+        options.add(CaptureOptions.Gallery(mediaType = mediaTypes.toPickerMediaType()))
+    }
+    // Find file options and merge them into one if there are multiples
+    val fileOptions = this.filterIsInstance<CaptureOptions.File>()
+    if (fileOptions.isNotEmpty()) {
+        val allowedMimeTypes = fileOptions.flatMap { it.allowedMimeTypes }.distinct()
+        options.add(CaptureOptions.File(allowedMimeTypes = allowedMimeTypes))
+    }
+    return options
+}
+
+/**
+ * Converts a list of [VisualMediaType] to a single [VisualMediaType] for the gallery picker.
+ */
 private fun List<VisualMediaType>.toPickerMediaType(): VisualMediaType = when {
     size == 1 -> first()
     contains(ActivityResultContracts.PickVisualMedia.ImageOnly) && contains(ActivityResultContracts.PickVisualMedia.VideoOnly) -> ActivityResultContracts.PickVisualMedia.ImageAndVideo

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
@@ -366,8 +366,14 @@ private fun AttachmentsFormInput.getCaptureOptions(): List<CaptureOptions> {
 }
 
 /**
- * Merges a list of [CaptureOptions] by combining multiple gallery options into one with multiple
- * media types and combining multiple file options into one with multiple allowed MIME types.
+ * A [GenericAttachmentFormInput] may contain multiple input types, which can lead to duplicate
+ * capture options. This function merges those duplicate options into one.
+ *
+ * For example, if there are multiple gallery options with different media types, they will be
+ * merged into one gallery option with multiple media types.
+ *
+ * Similarly, if there are multiple file options with different allowed MIME types, they will be merged
+ * into one file option with multiple allowed MIME types.
  */
 private fun List<CaptureOptions>.merge(): List<CaptureOptions> {
     val options = mutableListOf<CaptureOptions>()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2026 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.attachment
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.Photo
+import androidx.compose.material.icons.rounded.PhotoCamera
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.core.net.toUri
+import com.arcgismaps.toolkit.featureforms.R
+import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
+import com.arcgismaps.toolkit.featureforms.internal.utils.DialogType
+import com.arcgismaps.toolkit.featureforms.internal.utils.LocalDialogRequester
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import java.time.Instant
+
+/**
+ * A component that provides UI for adding attachments.
+ */
+@Composable
+internal fun AddAttachment(
+    onFocused: () -> Unit,
+    stateId: Int,
+    inputType: AttachmentsFormInput,
+    hasCameraPermission: Boolean,
+) {
+    var showMenu by remember { mutableStateOf(false) }
+    val dialogRequester = LocalDialogRequester.current
+    val scope = rememberCoroutineScope()
+    val pickerStyle = remember { MutableSharedFlow<PickerStyle>() }
+    val captureOptions = remember(inputType) {
+        inputType.getCaptureOptions()
+    }
+
+    Box {
+        IconButton(
+            onClick = {
+                onFocused()
+                showMenu = true
+            },
+        ) {
+            Icon(
+                Icons.Rounded.Add,
+                contentDescription = "Add attachment",
+                modifier = Modifier.size(32.dp)
+            )
+        }
+        DropdownMenu(
+            expanded = showMenu,
+            offset = DpOffset.Zero,
+            onDismissRequest = { showMenu = false }
+        ) {
+            captureOptions.forEach { option ->
+                when (option) {
+                    CaptureOptions.CaptureAudio -> {
+                        // not supported yet
+                    }
+
+                    is CaptureOptions.CaptureImage if hasCameraPermission -> {
+                        DropdownMenuItem(
+                            text = { Text(text = stringResource(R.string.take_photo)) },
+                            trailingIcon = {
+                                Icon(
+                                    imageVector = Icons.Rounded.PhotoCamera,
+                                    contentDescription = "Take Photo",
+                                    modifier = Modifier.alpha(0.4f)
+                                )
+                            },
+                            onClick = {
+                                scope.launch {
+                                    pickerStyle.emit(PickerStyle.Camera)
+                                    showMenu = false
+                                }
+                            }
+                        )
+                    }
+
+                    is CaptureOptions.CaptureVideo if hasCameraPermission -> {
+                        // not supported yet
+                    }
+
+                    is CaptureOptions.Gallery -> {
+                        DropdownMenuItem(
+                            text = { Text(text = stringResource(R.string.add_from_gallery)) },
+                            trailingIcon = {
+                                Icon(
+                                    imageVector = Icons.Rounded.Photo,
+                                    contentDescription = "Add From Gallery",
+                                    modifier = Modifier.alpha(0.4f)
+                                )
+                            },
+                            onClick = {
+                                scope.launch {
+                                    pickerStyle.emit(PickerStyle.PickMedia(option.mediaType))
+                                    showMenu = false
+                                }
+                            }
+                        )
+                    }
+
+                    is CaptureOptions.File -> {
+                        DropdownMenuItem(
+                            text = { Text(text = stringResource(R.string.add_file)) },
+                            trailingIcon = {
+                                Icon(
+                                    imageVector = Icons.Rounded.Folder,
+                                    contentDescription = "Add File",
+                                    modifier = Modifier.alpha(0.4f)
+                                )
+                            },
+                            onClick = {
+                                scope.launch {
+                                    pickerStyle.emit(PickerStyle.File(option.allowedMimeTypes))
+                                    showMenu = false
+                                }
+                            }
+                        )
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+    }
+    LaunchedEffect(Unit) {
+        pickerStyle.collect {
+            when (it) {
+                PickerStyle.Camera -> {
+                    dialogRequester.requestDialog(
+                        DialogType.ImageCaptureDialog(
+                            stateId = stateId
+                        )
+                    )
+                }
+
+                is PickerStyle.PickMedia -> {
+                    dialogRequester.requestDialog(
+                        DialogType.GalleryPickerDialog(
+                            stateId = stateId,
+                            type = it.type
+                        )
+                    )
+                }
+
+                is PickerStyle.File -> {
+                    dialogRequester.requestDialog(
+                        DialogType.FilePickerDialog(
+                            stateId = stateId,
+                            allowedTypes = it.allowedMimeTypes
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Launches the camera to capture an image. When an image is captured, the [onImageCaptured] callback
+ * is invoked with the URI of the captured image. In case of a dismissal or if no image is captured,
+ * the [onDismissRequest] callback is invoked.
+ *
+ * @param onDismissRequest A request to dismiss the camera picker.
+ * @param onImageCaptured A callback to invoke when an image is captured.
+ */
+@Composable
+internal fun ImageCapture(
+    onDismissRequest: () -> Unit,
+    onImageCaptured: (Uri) -> Unit
+) {
+    val context = LocalContext.current
+    var hasLaunched by rememberSaveable {
+        mutableStateOf(false)
+    }
+    val capturedImageUri = rememberSaveable(
+        saver = listSaver(
+            save = { listOf(it.toString()) },
+            restore = { it.first().toUri() }
+        )
+    ) {
+        val timeStamp = Instant.now().toEpochMilli()
+        AttachmentsFileProvider.createTempFileWithUri("IMAGE_$timeStamp", ".jpg", context)
+    }
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture(),
+        onResult = { success ->
+            if (success) {
+                onImageCaptured(capturedImageUri)
+            } else {
+                onDismissRequest()
+            }
+        }
+    )
+    LaunchedEffect(Unit) {
+        if (!hasLaunched) {
+            hasLaunched = true
+            cameraLauncher.launch(capturedImageUri)
+        }
+    }
+}
+
+/**
+ * Launches the Gallery to select an image, video or both based on the [type]. When a selection is
+ * made, the [onMediaSelected] callback is invoked with the URI of the selected image/video. In case
+ * of a dismissal or if no media is selected, the [onDismissRequest] callback is invoked.
+ *
+ * @param type The type of media to select.
+ * @param onDismissRequest A request to dismiss the gallery picker.
+ * @param onMediaSelected A callback to invoke when a media file is selected.
+ */
+@Composable
+internal fun GalleryPicker(
+    type: VisualMediaType,
+    onDismissRequest: () -> Unit,
+    onMediaSelected: (Uri) -> Unit
+) {
+    var hasLaunched by rememberSaveable {
+        mutableStateOf(false)
+    }
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia()
+    ) {
+        if (it != null) {
+            onMediaSelected(it)
+        } else {
+            onDismissRequest()
+        }
+    }
+    Dialog(onDismissRequest = onDismissRequest) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(50.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            strokeWidth = 5.dp
+        )
+    }
+    LaunchedEffect(Unit) {
+        if (!hasLaunched) {
+            hasLaunched = true
+            launcher.launch(PickVisualMediaRequest(type))
+        }
+    }
+}
+
+/**
+ * Launches the file picker to select a file based on the [allowedMimeTypes]. When a file is selected,
+ * the [onFileSelected] callback is invoked with the URI of the selected file. In case of a dismissal
+ * or if no file is selected, the [onDismissRequest] callback is invoked.
+ *
+ * @param allowedMimeTypes The list of allowed MIME types to select.
+ * @param onDismissRequest A request to dismiss the file picker.
+ * @param onFileSelected A callback to invoke when a file is selected.
+ */
+@Composable
+internal fun FilePicker(
+    allowedMimeTypes: List<String>,
+    onDismissRequest: () -> Unit,
+    onFileSelected: (Uri) -> Unit
+) {
+    var hasLaunched by rememberSaveable {
+        mutableStateOf(false)
+    }
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
+        if (it != null) {
+            onFileSelected(it)
+        } else {
+            onDismissRequest()
+        }
+    }
+    Dialog(onDismissRequest = onDismissRequest) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(50.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            strokeWidth = 5.dp
+        )
+    }
+    LaunchedEffect(Unit) {
+        if (!hasLaunched) {
+            hasLaunched = true
+            launcher.launch(allowedMimeTypes.toTypedArray())
+        }
+    }
+}
+
+/**
+ * Determines the type of picker to launch.
+ */
+private sealed class PickerStyle {
+    data object Camera : PickerStyle()
+    data class PickMedia(val type: VisualMediaType) : PickerStyle()
+    data class File(val allowedMimeTypes: List<String>) : PickerStyle()
+}
+
+/**
+ * Determines the capture options available for an attachment form input.
+ */
+private fun AttachmentsFormInput.getCaptureOptions(): List<CaptureOptions> {
+    return when (this) {
+        is ImageAttachmentsFormInput -> {
+            when (inputMethod) {
+                ImageAttachmentsFormInput.InputMethod.Capture -> listOf(CaptureOptions.CaptureImage)
+                ImageAttachmentsFormInput.InputMethod.Upload -> listOf(
+                    CaptureOptions.Gallery(mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly),
+                    CaptureOptions.File(allowedMimeTypes = listOf("image/*"))
+                )
+
+                ImageAttachmentsFormInput.InputMethod.Any -> listOf(
+                    CaptureOptions.CaptureImage,
+                    CaptureOptions.Gallery(mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly),
+                    CaptureOptions.File(allowedMimeTypes = listOf("image/*"))
+                )
+            }
+        }
+
+        is GenericAttachmentFormInput -> {
+            val options = mutableListOf<CaptureOptions>()
+            val types = mutableListOf<VisualMediaType>()
+            val mimeTypes = mutableListOf<String>()
+            inputTypes.forEach { type ->
+                when (type) {
+                    is ImageAttachmentsFormInput -> {
+                        when (type.inputMethod) {
+                            ImageAttachmentsFormInput.InputMethod.Capture -> {
+                                options.add(CaptureOptions.CaptureImage)
+                            }
+
+                            ImageAttachmentsFormInput.InputMethod.Upload -> {
+                                types.add(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                mimeTypes.add("image/*")
+                            }
+
+                            ImageAttachmentsFormInput.InputMethod.Any -> {
+                                options.add(CaptureOptions.CaptureImage)
+                                types.add(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                mimeTypes.add("image/*")
+                            }
+                        }
+                    }
+
+                    else -> {}
+                }
+            }
+            if (types.isNotEmpty()) {
+                options.add(CaptureOptions.Gallery(mediaType = types.toPickerMediaType()))
+            }
+            if (mimeTypes.isNotEmpty()) {
+                options.add(CaptureOptions.File(allowedMimeTypes = mimeTypes))
+            }
+            options
+        }
+    }
+}
+
+private fun List<VisualMediaType>.toPickerMediaType(): VisualMediaType = when {
+    size == 1 -> first()
+    contains(ActivityResultContracts.PickVisualMedia.ImageOnly) && contains(ActivityResultContracts.PickVisualMedia.VideoOnly) -> ActivityResultContracts.PickVisualMedia.ImageAndVideo
+    else -> throw IllegalArgumentException("Unsupported combination of media types")
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -130,7 +130,7 @@ internal class AttachmentElementState(
         associationType = AttachmentAssociationType.Exact,
         inputTypes = listOf(
             ImageAttachmentsFormInput(
-                inputMethod = ImageAttachmentsFormInput.InputMethod.Capture
+                inputMethod = ImageAttachmentsFormInput.InputMethod.Any
             )
         )
     ) // formElement.input

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -126,8 +126,13 @@ internal class AttachmentElementState(
      * The input type for the attachment form element. This is determined based on the allowed
      * attachment types specified by the form element.
      */
-    val inputType = ImageAttachmentsFormInput(
-        inputMethod = ImageAttachmentsFormInput.InputMethod.Capture
+    val inputType = GenericAttachmentFormInput(
+        associationType = AttachmentAssociationType.Exact,
+        inputTypes = listOf(
+            ImageAttachmentsFormInput(
+                inputMethod = ImageAttachmentsFormInput.InputMethod.Capture
+            )
+        )
     ) // formElement.input
 
     /**
@@ -515,56 +520,6 @@ internal class FormAttachmentState(
                 throw ex
             }
             null
-        }
-    }
-}
-
-/**
- * Represents valid options for capturing attachments. This is used to determine the types of
- * attachments that can be captured by the UI.
- */
-internal sealed class CaptureOptions {
-
-    data object Image : CaptureOptions()
-    data object Video : CaptureOptions()
-    data object Audio : CaptureOptions()
-    data object Document : CaptureOptions()
-    data object Signature : CaptureOptions()
-    data object Any : CaptureOptions()
-    data object Unknown : CaptureOptions()
-
-    /**
-     * Returns `true` if the capture options include image capture.
-     */
-    fun hasImageCapture(): Boolean = this is Any || this is Image
-
-    /**
-     * Returns `true` if the capture options include video capture.
-     */
-    fun hasVideoCapture(): Boolean = this is Any || this is Video
-
-    /**
-     * Returns `true` if the capture options include image or video capture.
-     */
-    fun hasMediaCapture(): Boolean = hasImageCapture() || hasVideoCapture()
-
-    /**
-     * Returns `true` if the capture options include document capture.
-     */
-    fun hasFileCapture(): Boolean = this is Any || this is Document
-
-    /**
-     * Returns a list of allowed mime types for this capture option.
-     */
-    fun getAllowedMimeTypes(): List<String> {
-        return when (this) {
-            is Any -> listOf("*/*")
-            Audio -> listOf("audio/*")
-            Document -> listOf("application/*", "text/*")
-            Image -> listOf("image/*")
-            Signature -> listOf("image/*")
-            Video -> listOf("video/*")
-            Unknown -> emptyList()
         }
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -139,7 +139,6 @@ internal fun AttachmentFormElement(
                     AddAttachment(
                         onFocused = onFocused,
                         stateId = stateId,
-                        //captureOptions = captureOptions,
                         inputType = inputType,
                         hasCameraPermission = hasCameraPermission
                     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -16,34 +16,18 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
-import android.net.Uri
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Add
-import androidx.compose.material.icons.rounded.Folder
-import androidx.compose.material.icons.rounded.Photo
-import androidx.compose.material.icons.rounded.PhotoCamera
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -52,16 +36,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.listSaver
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
@@ -69,29 +49,19 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import com.arcgismaps.mapping.featureforms.FormAttachmentType
-import com.arcgismaps.toolkit.featureforms.R
-import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
-import com.arcgismaps.toolkit.featureforms.internal.utils.DialogType
-import com.arcgismaps.toolkit.featureforms.internal.utils.LocalDialogRequester
+import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
 import com.arcgismaps.toolkit.featureforms.theme.AttachmentsElementColors
 import com.arcgismaps.toolkit.featureforms.theme.AttachmentsElementTypography
 import com.arcgismaps.toolkit.featureforms.theme.LocalColorScheme
 import com.arcgismaps.toolkit.featureforms.theme.LocalTypography
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-import java.time.Instant
-import androidx.core.net.toUri
-import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
 
 @Composable
 internal fun AttachmentFormElement(
@@ -100,13 +70,11 @@ internal fun AttachmentFormElement(
 ) {
     val context = LocalContext.current
     val editable by state.isEditable.collectAsState()
-    val inputType: ImageAttachmentsFormInput = state.inputType
     AttachmentFormElement(
         label = state.label,
         description = state.description,
         isEditable = editable,
-        captureOptions = CaptureOptions.Any,
-        inputType = inputType,
+        inputType = state.inputType,
         hasCameraPermission = state.hasCameraPermissions(context),
         allowUserRename = state.allowUserRename,
         displayFilename = state.displayFilename,
@@ -127,8 +95,7 @@ internal fun AttachmentFormElement(
     label: String,
     description: String,
     isEditable: Boolean,
-    captureOptions: CaptureOptions,
-    inputType: ImageAttachmentsFormInput,
+    inputType: AttachmentsFormInput,
     hasCameraPermission: Boolean,
     allowUserRename: Boolean,
     displayFilename: Boolean,
@@ -172,7 +139,7 @@ internal fun AttachmentFormElement(
                     AddAttachment(
                         onFocused = onFocused,
                         stateId = stateId,
-                        captureOptions = captureOptions,
+                        //captureOptions = captureOptions,
                         inputType = inputType,
                         hasCameraPermission = hasCameraPermission
                     )
@@ -284,281 +251,6 @@ private fun Header(
     }
 }
 
-@Composable
-private fun AddAttachment(
-    onFocused: () -> Unit,
-    stateId: Int,
-    captureOptions: CaptureOptions,
-    inputType: ImageAttachmentsFormInput,
-    hasCameraPermission: Boolean,
-) {
-    var showMenu by remember { mutableStateOf(false) }
-    val dialogRequester = LocalDialogRequester.current
-    val scope = rememberCoroutineScope()
-    val pickerStyle = remember { MutableSharedFlow<PickerStyle>() }
-    val inputMethod = inputType.inputMethod
-    val supportsCapture = remember(inputMethod) {
-        inputMethod == ImageAttachmentsFormInput.InputMethod.Capture ||
-            inputMethod == ImageAttachmentsFormInput.InputMethod.Any
-    }
-
-    val supportsUpload = remember(inputMethod) {
-        inputMethod == ImageAttachmentsFormInput.InputMethod.Upload ||
-            inputMethod == ImageAttachmentsFormInput.InputMethod.Any
-    }
-
-    Box {
-        IconButton(
-            onClick = {
-                onFocused()
-                showMenu = true
-            },
-        ) {
-            Icon(
-                Icons.Rounded.Add,
-                contentDescription = "Add attachment",
-                modifier = Modifier.size(32.dp)
-            )
-        }
-        DropdownMenu(
-            expanded = showMenu,
-            offset = DpOffset.Zero,
-            onDismissRequest = { showMenu = false }
-        ) {
-            if (hasCameraPermission && captureOptions.hasImageCapture() && supportsCapture) {
-                DropdownMenuItem(
-                    text = { Text(text = stringResource(R.string.take_photo)) },
-                    trailingIcon = {
-                        Icon(
-                            imageVector = Icons.Rounded.PhotoCamera,
-                            contentDescription = "Take Photo",
-                            modifier = Modifier.alpha(0.4f)
-                        )
-                    },
-                    onClick = {
-                        scope.launch {
-                            pickerStyle.emit(PickerStyle.Camera)
-                            showMenu = false
-                        }
-                    }
-                )
-            }
-            if (captureOptions.hasMediaCapture() && supportsUpload) {
-                DropdownMenuItem(
-                    text = { Text(text = stringResource(R.string.add_from_gallery)) },
-                    trailingIcon = {
-                        Icon(
-                            imageVector = Icons.Rounded.Photo,
-                            contentDescription = "Add From Gallery",
-                            modifier = Modifier.alpha(0.4f)
-                        )
-                    },
-                    onClick = {
-                        scope.launch {
-                            val visualMediaType =
-                                if (captureOptions.hasImageCapture() && captureOptions.hasVideoCapture()) {
-                                    ActivityResultContracts.PickVisualMedia.ImageAndVideo
-                                } else if (captureOptions.hasImageCapture()) {
-                                    ActivityResultContracts.PickVisualMedia.ImageOnly
-                                } else {
-                                    ActivityResultContracts.PickVisualMedia.VideoOnly
-                                }
-                            pickerStyle.emit(PickerStyle.PickMedia(visualMediaType))
-                            showMenu = false
-                        }
-                    }
-                )
-            }
-            if (captureOptions.hasFileCapture() && supportsUpload) {
-                DropdownMenuItem(
-                    text = { Text(text = stringResource(R.string.add_file)) },
-                    trailingIcon = {
-                        Icon(
-                            imageVector = Icons.Rounded.Folder,
-                            contentDescription = "Add File",
-                            modifier = Modifier.alpha(0.4f)
-                        )
-                    },
-                    onClick = {
-                        scope.launch {
-                            pickerStyle.emit(PickerStyle.File(captureOptions.getAllowedMimeTypes()))
-                            showMenu = false
-                        }
-                    }
-                )
-            }
-        }
-    }
-    LaunchedEffect(Unit) {
-        pickerStyle.collect {
-            when (it) {
-                PickerStyle.Camera -> {
-                    dialogRequester.requestDialog(
-                        DialogType.ImageCaptureDialog(
-                            stateId = stateId
-                        )
-                    )
-                }
-
-                is PickerStyle.PickMedia -> {
-                    dialogRequester.requestDialog(
-                        DialogType.GalleryPickerDialog(
-                            stateId = stateId,
-                            type = it.type
-                        )
-                    )
-                }
-
-                is PickerStyle.File -> {
-                    dialogRequester.requestDialog(
-                        DialogType.FilePickerDialog(
-                            stateId = stateId,
-                            allowedTypes = it.allowedMimeTypes
-                        )
-                    )
-                }
-            }
-        }
-    }
-}
-
-/**
- * Launches the camera to capture an image. When an image is captured, the [onImageCaptured] callback
- * is invoked with the URI of the captured image. In case of a dismissal or if no image is captured,
- * the [onDismissRequest] callback is invoked.
- *
- * @param onDismissRequest A request to dismiss the camera picker.
- * @param onImageCaptured A callback to invoke when an image is captured.
- */
-@Composable
-internal fun ImageCapture(
-    onDismissRequest: () -> Unit,
-    onImageCaptured: (Uri) -> Unit
-) {
-    val context = LocalContext.current
-    var hasLaunched by rememberSaveable {
-        mutableStateOf(false)
-    }
-    val capturedImageUri = rememberSaveable(
-        saver = listSaver(
-            save = { listOf(it.toString()) },
-            restore = { it.first().toUri() }
-        )
-    ) {
-        val timeStamp = Instant.now().toEpochMilli()
-        AttachmentsFileProvider.createTempFileWithUri("IMAGE_$timeStamp", ".jpg", context)
-    }
-    val cameraLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.TakePicture(),
-        onResult = { success ->
-            if (success) {
-                onImageCaptured(capturedImageUri)
-            } else {
-                onDismissRequest()
-            }
-        }
-    )
-    LaunchedEffect(Unit) {
-        if (!hasLaunched) {
-            hasLaunched = true
-            cameraLauncher.launch(capturedImageUri)
-        }
-    }
-}
-
-/**
- * Launches the Gallery to select an image, video or both based on the [type]. When a selection is
- * made, the [onMediaSelected] callback is invoked with the URI of the selected image/video. In case
- * of a dismissal or if no media is selected, the [onDismissRequest] callback is invoked.
- *
- * @param type The type of media to select.
- * @param onDismissRequest A request to dismiss the gallery picker.
- * @param onMediaSelected A callback to invoke when a media file is selected.
- */
-@Composable
-internal fun GalleryPicker(
-    type: ActivityResultContracts.PickVisualMedia.VisualMediaType,
-    onDismissRequest: () -> Unit,
-    onMediaSelected: (Uri) -> Unit
-) {
-    var hasLaunched by rememberSaveable {
-        mutableStateOf(false)
-    }
-    val launcher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickVisualMedia()
-    ) {
-        if (it != null) {
-            onMediaSelected(it)
-        } else {
-            onDismissRequest()
-        }
-    }
-    Dialog(onDismissRequest = onDismissRequest) {
-        CircularProgressIndicator(
-            modifier = Modifier.size(50.dp),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            strokeWidth = 5.dp
-        )
-    }
-    LaunchedEffect(Unit) {
-        if (!hasLaunched) {
-            hasLaunched = true
-            launcher.launch(PickVisualMediaRequest(type))
-        }
-    }
-}
-
-/**
- * Launches the file picker to select a file based on the [allowedMimeTypes]. When a file is selected,
- * the [onFileSelected] callback is invoked with the URI of the selected file. In case of a dismissal
- * or if no file is selected, the [onDismissRequest] callback is invoked.
- *
- * @param allowedMimeTypes The list of allowed MIME types to select.
- * @param onDismissRequest A request to dismiss the file picker.
- * @param onFileSelected A callback to invoke when a file is selected.
- */
-@Composable
-internal fun FilePicker(
-    allowedMimeTypes: List<String>,
-    onDismissRequest: () -> Unit,
-    onFileSelected: (Uri) -> Unit
-) {
-    var hasLaunched by rememberSaveable {
-        mutableStateOf(false)
-    }
-    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
-        if (it != null) {
-            onFileSelected(it)
-        } else {
-            onDismissRequest()
-        }
-    }
-    Dialog(onDismissRequest = onDismissRequest) {
-        CircularProgressIndicator(
-            modifier = Modifier.size(50.dp),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            strokeWidth = 5.dp
-        )
-    }
-    LaunchedEffect(Unit) {
-        if (!hasLaunched) {
-            hasLaunched = true
-            launcher.launch(allowedMimeTypes.toTypedArray())
-        }
-    }
-}
-
-/**
- * Determines the type of picker to launch.
- */
-private sealed class PickerStyle {
-    data object Camera : PickerStyle()
-    data class PickMedia(val type: ActivityResultContracts.PickVisualMedia.VisualMediaType) :
-        PickerStyle()
-
-    data class File(val allowedMimeTypes: List<String>) : PickerStyle()
-}
-
 /**
  * Creates a horizontal scrollbar for a [LazyRow] with the given [state]. [offsetY] can be used to
  * adjust the offset of the scrollbar in the Y axis. This also adds the required padding to the
@@ -651,7 +343,6 @@ private fun AttachmentFormElementPreview() {
         label = "Attachments",
         description = "Add attachments",
         isEditable = true,
-        captureOptions = CaptureOptions.Any,
         inputType = ImageAttachmentsFormInput(
             inputMethod = ImageAttachmentsFormInput.InputMethod.Capture
         ),

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentsFormInput.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentsFormInput.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.attachment
+
+import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
+
+// Prototype
+
+/**
+ * Base class for an input type for [AttachmentsFormElement].
+ */
+internal sealed class AttachmentsFormInput

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/CaptureOptions.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/CaptureOptions.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.attachment
+
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.arcgismaps.toolkit.featureforms.R
+
+/**
+ * Represents valid options for capturing attachments. This is used to determine the types of
+ * attachments that can be captured by the UI.
+ */
+internal sealed class CaptureOptions {
+
+    data object CaptureImage : CaptureOptions()
+    data object CaptureVideo : CaptureOptions()
+    data class Gallery(val mediaType: VisualMediaType) : CaptureOptions()
+    data object CaptureAudio : CaptureOptions()
+    data class File(val allowedMimeTypes: List<String>) : CaptureOptions()
+
+    /**
+     * Returns a list of allowed mime types for this capture option.
+     */
+    fun getAllowedMimeTypes(): List<String> {
+        return when (this) {
+            CaptureAudio -> listOf("audio/*")
+            //Document -> listOf("application/*", "text/*")
+            CaptureImage -> listOf("image/*")
+            CaptureVideo -> listOf("video/*")
+            else -> emptyList()
+        }
+    }
+
+    @Composable
+    fun getString(): String = when (this) {
+        is CaptureAudio -> stringResource(R.string.record_audio)
+        is CaptureImage -> stringResource(R.string.take_photo)
+        is CaptureVideo -> stringResource(R.string.record_video)
+        is File -> stringResource(R.string.add_file)
+        is Gallery -> stringResource(R.string.add_from_gallery)
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/CaptureOptions.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/CaptureOptions.kt
@@ -17,41 +17,15 @@
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.stringResource
-import com.arcgismaps.toolkit.featureforms.R
 
 /**
  * Represents valid options for capturing attachments. This is used to determine the types of
  * attachments that can be captured by the UI.
  */
 internal sealed class CaptureOptions {
-
+    data object CaptureAudio : CaptureOptions()
     data object CaptureImage : CaptureOptions()
     data object CaptureVideo : CaptureOptions()
     data class Gallery(val mediaType: VisualMediaType) : CaptureOptions()
-    data object CaptureAudio : CaptureOptions()
     data class File(val allowedMimeTypes: List<String>) : CaptureOptions()
-
-    /**
-     * Returns a list of allowed mime types for this capture option.
-     */
-    fun getAllowedMimeTypes(): List<String> {
-        return when (this) {
-            CaptureAudio -> listOf("audio/*")
-            //Document -> listOf("application/*", "text/*")
-            CaptureImage -> listOf("image/*")
-            CaptureVideo -> listOf("video/*")
-            else -> emptyList()
-        }
-    }
-
-    @Composable
-    fun getString(): String = when (this) {
-        is CaptureAudio -> stringResource(R.string.record_audio)
-        is CaptureImage -> stringResource(R.string.take_photo)
-        is CaptureVideo -> stringResource(R.string.record_video)
-        is File -> stringResource(R.string.add_file)
-        is Gallery -> stringResource(R.string.add_from_gallery)
-    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/GenericAttachmentFormInput.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/GenericAttachmentFormInput.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.attachment
+
+// Prototype
+
+/**
+ * A prototype implementation for a generic attachments form input class.
+ */
+internal class GenericAttachmentFormInput(
+    val associationType: AttachmentAssociationType,
+    val inputTypes : List<AttachmentsFormInput>
+) : AttachmentsFormInput()
+
+internal sealed class AttachmentAssociationType {
+    data object Any : AttachmentAssociationType()
+    data object Exact : AttachmentAssociationType()
+    data object ExactOrNone : AttachmentAssociationType()
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/ImageAttachmentFormInput.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/ImageAttachmentFormInput.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.setValue
 internal class ImageAttachmentsFormInput(
     inputMethod: InputMethod,
     maxImageSize: Int? = null
-) {
+) : AttachmentsFormInput() {
     var inputMethod by mutableStateOf(inputMethod)
 
     /**

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -179,4 +179,6 @@
     <string name="value">Value</string>
     <string name="filters_not_applied">Filters have not been applied</string>
     <string name="discard_changes_confirmation">Are you sure you want to discard the changes?</string>
+    <string name="record_audio">Record Audio</string>
+    <string name="record_video">Record Video</string>
 </resources>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #https://devtopia.esri.com/runtime/apollo/issues/1737

<!-- link to design, if applicable -->

### Description:

This PR introduces prototyped classes to support `GenericAttachmentFormInput` and its corresponding behavior.

### Summary of changes:

- Added prototyped classes for `GenericAttachmentFormInput`.
- Refactored how the `CaptureOptions` are used in the add attachment workflow. 
- Moved the code related to adding attachments and UI into its own file.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  