### PR TITLE
Chaining install, then grant permissions, to then run connected test

### DIFF
--- a/build-logic-internal/convention/src/main/kotlin/AndroidIntegrationTestingConventionPlugin.kt
+++ b/build-logic-internal/convention/src/main/kotlin/AndroidIntegrationTestingConventionPlugin.kt
@@ -67,6 +67,7 @@ class AndroidIntegrationTestingConventionPlugin : Plugin<Project> {
                 tasks.matching {
                     it.name.startsWith("connected") && it.name.endsWith("AndroidTest")
                 }.configureEach {
+                    dependsOn(grantDevicePermissionsTask)
                     if (syncTestDataBeforeInstrumentedTests) {
                         dependsOn(
                             gradle.includedBuild("build-logic-internal")
@@ -80,13 +81,12 @@ class AndroidIntegrationTestingConventionPlugin : Plugin<Project> {
                     )
                 }
 
-                // Wire the grantDevicePermissions task to depend on install*AndroidTest tasks
-                tasks.matching {
-                    it.name.startsWith("install") && it.name.endsWith("AndroidTest")
-                }.forEach {
-                    grantDevicePermissionsTask.configure {
-                        finalizedBy(it)
-                    }
+                grantDevicePermissionsTask.configure {
+                    dependsOn(
+                        tasks.matching {
+                            it.name.startsWith("install") && it.name.endsWith("AndroidTest")
+                        }
+                    )
                 }
 
             }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

Setup gradle chaining in the order to first install, then grant permissions, to then run connected test

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/1263