### PR TITLE
add PopupMedia altText support

### DIFF
--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaElementState.kt
@@ -116,6 +116,7 @@ internal class MediaElementState(
  *
  * @property title the title from the PopupMedia
  * @property caption the caption from the PopupMedia
+ * @property altText the alternative text of the PopupMedia
  * @property refreshInterval the PopupMedia refresh interval
  * @property linkUrl the link to use to view the media for image type media in the media viewer
  * @property sourceUrl the link to use to render the image for image type media
@@ -127,6 +128,7 @@ internal class MediaElementState(
 internal class PopupMediaState(
     val title: String,
     val caption: String,
+    val altText: String,
     private val refreshInterval: Long,
     @Suppress("unused") private val linkUrl: String,
     @Suppress("unused") private val sourceUrl: String,
@@ -160,6 +162,7 @@ internal class PopupMediaState(
     ) : this(
         title = media.title,
         caption = media.caption,
+        altText = media.alternativeText,
         refreshInterval = media.imageRefreshInterval,
         linkUrl = media.value?.linkUrl ?: "",
         sourceUrl = media.value?.sourceUrl ?: "",
@@ -207,7 +210,7 @@ internal class PopupMediaState(
             imageFolder: String,
             context: Context
         ): PopupMediaState {
-            val srcUrl: String? = media.value?.sourceUrl ?: ""
+            val srcUrl: String = media.value?.sourceUrl ?: ""
             return PopupMediaState(
                 media,
                 scope,
@@ -224,7 +227,7 @@ internal class PopupMediaState(
                     (context.imageLoader.execute(request).drawable as? BitmapDrawable)?.bitmap
                         ?: ContextCompat.getDrawable(context, R.drawable.no_image_32)?.toBitmap()
                         ?: throw IllegalStateException(
-                            if (srcUrl.isNullOrEmpty()) {
+                            if (srcUrl.isEmpty()) {
                                 "couldn't load image: sourceUrl is missing or empty, and placeholder drawable could not be loaded"
                             } else {
                                 "couldn't load image at $srcUrl, and placeholder drawable could not be loaded"

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.DefaultAlpha
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -137,6 +138,7 @@ internal fun MediaView(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .semantics(mergeDescendants = false) {}
     ) {
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)

--- a/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
+++ b/toolkit/popup/src/main/java/com/arcgismaps/toolkit/popup/internal/element/media/MediaTile.kt
@@ -84,6 +84,7 @@ internal fun MediaTile(
             model = model,
             title = state.title,
             caption = state.caption,
+            altText = state.altText,
             modifier = Modifier.padding(padding)
         )
     }
@@ -130,6 +131,7 @@ internal fun MediaView(
     model: String,
     title: String,
     caption: String,
+    altText: String?,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -141,7 +143,7 @@ internal fun MediaView(
                     .data(model)
                     .crossfade(1000)
                     .build(),
-                contentDescription = title,
+                contentDescription = altText ?: title,
                 contentScale = ContentScale.FillBounds,
                 modifier = modifier.fillMaxSize(),
                 alignment = Alignment.Center,


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/7749

<!-- link to design, if applicable -->

### Description:

add the altText to the contentDescription of AsyncImage composables that represent MediaPopups.


### Summary of changes:

- simply weave the PopupMedia.alternativeText to the contentDescription for PopupMedia images (chart and image).
- since AsyncImage has a required contentDescription parameter, ensure its containing Box's semantics does not merge descendants.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/1270
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  