### PR TITLE
`FeatureForm`: Add support for document input

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
@@ -67,15 +67,15 @@ import java.time.Instant
 internal fun AddAttachment(
     onFocused: () -> Unit,
     stateId: Int,
-    inputType: AttachmentsFormInput,
+    inputs: List<AttachmentsFormInput>,
     hasCameraPermission: Boolean,
 ) {
     var showMenu by remember { mutableStateOf(false) }
     val dialogRequester = LocalDialogRequester.current
     val scope = rememberCoroutineScope()
     val pickerStyle = remember { MutableSharedFlow<PickerStyle>() }
-    val captureOptions = remember(inputType) {
-        inputType.getCaptureOptions()
+    val captureOptions = remember(inputs) {
+        inputs.getCaptureOptions().merge()
     }
 
     Box {
@@ -339,34 +339,39 @@ private sealed class PickerStyle {
 /**
  * Determines the capture options available for an attachment form input.
  */
-private fun AttachmentsFormInput.getCaptureOptions(): List<CaptureOptions> {
-    return when (this) {
-        is ImageAttachmentsFormInput -> {
-            when (inputMethod) {
-                ImageAttachmentsFormInput.InputMethod.Capture -> listOf(CaptureOptions.CaptureImage)
-                ImageAttachmentsFormInput.InputMethod.Upload -> listOf(
-                    CaptureOptions.Gallery(mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly),
-                    CaptureOptions.File(allowedMimeTypes = listOf("image/*"))
-                )
+private fun List<AttachmentsFormInput>.getCaptureOptions(): List<CaptureOptions> {
+    return flatMap { input ->
+        when (input) {
+            is ImageFormInput -> {
+                when (input.inputMethod) {
+                    ImageFormInput.InputMethod.Capture -> listOf(CaptureOptions.CaptureImage)
+                    ImageFormInput.InputMethod.Upload -> listOf(
+                        CaptureOptions.Gallery(
+                            mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly
+                        ),
+                        CaptureOptions.File(allowedMimeTypes = listOf("image/*"))
+                    )
 
-                ImageAttachmentsFormInput.InputMethod.Any -> listOf(
-                    CaptureOptions.CaptureImage,
-                    CaptureOptions.Gallery(mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly),
-                    CaptureOptions.File(allowedMimeTypes = listOf("image/*"))
-                )
+
+                    ImageFormInput.InputMethod.Any -> listOf(
+                        CaptureOptions.CaptureImage,
+                        CaptureOptions.Gallery(
+                            mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly
+                        ),
+                        CaptureOptions.File(allowedMimeTypes = listOf("image/*"))
+                    )
+                }
             }
-        }
 
-        is GenericAttachmentFormInput -> {
-            inputTypes.flatMap { type ->
-                type.getCaptureOptions()
-            }.merge()
+            is DocumentFormInput -> listOf(
+                CaptureOptions.File(allowedMimeTypes = listOf("application/*", "text/*"))
+            )
         }
     }
 }
 
 /**
- * A [GenericAttachmentFormInput] may contain multiple input types, which can lead to duplicate
+ * The list of capture options may contain multiple input types, which can lead to duplicate
  * capture options. This function merges those duplicate options into one.
  *
  * For example, if there are multiple gallery options with different media types, they will be

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -126,14 +126,14 @@ internal class AttachmentElementState(
      * The input type for the attachment form element. This is determined based on the allowed
      * attachment types specified by the form element.
      */
-    val inputType = GenericAttachmentFormInput(
-        associationType = AttachmentAssociationType.Exact,
-        inputTypes = listOf(
-            ImageAttachmentsFormInput(
-                inputMethod = ImageAttachmentsFormInput.InputMethod.Any
-            )
-        )
+    val inputs : List<AttachmentsFormInput> = listOf(
+        ImageFormInput(
+            inputMethod = ImageFormInput.InputMethod.Any
+        ),
+        DocumentFormInput()
     ) // formElement.input
+
+    val attachmentKeywordAssociation : AttachmentKeywordAssociation = AttachmentKeywordAssociation.Exact
 
     /**
      * The state of the lazy list that displays the [attachments].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -74,7 +74,7 @@ internal fun AttachmentFormElement(
         label = state.label,
         description = state.description,
         isEditable = editable,
-        inputType = state.inputType,
+        inputs = state.inputs,
         hasCameraPermission = state.hasCameraPermissions(context),
         allowUserRename = state.allowUserRename,
         displayFilename = state.displayFilename,
@@ -95,7 +95,7 @@ internal fun AttachmentFormElement(
     label: String,
     description: String,
     isEditable: Boolean,
-    inputType: AttachmentsFormInput,
+    inputs: List<AttachmentsFormInput>,
     hasCameraPermission: Boolean,
     allowUserRename: Boolean,
     displayFilename: Boolean,
@@ -139,7 +139,7 @@ internal fun AttachmentFormElement(
                     AddAttachment(
                         onFocused = onFocused,
                         stateId = stateId,
-                        inputType = inputType,
+                        inputs = inputs,
                         hasCameraPermission = hasCameraPermission
                     )
                 }
@@ -342,8 +342,10 @@ private fun AttachmentFormElementPreview() {
         label = "Attachments",
         description = "Add attachments",
         isEditable = true,
-        inputType = ImageAttachmentsFormInput(
-            inputMethod = ImageAttachmentsFormInput.InputMethod.Capture
+        inputs = listOf(
+            ImageFormInput(
+                inputMethod = ImageFormInput.InputMethod.Capture
+            )
         ),
         hasCameraPermission = true,
         allowUserRename = true,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentKeywordAssociation.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentKeywordAssociation.kt
@@ -18,16 +18,8 @@ package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 // Prototype
 
-/**
- * A prototype implementation for a generic attachments form input class.
- */
-internal class GenericAttachmentFormInput(
-    val associationType: AttachmentAssociationType,
-    val inputTypes : List<AttachmentsFormInput>
-) : AttachmentsFormInput()
-
-internal sealed class AttachmentAssociationType {
-    data object Any : AttachmentAssociationType()
-    data object Exact : AttachmentAssociationType()
-    data object ExactOrNone : AttachmentAssociationType()
+internal sealed class AttachmentKeywordAssociation {
+    data object Any : AttachmentKeywordAssociation()
+    data object Exact : AttachmentKeywordAssociation()
+    data object ExactOrNone : AttachmentKeywordAssociation()
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/DocumentFormInput.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/DocumentFormInput.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms.internal.components.attachment
+
+/**
+ * A prototype implementation for the document attachments form input class.
+ */
+internal class DocumentFormInput(
+    maxFileSize: Int = Int.MAX_VALUE
+) : AttachmentsFormInput()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/ImageFormInput.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/ImageFormInput.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.setValue
  * A prototype implementation for the image attachments form input class.
  */
 @Stable
-internal class ImageAttachmentsFormInput(
+internal class ImageFormInput(
     inputMethod: InputMethod,
     maxImageSize: Int? = null
 ) : AttachmentsFormInput() {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #https://devtopia.esri.com/runtime/apollo/issues/1756

<!-- link to design, if applicable -->

### Description:

This PR adds support for document form input & updates the prototype to the latest design.

### Summary of changes:

- Added `DocumentFormInput` class.
- Updated the `AttachmentElementState.inputType` to `inputs : List<AttachmentsFormInput>` based on the latest design.
- Renamed classes based on the new design.
- Removed `GenericInput` since it is no longer part of the design.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  