### PR TITLE
`FeatureForm` : Add support for audio and video form inputs

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -60,10 +59,7 @@ import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
 import com.arcgismaps.toolkit.featureforms.internal.utils.DialogType
 import com.arcgismaps.toolkit.featureforms.internal.utils.LocalDialogRequester
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.launch
 import java.time.Instant
-import kotlin.math.max
 
 /**
  * A component that provides UI for adding attachments.
@@ -388,18 +384,18 @@ private fun List<AttachmentsFormInput>.getCaptureOptions(): List<CaptureOptions>
                 when (input.inputMethod) {
                     InputMethod.Capture -> listOf(CaptureOptions.CaptureAudio(input.maxDuration))
                     InputMethod.Upload -> listOf(
-                        CaptureOptions.File(allowedMimeTypes = listOf("audio/*"))
+                        CaptureOptions.File(allowedMimeTypes = input.getMimeTypes())
                     )
 
                     InputMethod.Any -> listOf(
                         CaptureOptions.CaptureAudio(input.maxDuration),
-                        CaptureOptions.File(allowedMimeTypes = listOf("audio/*"))
+                        CaptureOptions.File(allowedMimeTypes = input.getMimeTypes())
                     )
                 }
             }
 
             is DocumentFormInput -> listOf(
-                CaptureOptions.File(allowedMimeTypes = listOf("application/*", "text/*"))
+                CaptureOptions.File(allowedMimeTypes = input.getMimeTypes())
             )
 
             is ImageFormInput -> {
@@ -409,7 +405,7 @@ private fun List<AttachmentsFormInput>.getCaptureOptions(): List<CaptureOptions>
                         CaptureOptions.Gallery(
                             mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly
                         ),
-                        CaptureOptions.File(allowedMimeTypes = listOf("image/*"))
+                        CaptureOptions.File(allowedMimeTypes = input.getMimeTypes())
                     )
 
                     InputMethod.Any -> listOf(
@@ -417,7 +413,7 @@ private fun List<AttachmentsFormInput>.getCaptureOptions(): List<CaptureOptions>
                         CaptureOptions.Gallery(
                             mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly
                         ),
-                        CaptureOptions.File(allowedMimeTypes = listOf("image/*"))
+                        CaptureOptions.File(allowedMimeTypes = input.getMimeTypes())
                     )
                 }
             }
@@ -429,7 +425,7 @@ private fun List<AttachmentsFormInput>.getCaptureOptions(): List<CaptureOptions>
                         CaptureOptions.Gallery(
                             mediaType = ActivityResultContracts.PickVisualMedia.VideoOnly
                         ),
-                        CaptureOptions.File(allowedMimeTypes = listOf("video/*"))
+                        CaptureOptions.File(allowedMimeTypes = input.getMimeTypes())
                     )
 
                     InputMethod.Any -> listOf(
@@ -437,7 +433,7 @@ private fun List<AttachmentsFormInput>.getCaptureOptions(): List<CaptureOptions>
                         CaptureOptions.Gallery(
                             mediaType = ActivityResultContracts.PickVisualMedia.VideoOnly
                         ),
-                        CaptureOptions.File(allowedMimeTypes = listOf("video/*"))
+                        CaptureOptions.File(allowedMimeTypes = input.getMimeTypes())
                     )
                 }
             }
@@ -497,5 +493,22 @@ internal fun Long.toIntClamped(): Int {
         this > Int.MAX_VALUE -> Int.MAX_VALUE
         this < Int.MIN_VALUE -> Int.MIN_VALUE
         else -> this.toInt()
+    }
+}
+
+/**
+ * Gets the list of MIME types supported by an attachment form input.
+ *
+ * Suppresses the redundant else in when warning, as new input types may be added in the future and
+ * this provides binary compatibility without requiring changes to this function.
+ */
+@Suppress("REDUNDANT_ELSE_IN_WHEN")
+internal fun AttachmentsFormInput.getMimeTypes(): List<String> {
+    return when (this) {
+        is AudioFormInput -> listOf("audio/*")
+        is DocumentFormInput -> listOf("application/*", "text/*")
+        is ImageFormInput -> listOf("image/*")
+        is VideoFormInput -> listOf("video/*")
+        else -> emptyList()
     }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
@@ -16,7 +16,10 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
+import android.content.Context
+import android.content.Intent
 import android.net.Uri
+import android.provider.MediaStore
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -28,6 +31,7 @@ import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.Photo
 import androidx.compose.material.icons.rounded.PhotoCamera
+import androidx.compose.material.icons.rounded.Videocam
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -59,6 +63,7 @@ import com.arcgismaps.toolkit.featureforms.internal.utils.LocalDialogRequester
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import java.time.Instant
+import kotlin.math.max
 
 /**
  * A component that provides UI for adding attachments.
@@ -72,8 +77,6 @@ internal fun AddAttachment(
 ) {
     var showMenu by remember { mutableStateOf(false) }
     val dialogRequester = LocalDialogRequester.current
-    val scope = rememberCoroutineScope()
-    val pickerStyle = remember { MutableSharedFlow<PickerStyle>() }
     val captureOptions = remember(inputs) {
         inputs.getCaptureOptions().merge()
     }
@@ -98,7 +101,7 @@ internal fun AddAttachment(
         ) {
             captureOptions.forEach { option ->
                 when (option) {
-                    CaptureOptions.CaptureAudio -> {
+                    is CaptureOptions.CaptureAudio -> {
                         // not supported yet
                     }
 
@@ -113,16 +116,34 @@ internal fun AddAttachment(
                                 )
                             },
                             onClick = {
-                                scope.launch {
-                                    pickerStyle.emit(PickerStyle.Camera)
-                                    showMenu = false
-                                }
+                                dialogRequester.requestDialog(
+                                    DialogType.ImageCaptureDialog(stateId = stateId)
+                                )
+                                showMenu = false
                             }
                         )
                     }
 
                     is CaptureOptions.CaptureVideo if hasCameraPermission -> {
-                        // not supported yet
+                        DropdownMenuItem(
+                            text = { Text(text = "Take Video") },
+                            trailingIcon = {
+                                Icon(
+                                    imageVector = Icons.Rounded.Videocam,
+                                    contentDescription = "Take Video",
+                                    modifier = Modifier.alpha(0.4f)
+                                )
+                            },
+                            onClick = {
+                                dialogRequester.requestDialog(
+                                    DialogType.VideoCaptureDialog(
+                                        stateId = stateId,
+                                        maxDuration = option.maxDuration
+                                    )
+                                )
+                                showMenu = false
+                            }
+                        )
                     }
 
                     is CaptureOptions.Gallery -> {
@@ -131,15 +152,18 @@ internal fun AddAttachment(
                             trailingIcon = {
                                 Icon(
                                     imageVector = Icons.Rounded.Photo,
-                                    contentDescription = "Add From Gallery",
+                                    contentDescription = "Choose From Gallery",
                                     modifier = Modifier.alpha(0.4f)
                                 )
                             },
                             onClick = {
-                                scope.launch {
-                                    pickerStyle.emit(PickerStyle.PickMedia(option.mediaType))
-                                    showMenu = false
-                                }
+                                dialogRequester.requestDialog(
+                                    DialogType.GalleryPickerDialog(
+                                        stateId = stateId,
+                                        type = option.mediaType
+                                    )
+                                )
+                                showMenu = false
                             }
                         )
                     }
@@ -150,51 +174,23 @@ internal fun AddAttachment(
                             trailingIcon = {
                                 Icon(
                                     imageVector = Icons.Rounded.Folder,
-                                    contentDescription = "Add File",
+                                    contentDescription = "Choose From Files",
                                     modifier = Modifier.alpha(0.4f)
                                 )
                             },
                             onClick = {
-                                scope.launch {
-                                    pickerStyle.emit(PickerStyle.File(option.allowedMimeTypes))
-                                    showMenu = false
-                                }
+                                dialogRequester.requestDialog(
+                                    DialogType.FilePickerDialog(
+                                        stateId = stateId,
+                                        allowedTypes = option.allowedMimeTypes
+                                    )
+                                )
+                                showMenu = false
                             }
                         )
                     }
 
                     else -> {}
-                }
-            }
-        }
-    }
-    LaunchedEffect(Unit) {
-        pickerStyle.collect {
-            when (it) {
-                PickerStyle.Camera -> {
-                    dialogRequester.requestDialog(
-                        DialogType.ImageCaptureDialog(
-                            stateId = stateId
-                        )
-                    )
-                }
-
-                is PickerStyle.PickMedia -> {
-                    dialogRequester.requestDialog(
-                        DialogType.GalleryPickerDialog(
-                            stateId = stateId,
-                            type = it.type
-                        )
-                    )
-                }
-
-                is PickerStyle.File -> {
-                    dialogRequester.requestDialog(
-                        DialogType.FilePickerDialog(
-                            stateId = stateId,
-                            allowedTypes = it.allowedMimeTypes
-                        )
-                    )
                 }
             }
         }
@@ -241,6 +237,61 @@ internal fun ImageCapture(
         if (!hasLaunched) {
             hasLaunched = true
             cameraLauncher.launch(capturedImageUri)
+        }
+    }
+}
+
+/**
+ * Launches the camera to capture a video. When a video is captured, the [onVideoCaptured] callback
+ * is invoked with the URI of the captured video.
+ *
+ * @param onDismissRequest A request to dismiss the camera picker.
+ * @param onVideoCaptured A callback to invoke when a video is captured.
+ */
+@Composable
+internal fun VideoCapture(
+    maxDuration: Long,
+    onDismissRequest: () -> Unit,
+    onVideoCaptured: (Uri) -> Unit
+) {
+    val context = LocalContext.current
+    var hasLaunched by rememberSaveable {
+        mutableStateOf(false)
+    }
+    val capturedVideoUri = rememberSaveable(
+        saver = listSaver(
+            save = { listOf(it.toString()) },
+            restore = { it.first().toUri() }
+        )
+    ) {
+        val timeStamp = Instant.now().toEpochMilli()
+        AttachmentsFileProvider.createTempFileWithUri("VIDEO_$timeStamp", ".mp4", context)
+    }
+    val captureVideoContract = remember {
+        object : ActivityResultContracts.CaptureVideo() {
+            override fun createIntent(context: Context, input: Uri): Intent {
+                return super.createIntent(context, input).apply {
+                    // set the max duration limit for the captured video. The value must be clamped
+                    // to the range of Int values, as the intent extra only accepts Int values.
+                    putExtra(MediaStore.EXTRA_DURATION_LIMIT, maxDuration.toIntClamped())
+                }
+            }
+        }
+    }
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = captureVideoContract,
+        onResult = { success ->
+            if (success) {
+                onVideoCaptured(capturedVideoUri)
+            } else {
+                onDismissRequest()
+            }
+        }
+    )
+    LaunchedEffect(Unit) {
+        if (!hasLaunched) {
+            hasLaunched = true
+            cameraLauncher.launch(capturedVideoUri)
         }
     }
 }
@@ -328,32 +379,40 @@ internal fun FilePicker(
 }
 
 /**
- * Determines the type of picker to launch.
- */
-private sealed class PickerStyle {
-    data object Camera : PickerStyle()
-    data class PickMedia(val type: VisualMediaType) : PickerStyle()
-    data class File(val allowedMimeTypes: List<String>) : PickerStyle()
-}
-
-/**
  * Determines the capture options available for an attachment form input.
  */
 private fun List<AttachmentsFormInput>.getCaptureOptions(): List<CaptureOptions> {
     return flatMap { input ->
         when (input) {
+            is AudioFormInput -> {
+                when (input.inputMethod) {
+                    InputMethod.Capture -> listOf(CaptureOptions.CaptureAudio(input.maxDuration))
+                    InputMethod.Upload -> listOf(
+                        CaptureOptions.File(allowedMimeTypes = listOf("audio/*"))
+                    )
+
+                    InputMethod.Any -> listOf(
+                        CaptureOptions.CaptureAudio(input.maxDuration),
+                        CaptureOptions.File(allowedMimeTypes = listOf("audio/*"))
+                    )
+                }
+            }
+
+            is DocumentFormInput -> listOf(
+                CaptureOptions.File(allowedMimeTypes = listOf("application/*", "text/*"))
+            )
+
             is ImageFormInput -> {
                 when (input.inputMethod) {
-                    ImageFormInput.InputMethod.Capture -> listOf(CaptureOptions.CaptureImage)
-                    ImageFormInput.InputMethod.Upload -> listOf(
+                    InputMethod.Capture -> listOf(CaptureOptions.CaptureImage)
+                    InputMethod.Upload -> listOf(
                         CaptureOptions.Gallery(
                             mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly
                         ),
                         CaptureOptions.File(allowedMimeTypes = listOf("image/*"))
                     )
 
-
-                    ImageFormInput.InputMethod.Any -> listOf(
+                    InputMethod.Any -> listOf(
                         CaptureOptions.CaptureImage,
                         CaptureOptions.Gallery(
                             mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly
@@ -363,9 +422,25 @@ private fun List<AttachmentsFormInput>.getCaptureOptions(): List<CaptureOptions>
                 }
             }
 
-            is DocumentFormInput -> listOf(
-                CaptureOptions.File(allowedMimeTypes = listOf("application/*", "text/*"))
-            )
+            is VideoFormInput -> {
+                when (input.inputMethod) {
+                    InputMethod.Capture -> listOf(CaptureOptions.CaptureVideo(input.maxDuration))
+                    InputMethod.Upload -> listOf(
+                        CaptureOptions.Gallery(
+                            mediaType = ActivityResultContracts.PickVisualMedia.VideoOnly
+                        ),
+                        CaptureOptions.File(allowedMimeTypes = listOf("video/*"))
+                    )
+
+                    InputMethod.Any -> listOf(
+                        CaptureOptions.CaptureVideo(input.maxDuration),
+                        CaptureOptions.Gallery(
+                            mediaType = ActivityResultContracts.PickVisualMedia.VideoOnly
+                        ),
+                        CaptureOptions.File(allowedMimeTypes = listOf("video/*"))
+                    )
+                }
+            }
         }
     }
 }
@@ -412,4 +487,15 @@ private fun List<VisualMediaType>.toPickerMediaType(): VisualMediaType = when {
     size == 1 -> first()
     contains(ActivityResultContracts.PickVisualMedia.ImageOnly) && contains(ActivityResultContracts.PickVisualMedia.VideoOnly) -> ActivityResultContracts.PickVisualMedia.ImageAndVideo
     else -> throw IllegalArgumentException("Unsupported combination of media types")
+}
+
+/**
+ * Clamps a Long value to the range of Int values.
+ */
+internal fun Long.toIntClamped(): Int {
+    return when {
+        this > Int.MAX_VALUE -> Int.MAX_VALUE
+        this < Int.MIN_VALUE -> Int.MIN_VALUE
+        else -> this.toInt()
+    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -126,14 +126,15 @@ internal class AttachmentElementState(
      * The input type for the attachment form element. This is determined based on the allowed
      * attachment types specified by the form element.
      */
-    val inputs : List<AttachmentsFormInput> = listOf(
-        ImageFormInput(
-            inputMethod = ImageFormInput.InputMethod.Any
-        ),
+    val inputs: List<AttachmentsFormInput> = listOf(
+        //ImageFormInput(inputMethod = InputMethod.Any),
+        //AudioFormInput(inputMethod = InputMethod.Any),
+        VideoFormInput(inputMethod = InputMethod.Any, maxDuration = 10),
         DocumentFormInput()
     ) // formElement.input
 
-    val attachmentKeywordAssociation : AttachmentKeywordAssociation = AttachmentKeywordAssociation.Exact
+    val attachmentKeywordAssociation: AttachmentKeywordAssociation =
+        AttachmentKeywordAssociation.Exact
 
     /**
      * The state of the lazy list that displays the [attachments].

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentFormElement.kt
@@ -344,7 +344,7 @@ private fun AttachmentFormElementPreview() {
         isEditable = true,
         inputs = listOf(
             ImageFormInput(
-                inputMethod = ImageFormInput.InputMethod.Capture
+                inputMethod = InputMethod.Capture
             )
         ),
         hasCameraPermission = true,

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AudioFormInput.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AudioFormInput.kt
@@ -17,8 +17,9 @@
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 /**
- * A prototype implementation for the document attachments form input class.
+ * A prototype implementation for the audio attachments form input class.
  */
-internal class DocumentFormInput(
-    val maxFileSize: Int = Int.MAX_VALUE
+internal class AudioFormInput(
+    val inputMethod: InputMethod,
+    val maxDuration : Long = Long.MAX_VALUE
 ) : AttachmentsFormInput()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/CaptureOptions.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/CaptureOptions.kt
@@ -23,9 +23,9 @@ import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
  * attachments that can be captured by the UI.
  */
 internal sealed class CaptureOptions {
-    data object CaptureAudio : CaptureOptions()
+    data class CaptureAudio(val maxDuration: Long) : CaptureOptions()
     data object CaptureImage : CaptureOptions()
-    data object CaptureVideo : CaptureOptions()
+    data class CaptureVideo(val maxDuration: Long) : CaptureOptions()
     data class Gallery(val mediaType: VisualMediaType) : CaptureOptions()
     data class File(val allowedMimeTypes: List<String>) : CaptureOptions()
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/ImageFormInput.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/ImageFormInput.kt
@@ -40,10 +40,4 @@ internal class ImageFormInput(
      * images will not be resized.
      */
     var maxImageSize by mutableStateOf(maxImageSize)
-
-    enum class InputMethod {
-        Any,
-        Capture,
-        Upload
-    }
 }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/InputMethod.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/InputMethod.kt
@@ -17,8 +17,10 @@
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 /**
- * A prototype implementation for the document attachments form input class.
+ * The method by which the user will provide an attachment.
  */
-internal class DocumentFormInput(
-    val maxFileSize: Int = Int.MAX_VALUE
-) : AttachmentsFormInput()
+internal enum class InputMethod {
+    Any,
+    Capture,
+    Upload
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/VideoFormInput.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/VideoFormInput.kt
@@ -17,8 +17,9 @@
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
 /**
- * A prototype implementation for the document attachments form input class.
+ * A prototype implementation for the video attachments form input class.
  */
-internal class DocumentFormInput(
-    val maxFileSize: Int = Int.MAX_VALUE
+internal class VideoFormInput(
+    val inputMethod: InputMethod,
+    val maxDuration: Long = Long.MAX_VALUE
 ) : AttachmentsFormInput()

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -60,7 +60,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.time.Instant
-import kotlin.math.max
 
 /**
  * Local containing the default [DialogRequester] for providing the same instance in the

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -42,6 +42,7 @@ import com.arcgismaps.toolkit.featureforms.internal.components.attachment.FilePi
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.GalleryPicker
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.ImageCapture
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.RenameAttachmentDialog
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.VideoCapture
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.addAttachmentFromUri
 import com.arcgismaps.toolkit.featureforms.internal.components.barcode.BarcodeScanner
 import com.arcgismaps.toolkit.featureforms.internal.components.barcode.BarcodeTextFieldState
@@ -59,6 +60,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.time.Instant
+import kotlin.math.max
 
 /**
  * Local containing the default [DialogRequester] for providing the same instance in the
@@ -119,6 +121,16 @@ internal sealed class DialogType {
      */
     data class ImageCaptureDialog(
         val stateId: Int
+    ) : DialogType()
+
+    /**
+     * Indicates a video capture dialog.
+     *
+     * @param stateId The id of the [AttachmentElementState] that requested the dialog.
+     */
+    data class VideoCaptureDialog(
+        val stateId: Int,
+        val maxDuration: Long
     ) : DialogType()
 
     /**
@@ -259,6 +271,30 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
                 return
             }
             ImageCapture(
+                onDismissRequest = dialogRequester::dismissDialog
+            ) { uri ->
+                scope.launch {
+                    state.addAttachmentFromUri(uri, context, false).onFailure {
+                        showError(
+                            context,
+                            it.message ?: attachmentError
+                        )
+                    }
+                    dialogRequester.dismissDialog()
+                }
+            }
+        }
+
+        is DialogType.VideoCaptureDialog -> {
+            val stateId = (dialogType as DialogType.VideoCaptureDialog).stateId
+            val maxDuration = (dialogType as DialogType.VideoCaptureDialog).maxDuration
+            val state = states[stateId] as? AttachmentElementState
+            if (state == null) {
+                dialogRequester.dismissDialog()
+                return
+            }
+            VideoCapture(
+                maxDuration = maxDuration,
                 onDismissRequest = dialogRequester::dismissDialog
             ) { uri ->
                 scope.launch {

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -94,12 +94,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Take Photo</string>
-    <string name="add_from_gallery">Add From Gallery</string>
+    <string name="add_from_gallery">Choose From Gallery</string>
     <string name="rename">Rename</string>
     <string name="delete">Delete</string>
     <string name="rename_attachment">Rename Attachment</string>
     <string name="name">Name</string>
-    <string name="add_file">Add From Files</string>
+    <string name="add_file">Choose From Files</string>
     <string name="attachment_error">Error Adding Attachment</string>
     <string name="no_app_found">No application found to open this file type.</string>
     <string name="attachment_too_large">The File is too large. Please add a file less than 50 MB.</string>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/1758](https://devtopia.esri.com/runtime/apollo/issues/1758)

<!-- link to design, if applicable -->

### Description:

This PR adds support for AudioFormInput and VideoFormInput attachment types.

### Summary of changes:

- `AudioFormInput` support only includes adding via file. Custom control will be implemented later.
- Added support for a Video Capture intent for the `VideoFormInput` type.
- Video capture also support a `maxDuration` property.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  