### PR TITLE
Chri7325/codeql

### DIFF
--- a/.codeql
+++ b/.codeql
@@ -1,0 +1,21 @@
+# CodeQL configuration file that combines the settings from the codeql configuration options with the sarif-tools
+# configurations options. Codeql options only allow filtering queries for compiled languages and the sarif-tools allow
+# filtering results from a single configuration file.
+
+# CodeQL configurations
+# https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#custom-configuration-files
+name: "CodeQL"
+
+queries:
+  # - uses: "code-scanning" # level 1 minimal baseline checks
+  # - uses: "security-extended" # level 2 minimal baseline and extended security checks
+  - uses: "security-and-quality" # level 3 minimal baseline, extended security and code quality level checks
+
+# paths: does not work with compiled languages, the build command dictates what files are analyzed
+# paths-ignore: does not work with compiled languages, use exclude in the sarif-tools filter configuration instead
+
+# SARIF Tools filter configurations
+# https://github.com/microsoft/sarif-tools?tab=readme-ov-file#filtering
+# exclude:
+#   - location: "path/to/non/esri/generated/sources"
+#   - location: "path/to/package/cache"

--- a/.codeql
+++ b/.codeql
@@ -11,6 +11,10 @@ queries:
   # - uses: "security-extended" # level 2 minimal baseline and extended security checks
   - uses: "security-and-quality" # level 3 minimal baseline, extended security and code quality level checks
 
+query-filters:
+  - exclude:
+      id: java/field-masks-super-field
+
 # paths: does not work with compiled languages, the build command dictates what files are analyzed
 # paths-ignore: does not work with compiled languages, use exclude in the sarif-tools filter configuration instead
 


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: # Internal issue

<!-- link to design, if applicable -->

### Description:

Adds a .codeql file that will be used to configure the codeQL daily scans of toolkit

### Summary of changes:

- Add initial codeQL configuration file

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link:
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  