### PR TITLE
UtilityTraceFunctionResult: display functionName if available, fall back to networkAttribute name

### DIFF
--- a/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
+++ b/toolkit/utilitynetworks/src/main/java/com/arcgismaps/toolkit/utilitynetworks/ui/TraceResultScreen.kt
@@ -236,8 +236,9 @@ private fun FunctionResult(functionResults: List<UtilityTraceFunctionOutput>) {
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
+                    val function = functionResult.function
                     Text(
-                        text = functionResult.function.networkAttribute.name,
+                        text = if (function.functionName.isNotEmpty()) { function.functionName } else { function.networkAttribute.name },
                         style = MaterialTheme.typography.titleMedium
                     )
                     Column(horizontalAlignment = Alignment.End) {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: https://devtopia.esri.com/runtime/kotlin/issues/7673

toolkit design: https://devtopia.esri.com/runtime/nautilus/issues/2993

<!-- link to design, if applicable -->

### Description:

small update to UtilityNetworkTrace tool

### Summary of changes:

- for function results, display functionName if available (requires enterprise >= 12.1,  sdk >= 300.1)

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/toolkit/1286/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  