### PR TITLE
`FeatureForm`: Fix deprecation

### DIFF
--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/FeatureForm.kt
@@ -376,7 +376,7 @@ public fun FeatureForm(
         val form = state.getActiveFormStateData().featureForm
         focusManager.clearFocus()
         // Check for validation errors
-        val errorCount = form.validationErrors.value.entries.count()
+        val errorCount = form.elementValidationErrors.value.entries.count()
         return if (errorCount == 0) {
             // Finish editing the form if there are no validation errors
             state.saveEdits().onSuccess {


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #

<!-- link to design, if applicable -->

### Description:

This PR fixes the recently introduced deprecation to the `FeatureForm.validationErrors` property and provides its replacement.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1295/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  