### PR TITLE
`FeatureForm`: add AttachmentsFormElement tests

### DIFF
--- a/toolkit/featureforms/build.gradle.kts
+++ b/toolkit/featureforms/build.gradle.kts
@@ -195,6 +195,8 @@ dependencies {
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.bundles.composeTest)
     androidTestImplementation(libs.bundles.androidXTest)
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.espresso.intents)
     debugImplementation(libs.bundles.debug)
 
     // Include only if internal tests are required

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentTests.kt
@@ -55,7 +55,7 @@ class AttachmentTests : FeatureFormTestRunner(
             FeatureForm(featureFormState = featureFormState)
         }
         val attachmentsFormElement = featureForm.elements.firstOrNull {
-            it.label == "General"
+            it.label == "Attachments"
         } as? AttachmentsFormElement
         assertThat(attachmentsFormElement).isNotNull()
         composeTestRule.waitUntil(

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
@@ -1,0 +1,659 @@
+/*
+ * Copyright 2026 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Context
+import android.content.Intent
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDialog
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isPopup
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.rule.IntentsRule
+import androidx.test.platform.app.InstrumentationRegistry
+import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
+import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.io.FileWriter
+
+/**
+ * Test class for the authored AttachmentsFormElement in the FeatureForm.
+ *
+ * @since 300.1.0
+ */
+class AttachmentsFormElementTests : FeatureFormTestRunner(
+    uri = "https://www.arcgis.com/home/item.html?id=7064081d2d1a4af6b871d35954417e5e",
+    objectId = 1
+) {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val intentsTestRule = IntentsRule()
+
+    /**
+     * The test [Context].
+     */
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    /**
+     * Test case 14.1:
+     * Given a `FeatureForm` with authored `AttachmentsFormElement`s and constraints
+     * When the `FeatureForm` is displayed and attachments are added
+     * Then the appropriate attachment options and validation errors are displayed
+     * And the minimum and maximum attachment constraints are honored
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-141-general-attachments-form-elements
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun testAttachmentsFormElementWithGeneralInputs() = runTest {
+        // Create a FeatureFormState and set the compose content
+        val featureFormState = FeatureFormState(
+            featureForm = featureForm,
+            coroutineScope = scope
+        )
+        composeTestRule.setContent {
+            FeatureForm(featureFormState = featureFormState)
+        }
+        val attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "General - All Inputs"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+        // Assert that the attachments element is displayed
+        val generalAttachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement!!.label)
+        generalAttachmentsNode.assertIsDisplayed()
+
+        // Get the add attachment button and assert that it is displayed
+        val addAttachmentButton =
+            generalAttachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed()
+        addAttachmentButton.performClick()
+
+        // Assert all the options are displayed
+        val menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(
+                context.getString(R.string.take_photo),
+                context.getString(R.string.take_video),
+                context.getString(R.string.choose_from_gallery)
+            ),
+        )
+        val chooseFromFiles = menu.onChildWithText(
+            value = context.getString(R.string.choose_from_files),
+            recurse = true
+        ).assertIsDisplayed()
+
+        // Create a temporary file to simulate the selected document
+        mockFilePickerIntentResult(context, "test_document.txt")
+        // Perform the click on the "Choose From Files" option
+        chooseFromFiles.performClick()
+        composeTestRule.waitForIdle()
+        // Assert that the intent was sent and received correctly by the component and the new
+        // attachment is displayed in the attachments list
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            // Check for the content description since `displayFileName` is false
+            generalAttachmentsNode.onChildWithContentDescription(
+                "Attachment: test_document.txt"
+            ).isDisplayed()
+        }
+
+        var attachmentNode = generalAttachmentsNode.onChildWithContentDescription(
+            "Attachment: test_document.txt"
+        )
+        // Long click on the attachment to trigger the context menu
+        attachmentNode.performTouchInput { longClick() }
+        // Assert the Rename option is disable
+        composeTestRule.onNodeWithText(context.getString(R.string.rename)).assert(isEnabled().not())
+
+        // Create another temporary file to simulate the selected document
+        mockFilePickerIntentResult(context, "test_document_2.txt")
+        // Perform the click on the "Choose From Files" option
+        addAttachmentButton.performClick()
+        composeTestRule.onNodeWithContentDescription(
+            context.getString(R.string.choose_from_files),
+        ).performClick()
+        composeTestRule.waitForIdle()
+        // Assert that the intent was sent and received correctly by the component and the new
+        // attachment is displayed in the attachments list
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            // Check for the content description since `displayFileName` is false
+            generalAttachmentsNode.onChildWithContentDescription(
+                "Attachment: test_document_2.txt"
+            ).isDisplayed()
+        }
+
+        attachmentNode = generalAttachmentsNode.onChildWithContentDescription(
+            "Attachment: test_document_2.txt"
+        )
+        // Long click on the attachment to trigger the context menu
+        attachmentNode.performTouchInput { longClick() }
+        // Assert the Rename option is disable
+        composeTestRule.onNodeWithText(context.getString(R.string.rename)).assert(isEnabled().not())
+
+        // Assert that the add attachments button is now disabled since the max number of
+        // attachments configured is 2
+        composeTestRule.waitUntil(timeoutMillis = 2_000) {
+            addAttachmentButton.isEnabled().not()
+        }
+
+        // Find the "General - Photo Only" attachments form element
+        val photoAttachmentsElement = featureForm.elements.firstOrNull {
+            it.label == "General - Photo Only"
+        } as? AttachmentsFormElement
+        assertThat(photoAttachmentsElement).isNotNull()
+        val photoAttachmentsNode = composeTestRule.onNodeWithText(photoAttachmentsElement!!.label)
+        photoAttachmentsNode.assertIsDisplayed()
+
+        // Click the save button to trigger validation
+        val saveButton = composeTestRule.onNodeWithText(context.getString(R.string.save))
+        saveButton.assertIsDisplayed()
+        saveButton.performClick()
+
+        // Assert that the validation error dialog is displayed
+        val validationErrorDialog = composeTestRule.onNode(isDialog())
+        validationErrorDialog.assertIsDisplayed()
+        val okButton = validationErrorDialog.onChildWithText(
+            value = context.getString(R.string.ok),
+            recurse = true
+        )
+        // dismiss the dialog
+        okButton.assertIsDisplayed().performClick()
+
+        // Assert that the validation error is now visible on the element
+        photoAttachmentsNode.assertTextContains(
+            context.resources.getQuantityString(
+                R.plurals.min_attachments_required, 1, 1
+            )
+        )
+    }
+
+    /**
+     * Test case 14.2:
+     * Given a `FeatureForm` with an authored `AttachmentsFormElement` of type `DocumentFormInput`
+     * When the `FeatureForm` is displayed and the add attachment button is clicked
+     * Then only the "Choose From Files" option is displayed in the menu
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-142-document-attachments-form-elements
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun testAttachmentsFormElementWithDocumentInput() = runTest {
+        // Create a FeatureFormState and set the compose content
+        val featureFormState = FeatureFormState(
+            featureForm = featureForm,
+            coroutineScope = scope
+        )
+        composeTestRule.setContent {
+            FeatureForm(featureFormState = featureFormState)
+        }
+        val attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Document"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        // Assert that the attachments element is displayed
+        val attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement!!.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        val addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        // Assert only the "Choose From Files" option is displayed
+        val menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(context.getString(R.string.choose_from_files)),
+            nonVisibleOptions = listOf(
+                context.getString(R.string.take_photo),
+                context.getString(R.string.take_video),
+                context.getString(R.string.choose_from_gallery)
+            )
+        )
+    }
+
+    /**
+     * Test case 14.3:
+     * Given a `FeatureForm` with `AttachmentsFormElement`s using `ImageFormInput`s with different `AttachmentInputMethod`s
+     * When the `FeatureForm` is displayed and their add attachment menu is opened
+     * Then each menu displays the appropriate options
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-143-photo-media-attachments-form-elements
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun testAttachmentsFormElementWithImageInput() = runTest {
+        // Create a FeatureFormState and set the compose content
+        val featureFormState = FeatureFormState(
+            featureForm = featureForm,
+            coroutineScope = scope
+        )
+        composeTestRule.setContent {
+            FeatureForm(featureFormState = featureFormState)
+        }
+
+        // Find the lazy column node the FeatureForm is displayed in
+        val lazyColumnNode = composeTestRule.onNodeWithContentDescription("lazy column")
+
+        // Find the "Media - Photo - Any" attachments form element
+        var attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Photo - Any"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        // Assert that the attachments element is displayed
+        var attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement!!.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        var addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        // Assert all the appropriate options are displayed in the menu
+        var menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(
+                context.getString(R.string.take_photo),
+                context.getString(R.string.choose_from_gallery),
+                context.getString(R.string.choose_from_files)
+            ),
+            nonVisibleOptions = listOf(
+                context.getString(R.string.take_video)
+            )
+        )
+        // Dismiss the menu
+        Espresso.pressBack()
+
+        // Find the "Media - Photo - Capture" attachments form element
+        attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Photo - Capture"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        // Assert that the attachments element is displayed
+        lazyColumnNode.performScrollToNode(hasText(attachmentsFormElement!!.label))
+        attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        // Assert all the appropriate options are displayed in the menu
+        menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(
+                context.getString(R.string.take_photo)
+            ),
+            nonVisibleOptions = listOf(
+                context.getString(R.string.take_video),
+                context.getString(R.string.choose_from_gallery),
+                context.getString(R.string.choose_from_files)
+            )
+        )
+        // Dismiss the menu
+        Espresso.pressBack()
+
+        // Find the "Media - Photo - Upload" attachments form element
+        attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Photo - Upload"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        lazyColumnNode.performScrollToNode(hasText(attachmentsFormElement!!.label))
+        // Assert that the attachments element is displayed
+        attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        // Assert all the appropriate options are displayed in the menu
+        menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(
+                context.getString(R.string.choose_from_gallery),
+                context.getString(R.string.choose_from_files)
+            ),
+            nonVisibleOptions = listOf(
+                context.getString(R.string.take_photo),
+                context.getString(R.string.take_video)
+            )
+        )
+    }
+
+    /**
+     * Test case 14.4:
+     * Given a `FeatureForm` with an authored `AttachmentsFormElement` of type `VideoFormInput`s with different `AttachmentInputMethod`s
+     * When the `FeatureForm` is displayed and the add attachment menu is opened
+     * Then the menu displays the appropriate options
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-144-video-media-attachments-form-elements
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun testAttachmentsFormElementWithVideoInput() = runTest {
+        // Create a FeatureFormState and set the compose content
+        val featureFormState = FeatureFormState(
+            featureForm = featureForm,
+            coroutineScope = scope
+        )
+        composeTestRule.setContent {
+            FeatureForm(featureFormState = featureFormState)
+        }
+
+        // Find the lazy column node the FeatureForm is displayed in
+        val lazyColumnNode = composeTestRule.onNodeWithContentDescription("lazy column")
+
+        // Find the "Media - Video - Any" attachments form element
+        var attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Video - Any"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        lazyColumnNode.performScrollToNode(hasText(attachmentsFormElement!!.label))
+        // Assert that the attachments element is displayed
+        var attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        var addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        // Assert all the appropriate options are displayed in the menu
+        var menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(
+                context.getString(R.string.take_video),
+                context.getString(R.string.choose_from_gallery),
+                context.getString(R.string.choose_from_files)
+            ),
+            nonVisibleOptions = listOf(
+                context.getString(R.string.take_photo)
+            )
+        )
+        // Dismiss the menu
+        Espresso.pressBack()
+
+        // Find the "Media - Video - Capture" attachments form element
+        attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Video - Capture"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        // Assert that the attachments element is displayed
+        lazyColumnNode.performScrollToNode(hasText(attachmentsFormElement!!.label))
+        attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        // Assert all the appropriate options are displayed in the menu
+        menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(
+                context.getString(R.string.take_video)
+            ),
+            nonVisibleOptions = listOf(
+                context.getString(R.string.take_photo),
+                context.getString(R.string.choose_from_gallery),
+                context.getString(R.string.choose_from_files)
+            )
+        )
+        // Dismiss the menu
+        Espresso.pressBack()
+
+        // Find the "Media - Video - Upload" attachments form element
+        attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Video - Upload"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        lazyColumnNode.performScrollToNode(hasText(attachmentsFormElement!!.label))
+        // Assert that the attachments element is displayed
+        attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        // Assert all the appropriate options are displayed in the menu
+        menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(
+                context.getString(R.string.choose_from_gallery),
+                context.getString(R.string.choose_from_files)
+            ),
+            nonVisibleOptions = listOf(
+                context.getString(R.string.take_photo),
+                context.getString(R.string.take_video)
+            )
+        )
+    }
+
+    /**
+     * Test case 14.5:
+     * Given a `FeatureForm` with an authored `AttachmentsFormElement` of type `AudioFormInput`s with different `AttachmentInputMethod`s
+     * When the `FeatureForm` is displayed and the add attachment menu is opened
+     * Then the menu displays the appropriate options
+     *
+     * https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#test-case-145-audio-media-attachments-form-elements
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun testAttachmentsFormElementWithAudioInput() = runTest {
+        // Create a FeatureFormState and set the compose content
+        val featureFormState = FeatureFormState(
+            featureForm = featureForm,
+            coroutineScope = scope
+        )
+        composeTestRule.setContent {
+            FeatureForm(featureFormState = featureFormState)
+        }
+
+        // Find the lazy column node the FeatureForm is displayed in
+        val lazyColumnNode = composeTestRule.onNodeWithContentDescription("lazy column")
+
+        // Find the "Media - Audio - Any" attachments form element
+        var attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Audio - Any"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        lazyColumnNode.performScrollToNode(hasText(attachmentsFormElement!!.label))
+        // Assert that the attachments element is displayed
+        var attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        var addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        // Assert all the appropriate options are displayed in the menu
+        var menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        // Recording audio is not currently supported in the toolkit
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(
+                context.getString(R.string.choose_from_files)
+            ),
+            nonVisibleOptions = listOf(
+                context.getString(R.string.take_video),
+                context.getString(R.string.choose_from_gallery),
+                context.getString(R.string.take_photo)
+            )
+        )
+        // Dismiss the menu
+        Espresso.pressBack()
+
+        // Find the "Media - Audio - Capture" attachments form element
+        attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Audio - Capture"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        // Assert that the attachments element is displayed
+        lazyColumnNode.performScrollToNode(hasText(attachmentsFormElement!!.label))
+        attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        menu = composeTestRule.onNode(isPopup())
+        // Recording audio is not currently supported in the toolkit
+        menu.assertIsNotDisplayed()
+
+        // Find the "Media - Audio - Upload" attachments form element
+        attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Audio - Upload"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        lazyColumnNode.performScrollToNode(hasText(attachmentsFormElement!!.label))
+        // Assert that the attachments element is displayed
+        attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Assert that the add attachment button is displayed and enabled
+        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton.assertIsDisplayed().performClick()
+
+        // Assert all the appropriate options are displayed in the menu
+        menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        assertValidCaptureOptions(
+            node = menu,
+            visibleOptions = listOf(
+                context.getString(R.string.choose_from_files)
+            ),
+            nonVisibleOptions = listOf(
+                context.getString(R.string.take_photo),
+                context.getString(R.string.take_video),
+                context.getString(R.string.choose_from_gallery)
+            )
+        )
+    }
+
+    /**
+     * Mocks the result of a file picker intent to simulate selecting a file from the device's
+     * storage.
+     *
+     * @param context The context used to create the mock file and intent.
+     * @param fileName The name of the file to be mocked as selected.
+     */
+    private fun mockFilePickerIntentResult(
+        context: Context,
+        fileName: String
+    ) {
+        val file = File(
+            // parent nested dir must match the path in the file provider xml
+            File(context.cacheDir, "feature_forms_attachments"),
+            // the test file
+            fileName //"test_document.txt"
+        )
+        // Create the mock document file with some content
+        file.parentFile?.mkdirs()
+        // Create the mock document file with some content if it doesn't exist
+        if (file.exists().not()) {
+            FileWriter(file).use { writer ->
+                writer.write("Mock file content for testing.")
+                writer.flush()
+            }
+        }
+        // Set up the intent response with the file URI
+        val resultData = Intent().apply {
+            data = AttachmentsFileProvider.getUriForFile(file, context)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        val result = Instrumentation.ActivityResult(Activity.RESULT_OK, resultData)
+        // Set up the intent matcher to respond with the result when the "Choose From Files" action
+        // is triggered
+        intending(hasAction(Intent.ACTION_OPEN_DOCUMENT)).respondWith(result)
+    }
+
+    private fun assertValidCaptureOptions(
+        node: SemanticsNodeInteraction,
+        visibleOptions: List<String> = emptyList(),
+        nonVisibleOptions: List<String> = emptyList(),
+    ) {
+        visibleOptions.forEach { option ->
+            node.onChildWithText(
+                value = option,
+                recurse = true
+            ).assertIsDisplayed()
+        }
+        nonVisibleOptions.forEach { option ->
+            assertThrows(AssertionError::class.java) {
+                node.onChildWithText(
+                    value = option,
+                    recurse = true
+                ).assertIsDisplayed()
+            }
+        }
+    }
+}

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
@@ -20,6 +20,7 @@ import android.app.Activity
 import android.app.Instrumentation
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
@@ -29,6 +30,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
@@ -103,13 +105,13 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         generalAttachmentsNode.assertIsDisplayed()
 
         // Get the add attachment button and assert that it is displayed
-        val addAttachmentButton =
+        var addAttachmentButton =
             generalAttachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed()
         addAttachmentButton.performClick()
 
         // Assert all the options are displayed
-        val menu = composeTestRule.onNode(isPopup())
+        var menu = composeTestRule.onNode(isPopup())
         menu.assertIsDisplayed()
         assertValidCaptureOptions(
             node = menu,
@@ -125,7 +127,7 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         ).assertIsDisplayed()
 
         // Create a temporary file to simulate the selected document
-        mockFilePickerIntentResult(context, "test_document.txt")
+        mockFilePickerIntentResult(context, "test_document.txt", "text/plain")
         // Perform the click on the "Choose From Files" option
         chooseFromFiles.performClick()
         composeTestRule.waitForIdle()
@@ -147,7 +149,7 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         composeTestRule.onNodeWithText(context.getString(R.string.rename)).assert(isEnabled().not())
 
         // Create another temporary file to simulate the selected document
-        mockFilePickerIntentResult(context, "test_document_2.txt")
+        mockFilePickerIntentResult(context, "test_document_2.txt", "text/plain")
         // Perform the click on the "Choose From Files" option
         addAttachmentButton.performClick()
         composeTestRule.onNodeWithContentDescription(
@@ -168,8 +170,10 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         )
         // Long click on the attachment to trigger the context menu
         attachmentNode.performTouchInput { longClick() }
-        // Assert the Rename option is disable
+        // Assert the Rename option is disabled
         composeTestRule.onNodeWithText(context.getString(R.string.rename)).assert(isEnabled().not())
+        // Dismiss the menu
+        Espresso.pressBack()
 
         // Assert that the add attachments button is now disabled since the max number of
         // attachments configured is 2
@@ -206,6 +210,59 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
                 R.plurals.min_attachments_required, 1, 1
             )
         )
+
+        // Create a temporary file to simulate the selected image
+        mockFilePickerIntentResult(context, "test_img.png", "image/png")
+
+        // Click the add attachment button to open the menu
+        addAttachmentButton = photoAttachmentsNode.onChildWithContentDescription(
+            context.getString(R.string.add_attachment)
+        ).assertIsDisplayed()
+        addAttachmentButton.performClick()
+
+        // Perform the click on the "Choose From Files" option
+        menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        menu.onChildWithText(
+            value = context.getString(R.string.choose_from_files),
+            recurse = true
+        ).performClick()
+        composeTestRule.waitForIdle()
+
+        // Wait until the progress dialog is dismissed
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onNode(isDialog()).isNotDisplayed()
+        }
+
+        // Assert that the new attachment is displayed in the attachments list
+        composeTestRule.waitUntil {
+            // Check for the thumbnail in content description since `displayFileName` is true
+            photoAttachmentsNode.onChildWithContentDescription(
+                "Thumbnail",
+                recurse = true
+            ).isDisplayed()
+        }
+
+        // Assert that the attachment has a name that matches the pattern "attachment_#.png"
+        attachmentNode = photoAttachmentsNode.onChildWithContentDescription(
+            "Thumbnail",
+            recurse = true
+        )
+        val pattern = Regex("attachment_\\d+\\.png", RegexOption.IGNORE_CASE)
+        attachmentNode.assert(hasTextMatching(pattern))
+
+        // Assert the validation error is no longer visible on the element
+        photoAttachmentsNode.assert(
+            hasText(
+                context.resources.getQuantityString(
+                    R.plurals.min_attachments_required, 1, 1
+                )
+            ).not()
+        )
+
+        // Assert the attachment can be renamed
+        attachmentNode.performTouchInput { longClick() }
+        composeTestRule.onNodeWithText(context.getString(R.string.rename)).assert(isEnabled())
     }
 
     /**
@@ -610,14 +667,20 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
 
     /**
      * Mocks the result of a file picker intent to simulate selecting a file from the device's
-     * storage.
+     * storage. This method supports mocking files with the following content types: "image/png" and
+     * "text/plain". If an unsupported content type is provided, an [UnsupportedOperationException]
+     * will be thrown.
      *
      * @param context The context used to create the mock file and intent.
      * @param fileName The name of the file to be mocked as selected.
+     * @param contentType The MIME type of the file to be mocked as selected.
+     *
+     * @throws UnsupportedOperationException if the provided content type is not supported.
      */
     private fun mockFilePickerIntentResult(
         context: Context,
-        fileName: String
+        fileName: String,
+        contentType: String
     ) {
         val file = File(
             // parent nested dir must match the path in the file provider xml
@@ -627,11 +690,27 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         )
         // Create the mock document file with some content
         file.parentFile?.mkdirs()
-        // Create the mock document file with some content if it doesn't exist
-        if (file.exists().not()) {
-            FileWriter(file).use { writer ->
-                writer.write("Mock file content for testing.")
-                writer.flush()
+        // If the file already exists, we don't need to create it again
+        if (file.exists()) return
+        when (contentType) {
+            "image/png" -> {
+                val bitmap = Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
+                file.outputStream().use { outputStream ->
+                    bitmap.compress(Bitmap.CompressFormat.PNG, 0, outputStream)
+                }
+                bitmap.recycle()
+            }
+
+            "text/plain" -> {
+                FileWriter(file).use { writer ->
+                    writer.write("Mock file content for testing.")
+                    writer.flush()
+                }
+            }
+
+            else -> {
+                // If the content type is not supported, throw an exception
+                throw UnsupportedOperationException("Unsupported content type: $contentType")
             }
         }
         // Set up the intent response with the file URI

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
@@ -636,6 +636,13 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         intending(hasAction(Intent.ACTION_OPEN_DOCUMENT)).respondWith(result)
     }
 
+    /**
+     * Asserts that the specified options are displayed or not displayed in the given node.
+     *
+     * @param node The [SemanticsNodeInteraction] to check for the options.
+     * @param visibleOptions A list of options that should be displayed.
+     * @param nonVisibleOptions A list of options that should not be displayed.
+     */
     private fun assertValidCaptureOptions(
         node: SemanticsNodeInteraction,
         visibleOptions: List<String> = emptyList(),

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
@@ -23,7 +23,6 @@ import android.content.Intent
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasText
@@ -105,7 +104,7 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
 
         // Get the add attachment button and assert that it is displayed
         val addAttachmentButton =
-            generalAttachmentsNode.onChildWithContentDescription("Add Attachment")
+            generalAttachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed()
         addAttachmentButton.performClick()
 
@@ -239,7 +238,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        val addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        val addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed().performClick()
 
         // Assert only the "Choose From Files" option is displayed
@@ -291,7 +291,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        var addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        var addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed().performClick()
 
         // Assert all the appropriate options are displayed in the menu
@@ -323,7 +324,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed().performClick()
 
         // Assert all the appropriate options are displayed in the menu
@@ -355,7 +357,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed().performClick()
 
         // Assert all the appropriate options are displayed in the menu
@@ -410,7 +413,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        var addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        var addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed().performClick()
 
         // Assert all the appropriate options are displayed in the menu
@@ -442,7 +446,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed().performClick()
 
         // Assert all the appropriate options are displayed in the menu
@@ -474,7 +479,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed().performClick()
 
         // Assert all the appropriate options are displayed in the menu
@@ -529,7 +535,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        var addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        var addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed().performClick()
 
         // Assert all the appropriate options are displayed in the menu
@@ -562,7 +569,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed()
         // Recording audio is not currently supported in the toolkit and hence the add option
         // is disabled
@@ -580,7 +588,8 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         attachmentsNode.assertIsDisplayed()
 
         // Assert that the add attachment button is displayed and enabled
-        addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
+        addAttachmentButton =
+            attachmentsNode.onChildWithContentDescription(context.getString(R.string.add_attachment))
         addAttachmentButton.assertIsDisplayed().performClick()
 
         // Assert all the appropriate options are displayed in the menu

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDialog
@@ -562,11 +563,10 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
 
         // Assert that the add attachment button is displayed and enabled
         addAttachmentButton = attachmentsNode.onChildWithContentDescription("Add Attachment")
-        addAttachmentButton.assertIsDisplayed().performClick()
-
-        menu = composeTestRule.onNode(isPopup())
-        // Recording audio is not currently supported in the toolkit
-        menu.assertIsNotDisplayed()
+        addAttachmentButton.assertIsDisplayed()
+        // Recording audio is not currently supported in the toolkit and hence the add option
+        // is disabled
+        addAttachmentButton.assertIsNotEnabled()
 
         // Find the "Media - Audio - Upload" attachments form element
         attachmentsFormElement = featureForm.elements.firstOrNull {

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/SemanticsNodeUtil.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/SemanticsNodeUtil.kt
@@ -190,3 +190,24 @@ internal fun hasEditableText(
         actual == textValue
     }
 }
+
+/**
+ * Creates a semantic matcher to match text with the given regex.
+ *
+ * @param regex the regex to match
+ * @return a SemanticsMatcher to match the text of a SemanticsNodeInteraction.
+ */
+internal fun hasTextMatching(
+    regex: Regex
+) : SemanticsMatcher {
+    return SemanticsMatcher(
+        "Text matches regex [$regex]"
+    ) { node ->
+        val list = node.config.getOrNull(SemanticsProperties.Text)
+            ?: return@SemanticsMatcher false
+
+        list.any {
+            it.text.matches(regex)
+        }
+    }
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
@@ -91,11 +91,11 @@ internal fun AddAttachment(
                 onFocused()
                 showMenu = true
             },
-            enabled = enabled
+            enabled = enabled && captureOptions.isNotEmpty()
         ) {
             Icon(
                 Icons.Rounded.Add,
-                contentDescription = "Add attachment",
+                contentDescription = "Add Attachment",
                 modifier = Modifier.size(32.dp),
             )
         }
@@ -132,7 +132,7 @@ internal fun AddAttachment(
 
                     is CaptureOptions.CaptureVideo if hasCameraPermission -> {
                         DropdownMenuItem(
-                            text = { Text(text = "Take Video") },
+                            text = { Text(text = stringResource(R.string.take_video)) },
                             trailingIcon = {
                                 Icon(
                                     imageVector = Icons.Rounded.Videocam,
@@ -154,7 +154,7 @@ internal fun AddAttachment(
 
                     is CaptureOptions.Gallery -> {
                         DropdownMenuItem(
-                            text = { Text(text = stringResource(R.string.add_from_gallery)) },
+                            text = { Text(text = stringResource(R.string.choose_from_gallery)) },
                             trailingIcon = {
                                 Icon(
                                     imageVector = Icons.Rounded.Photo,
@@ -176,7 +176,7 @@ internal fun AddAttachment(
 
                     is CaptureOptions.File -> {
                         DropdownMenuItem(
-                            text = { Text(text = stringResource(R.string.add_file)) },
+                            text = { Text(text = stringResource(R.string.choose_from_files)) },
                             trailingIcon = {
                                 Icon(
                                     imageVector = Icons.Rounded.Folder,
@@ -394,7 +394,7 @@ private fun List<AttachmentsFormInput>.getCaptureOptions(): List<CaptureOptions>
         when (input) {
             is AudioFormInput -> {
                 when (input.inputMethod) {
-                    AttachmentInputMethod.Capture -> listOf(CaptureOptions.CaptureAudio(input.maxDuration))
+                    AttachmentInputMethod.Capture -> emptyList() // not supported yet
                     AttachmentInputMethod.Upload -> listOf(
                         CaptureOptions.File(allowedMimeTypes = input.getMimeTypes())
                     )

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
@@ -95,7 +95,7 @@ internal fun AddAttachment(
         ) {
             Icon(
                 Icons.Rounded.Add,
-                contentDescription = "Add Attachment",
+                contentDescription = stringResource(R.string.add_attachment),
                 modifier = Modifier.size(32.dp),
             )
         }

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -71,6 +71,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -120,7 +122,14 @@ internal fun AttachmentTile(
         onClick = {},
         modifier = modifier
             .width(AttachmentFormElementDefaults.tileWidth)
-            .height(AttachmentFormElementDefaults.tileHeight),
+            .height(AttachmentFormElementDefaults.tileHeight)
+            .semantics(mergeDescendants = displayFilename) {
+                // set the content description, when displayFilename is false
+                if (name.isEmpty()) {
+                    contentDescription =
+                        context.getString(R.string.attachment_with_name, state.name)
+                }
+            },
         colors = CardDefaults.cardColors(
             containerColor = colors.tileContainerColor
         ),
@@ -220,7 +229,7 @@ internal fun AttachmentTile(
                         } else if (loadStatus is LoadStatus.Loaded) {
                             // open attachment
                             val intent = Intent()
-                            intent.setAction(Intent.ACTION_VIEW)
+                            intent.action = Intent.ACTION_VIEW
                             val uri = AttachmentsFileProvider.getUriForFile(
                                 context = context,
                                 file = File(state.filePath)

--- a/toolkit/featureforms/src/main/res/values-ar/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ar/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">مساءً</string>
 
     <string name="take_photo">التقاط صورة</string>
-    <string name="add_from_gallery">إضافة من المعرض</string>
+    <string name="choose_from_gallery">إضافة من المعرض</string>
     <string name="rename">إعادة تسمية</string>
     <string name="delete">حذف</string>
     <string name="rename_attachment">إعادة تسمية المرفق</string>
     <string name="name">الاسم</string>
-    <string name="add_file">إضافة من الملفات</string>
+    <string name="choose_from_files">إضافة من الملفات</string>
     <string name="attachment_error">حدث خطأ في أثناء إضافة المرفق</string>
     <string name="no_app_found">لم يتم العثور على تطبيق لفتح هذا النوع من الملفات.</string>
     <string name="attachment_too_large">الملف كبير للغاية. يرجى إضافة ملف أقل من 50 ميجابايت.</string>

--- a/toolkit/featureforms/src/main/res/values-bg/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-bg/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">След обяд</string>
 
     <string name="take_photo">Направете снимка</string>
-    <string name="add_from_gallery">Добавете от Галерия</string>
+    <string name="choose_from_gallery">Добавете от Галерия</string>
     <string name="rename">Преименуване</string>
     <string name="delete">Изтриване</string>
     <string name="rename_attachment">Преименуване на прикачен файл</string>
     <string name="name">Име</string>
-    <string name="add_file">Добавете от Файлове</string>
+    <string name="choose_from_files">Добавете от Файлове</string>
     <string name="attachment_error">Грешка при добавяне на прикачен файл</string>
     <string name="no_app_found">Няма налично приложение, което да отвори този тип файл.</string>
     <string name="attachment_too_large">Файлът е твърде голям. Моля, добавете файл по-малък от 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-bs/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-bs/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">Popodne</string>
 
     <string name="take_photo">Snimi fotografiju</string>
-    <string name="add_from_gallery">Dodaj iz galerije</string>
+    <string name="choose_from_gallery">Dodaj iz galerije</string>
     <string name="rename">Preimenuj</string>
     <string name="delete">Izbriši</string>
     <string name="rename_attachment">Preimenuj privitak</string>
     <string name="name">Naziv</string>
-    <string name="add_file">Dodaj iz datoteka</string>
+    <string name="choose_from_files">Dodaj iz datoteka</string>
     <string name="attachment_error">Pogreška prilikom dodavanja privitka.</string>
     <string name="no_app_found">Nije pronađena aplikacija za otvaranje ove vrste datoteka.</string>
     <string name="attachment_too_large">Datoteka je prevelika. Dodajte datoteku manju od 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-ca/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ca/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Feu una foto</string>
-    <string name="add_from_gallery">Afegeix des de la galeria</string>
+    <string name="choose_from_gallery">Afegeix des de la galeria</string>
     <string name="rename">Canvia el nom</string>
     <string name="delete">Suprimeix</string>
     <string name="rename_attachment">Canvia el nom del fitxer adjunt</string>
     <string name="name">Nom</string>
-    <string name="add_file">Afegeix des dels fitxers</string>
+    <string name="choose_from_files">Afegeix des dels fitxers</string>
     <string name="attachment_error">Error en afegir el fitxer adjunt</string>
     <string name="no_app_found">No s\'ha trobat cap aplicació per obrir aquest tipus de fitxer.</string>
     <string name="attachment_too_large">El fitxer és massa gran. Afegiu un fitxer de menys de 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-cs/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-cs/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">odpoledne</string>
 
     <string name="take_photo">Vyfotografovat</string>
-    <string name="add_from_gallery">Přidat z galerie</string>
+    <string name="choose_from_gallery">Přidat z galerie</string>
     <string name="rename">Přejmenovat</string>
     <string name="delete">Odstranit</string>
     <string name="rename_attachment">Přejmenovat přílohu</string>
     <string name="name">Název</string>
-    <string name="add_file">Přidat ze souborů</string>
+    <string name="choose_from_files">Přidat ze souborů</string>
     <string name="attachment_error">Chyba při přidávání přílohy</string>
     <string name="no_app_found">Nebyla nalezena žádná aplikace, která by mohla otevřít tento typ souboru.</string>
     <string name="attachment_too_large">Soubor je příliš velký. Přidejte soubor menší než 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-da/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-da/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Tag foto</string>
-    <string name="add_from_gallery">Tilføj fra galleri</string>
+    <string name="choose_from_gallery">Tilføj fra galleri</string>
     <string name="rename">Omdøb</string>
     <string name="delete">Slet</string>
     <string name="rename_attachment">Omdøb vedhæftning</string>
     <string name="name">Navn</string>
-    <string name="add_file">Tilføj fra filer</string>
+    <string name="choose_from_files">Tilføj fra filer</string>
     <string name="attachment_error">Fejl under tilføjelse af vedhæftning</string>
     <string name="no_app_found">Der blev ikke fundet nogen applikation til at åbne denne filtype.</string>
     <string name="attachment_too_large">Filen er for stor. Tilføj en fil, der er mindre end 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-de/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-de/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Foto aufnehmen</string>
-    <string name="add_from_gallery">Aus Galerie hinzufügen</string>
+    <string name="choose_from_gallery">Aus Galerie hinzufügen</string>
     <string name="rename">Umbenennen</string>
     <string name="delete">Löschen</string>
     <string name="rename_attachment">Anlage umbenennen</string>
     <string name="name">Name</string>
-    <string name="add_file">Aus Dateien hinzufügen</string>
+    <string name="choose_from_files">Aus Dateien hinzufügen</string>
     <string name="attachment_error">Anlage konnte nicht hinzugefügt werden.</string>
     <string name="no_app_found">Keine Anwendung zum Öffnen dieses Dateityps gefunden.</string>
     <string name="attachment_too_large">Die Datei ist zu groß. Fügen Sie eine Datei mit weniger als 50 MB hinzu.</string>

--- a/toolkit/featureforms/src/main/res/values-el/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-el/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">μ.μ.</string>
 
     <string name="take_photo">Λήψη φωτογραφίας</string>
-    <string name="add_from_gallery">Προσθήκη από τη Συλλογή</string>
+    <string name="choose_from_gallery">Προσθήκη από τη Συλλογή</string>
     <string name="rename">Μετονομασία</string>
     <string name="delete">Διαγραφή</string>
     <string name="rename_attachment">Μετονομασία συνημμένου</string>
     <string name="name">Όνομα</string>
-    <string name="add_file">Προσθήκη από τα αρχεία</string>
+    <string name="choose_from_files">Προσθήκη από τα αρχεία</string>
     <string name="attachment_error">Σφάλμα κατά την προσθήκη του συνημμένου</string>
     <string name="no_app_found">Δεν βρέθηκε εφαρμογή για το άνοιγμα αυτού του τύπου αρχείου.</string>
     <string name="attachment_too_large">Το αρχείο είναι πολύ μεγάλο. Προσθέστε ένα αρχείο με μέγεθος μικρότερο από 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-es/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-es/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">p.m.</string>
 
     <string name="take_photo">Tomar foto</string>
-    <string name="add_from_gallery">Agregar desde galería</string>
+    <string name="choose_from_gallery">Agregar desde galería</string>
     <string name="rename">Cambiar el nombre</string>
     <string name="delete">Eliminar</string>
     <string name="rename_attachment">Cambiar nombre de adjunto</string>
     <string name="name">Nombre</string>
-    <string name="add_file">Agregar desde archivos</string>
+    <string name="choose_from_files">Agregar desde archivos</string>
     <string name="attachment_error">Error al agregar adjunto</string>
     <string name="no_app_found">No se ha encontrado ninguna aplicación para abrir este tipo de archivo.</string>
     <string name="attachment_too_large">El archivo es demasiado grande. Agregue un archivo de menos de 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-et/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-et/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">p.l.</string>
 
     <string name="take_photo">Pildista</string>
-    <string name="add_from_gallery">Lisa galeriist</string>
+    <string name="choose_from_gallery">Lisa galeriist</string>
     <string name="rename">Nimeta ümber</string>
     <string name="delete">Kustuta</string>
     <string name="rename_attachment">Nimeta manus ümber</string>
     <string name="name">Nimi</string>
-    <string name="add_file">Lisa failide hulgast</string>
+    <string name="choose_from_files">Lisa failide hulgast</string>
     <string name="attachment_error">Manuse lisamise tõrge</string>
     <string name="no_app_found">Selle failitüübi avamiseks rakendust ei leitud.</string>
     <string name="attachment_too_large">Fail on liiga suur Lisa fail, mis on väiksem kui 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-fi/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-fi/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">IP</string>
 
     <string name="take_photo">Ota valokuva</string>
-    <string name="add_from_gallery">Lisää galleriasta</string>
+    <string name="choose_from_gallery">Lisää galleriasta</string>
     <string name="rename">Nimeä uudelleen</string>
     <string name="delete">Poista</string>
     <string name="rename_attachment">Nimeä liite uudelleen</string>
     <string name="name">Nimi</string>
-    <string name="add_file">Lisää tiedostoista</string>
+    <string name="choose_from_files">Lisää tiedostoista</string>
     <string name="attachment_error">Virhe lisättäessä liitettä</string>
     <string name="no_app_found">Tämän tiedostotyypin avaamiseen ei löytynyt sovellusta.</string>
     <string name="attachment_too_large">Tiedosto on liian suuri. Lisää tiedosto, jonka koko on alle 50 Mt.</string>

--- a/toolkit/featureforms/src/main/res/values-fr/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-fr/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Prendre une photo</string>
-    <string name="add_from_gallery">Ajouter à partir de la bibliothèque</string>
+    <string name="choose_from_gallery">Ajouter à partir de la bibliothèque</string>
     <string name="rename">Renommer</string>
     <string name="delete">Supprimer</string>
     <string name="rename_attachment">Renommer la pièce jointe</string>
     <string name="name">Nom</string>
-    <string name="add_file">Ajouter à partir de fichiers</string>
+    <string name="choose_from_files">Ajouter à partir de fichiers</string>
     <string name="attachment_error">Erreur lors de l’ajout de la pièce jointe</string>
     <string name="no_app_found">Aucune application trouvée pour ouvrir ce type de fichier.</string>
     <string name="attachment_too_large">Le fichier est trop volumineux. Ajoutez un fichier de moins de 50 Mo.</string>

--- a/toolkit/featureforms/src/main/res/values-hr/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-hr/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">Popodne</string>
 
     <string name="take_photo">Snimi fotografiju</string>
-    <string name="add_from_gallery">Dodaj iz galerije</string>
+    <string name="choose_from_gallery">Dodaj iz galerije</string>
     <string name="rename">Preimenuj</string>
     <string name="delete">Izbriši</string>
     <string name="rename_attachment">Preimenuj privitak</string>
     <string name="name">Naziv</string>
-    <string name="add_file">Dodaj iz datoteka</string>
+    <string name="choose_from_files">Dodaj iz datoteka</string>
     <string name="attachment_error">Pogreška prilikom dodavanja privitka.</string>
     <string name="no_app_found">Nije pronađena aplikacija za otvaranje ove vrste datoteka.</string>
     <string name="attachment_too_large">Datoteka je prevelika. Dodajte datoteku manju od 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-hu/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-hu/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">DU</string>
 
     <string name="take_photo">Fénykép készítése</string>
-    <string name="add_from_gallery">Hozzáadás a galériából</string>
+    <string name="choose_from_gallery">Hozzáadás a galériából</string>
     <string name="rename">Átnevezés</string>
     <string name="delete">Törlés</string>
     <string name="rename_attachment">Csatolmány átnevezése</string>
     <string name="name">Név</string>
-    <string name="add_file">Hozzáadás fájlokból</string>
+    <string name="choose_from_files">Hozzáadás fájlokból</string>
     <string name="attachment_error">Hiba a csatolmány hozzáadásakor</string>
     <string name="no_app_found">Nem található alkalmazás ezen fájltípus megnyitásához.</string>
     <string name="attachment_too_large">A fájl túl nagy. Kérjük, 50 MB-nál kisebb fájlokat adjon hozzá.</string>

--- a/toolkit/featureforms/src/main/res/values-in/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-in/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Ambil Foto</string>
-    <string name="add_from_gallery">Tambahkan Dari Galeri</string>
+    <string name="choose_from_gallery">Tambahkan Dari Galeri</string>
     <string name="rename">Ubah Nama</string>
     <string name="delete">Hapus</string>
     <string name="rename_attachment">Ganti Nama Lampiran</string>
     <string name="name">Nama</string>
-    <string name="add_file">Tambahkan Dari File</string>
+    <string name="choose_from_files">Tambahkan Dari File</string>
     <string name="attachment_error">Kesalahan Saat Menambahkan Lampiran</string>
     <string name="no_app_found">Tidak ditemukan aplikasi untuk membuka jenis file ini.</string>
     <string name="attachment_too_large">Ukuran File terlalu besar. Silakan tambahkan file yang lebih kecil dari 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-it/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-it/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Scatta una foto</string>
-    <string name="add_from_gallery">Aggiungi da galleria</string>
+    <string name="choose_from_gallery">Aggiungi da galleria</string>
     <string name="rename">Rinomina</string>
     <string name="delete">Elimina</string>
     <string name="rename_attachment">Rinomina allegato</string>
     <string name="name">Nome</string>
-    <string name="add_file">Aggiungi da file</string>
+    <string name="choose_from_files">Aggiungi da file</string>
     <string name="attachment_error">Errore durante l\'aggiunta dell\'allegato</string>
     <string name="no_app_found">Nessuna applicazione trovata per aprire questo tipo di file.</string>
     <string name="attachment_too_large">Il file è troppo grande. Aggiungi un file di dimensioni inferiori a 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-iw/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-iw/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">צלם תמונה</string>
-    <string name="add_from_gallery">הוסף מהגלריה</string>
+    <string name="choose_from_gallery">הוסף מהגלריה</string>
     <string name="rename">שנה שם</string>
     <string name="delete">מחק</string>
     <string name="rename_attachment">שנה שם קובץ מצורף</string>
     <string name="name">שם</string>
-    <string name="add_file">הוסף מקבצים</string>
+    <string name="choose_from_files">הוסף מקבצים</string>
     <string name="attachment_error">שגיאה בהוספת צורפה</string>
     <string name="no_app_found">לא נמצא יישום לפתיחת סוג קובץ זה.</string>
     <string name="attachment_too_large">הקובץ גדול מדי. הוסף קובץ קטן מ-50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-ja/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ja/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">写真の撮影</string>
-    <string name="add_from_gallery">ギャラリーから追加</string>
+    <string name="choose_from_gallery">ギャラリーから追加</string>
     <string name="rename">名前の変更</string>
     <string name="delete">削除</string>
     <string name="rename_attachment">添付ファイル名の変更</string>
     <string name="name">名前</string>
-    <string name="add_file">ファイルから追加</string>
+    <string name="choose_from_files">ファイルから追加</string>
     <string name="attachment_error">添付ファイルの追加中にエラーが発生しました</string>
     <string name="no_app_found">このファイルの種類を開くアプリケーションが見つかりませんでした。</string>
     <string name="attachment_too_large">ファイルが大きすぎます。 50 MB 未満のファイルを追加してください。</string>

--- a/toolkit/featureforms/src/main/res/values-ko/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ko/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">오후</string>
 
     <string name="take_photo">사진 촬영</string>
-    <string name="add_from_gallery">갤러리에서 추가</string>
+    <string name="choose_from_gallery">갤러리에서 추가</string>
     <string name="rename">이름 바꾸기</string>
     <string name="delete">삭제</string>
     <string name="rename_attachment">첨부 파일 이름 바꾸기</string>
     <string name="name">이름</string>
-    <string name="add_file">파일에서 추가</string>
+    <string name="choose_from_files">파일에서 추가</string>
     <string name="attachment_error">첨부 파일을 추가하는 동안 오류 발생</string>
     <string name="no_app_found">이 파일 유형을 열 응용프로그램을 찾을 수 없습니다.</string>
     <string name="attachment_too_large">파일이 너무 큽니다. 크기가 50MB 미만인 파일을 추가하세요.</string>

--- a/toolkit/featureforms/src/main/res/values-lt/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-lt/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">popiet</string>
 
     <string name="take_photo">Fotografuoti</string>
-    <string name="add_from_gallery">Pridėti iš galerijos</string>
+    <string name="choose_from_gallery">Pridėti iš galerijos</string>
     <string name="rename">Pervardinti</string>
     <string name="delete">Ištrinti</string>
     <string name="rename_attachment">Pervardinti priedą</string>
     <string name="name">Pavadinimas</string>
-    <string name="add_file">Pridėti iš failų</string>
+    <string name="choose_from_files">Pridėti iš failų</string>
     <string name="attachment_error">Pridedant priedą įvyko klaida</string>
     <string name="no_app_found">Nerasta programėlės šio tipo failui atidaryti.</string>
     <string name="attachment_too_large">Failas yra per didelis. Pridėkite mažesnį nei 50 MB failą.</string>

--- a/toolkit/featureforms/src/main/res/values-lv/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-lv/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Uzņemt fotoattēlu</string>
-    <string name="add_from_gallery">Pievienot no galerijas</string>
+    <string name="choose_from_gallery">Pievienot no galerijas</string>
     <string name="rename">Pārdēvēt</string>
     <string name="delete">Dzēst</string>
     <string name="rename_attachment">Pārdēvēt pielikumu</string>
     <string name="name">Nosaukums</string>
-    <string name="add_file">Pievienot no failiem</string>
+    <string name="choose_from_files">Pievienot no failiem</string>
     <string name="attachment_error">Pievienojot pielikumu, radās kļūda</string>
     <string name="no_app_found">Nav atrasta šī failu tipa atvēršanai piemērota lietotne.</string>
     <string name="attachment_too_large">Fails ir pārāk liels. Pievienot failu, kura izmērs ir mazāks par 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-nl/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-nl/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Foto maken</string>
-    <string name="add_from_gallery">Toevoegen uit galerij</string>
+    <string name="choose_from_gallery">Toevoegen uit galerij</string>
     <string name="rename">Naam wijzigen</string>
     <string name="delete">Verwijderen</string>
     <string name="rename_attachment">Naam bijlage wijzigen</string>
     <string name="name">Naam</string>
-    <string name="add_file">Toevoegen uit bestanden</string>
+    <string name="choose_from_files">Toevoegen uit bestanden</string>
     <string name="attachment_error">Fout bij toevoegen bijlage</string>
     <string name="no_app_found">Kan geen applicatie vinden voor het openen van dit bestandstype.</string>
     <string name="attachment_too_large">Het bestand is te groot Voeg een bestand toe dat kleiner is dan 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-no/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-no/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Ta bilde</string>
-    <string name="add_from_gallery">Legg til fra Galleriet</string>
+    <string name="choose_from_gallery">Legg til fra Galleriet</string>
     <string name="rename">Gi nytt navn</string>
     <string name="delete">Slett</string>
     <string name="rename_attachment">Endre navn på vedlegg</string>
     <string name="name">Navn</string>
-    <string name="add_file">Legg til fra Filer</string>
+    <string name="choose_from_files">Legg til fra Filer</string>
     <string name="attachment_error">Feil ved tillegging av vedlegg</string>
     <string name="no_app_found">Fant ingen applikasjon for å åpne denne filtypen.</string>
     <string name="attachment_too_large">Filen er for stor. Legg til en fil som er mindre enn 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-pl/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-pl/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">po południu</string>
 
     <string name="take_photo">Zrób zdjęcie</string>
-    <string name="add_from_gallery">Dodaj z galerii</string>
+    <string name="choose_from_gallery">Dodaj z galerii</string>
     <string name="rename">Zmień nazwę</string>
     <string name="delete">Usuń</string>
     <string name="rename_attachment">Zmień nazwę załącznika</string>
     <string name="name">Nazwa</string>
-    <string name="add_file">Dodaj z plików</string>
+    <string name="choose_from_files">Dodaj z plików</string>
     <string name="attachment_error">Błąd podczas dodawania załącznika</string>
     <string name="no_app_found">Nie znaleziono aplikacji do otwarcia tego typu pliku.</string>
     <string name="attachment_too_large">Plik jest za duży. Dodaj plik o rozmiarze mniejszym niż 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-pt-rBR/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-pt-rBR/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Tirar Foto</string>
-    <string name="add_from_gallery">Adicionar da Galeria</string>
+    <string name="choose_from_gallery">Adicionar da Galeria</string>
     <string name="rename">Renomear</string>
     <string name="delete">Excluir</string>
     <string name="rename_attachment">Renomear Anexo</string>
     <string name="name">Nome</string>
-    <string name="add_file">Adicionar de Arquivos</string>
+    <string name="choose_from_files">Adicionar de Arquivos</string>
     <string name="attachment_error">Erro ao Adicionar Anexo</string>
     <string name="no_app_found">Nenhum aplicativo encontrado para abrir este tipo de arquivo.</string>
     <string name="attachment_too_large">O Arquivo é muito grande. Adicione um arquivo com menos de 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-pt-rPT/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-pt-rPT/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Tirar fotografia</string>
-    <string name="add_from_gallery">Adicionar a partir da galeria</string>
+    <string name="choose_from_gallery">Adicionar a partir da galeria</string>
     <string name="rename">Mudar o nome</string>
     <string name="delete">Eliminar</string>
     <string name="rename_attachment">Mudar o nome do anexo</string>
     <string name="name">Nome</string>
-    <string name="add_file">Adicionar a partir dos ficheiros</string>
+    <string name="choose_from_files">Adicionar a partir dos ficheiros</string>
     <string name="attachment_error">Erro ao adicionar anexo</string>
     <string name="no_app_found">Não foi encontrada nenhuma aplicação para abrir este tipo de ficheiro.</string>
     <string name="attachment_too_large">O ficheiro é demasiado grande. Adicione um ficheiro com menos de 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-ro/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ro/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Realizare fotografie</string>
-    <string name="add_from_gallery">Adăugați din galerie</string>
+    <string name="choose_from_gallery">Adăugați din galerie</string>
     <string name="rename">Redenumire</string>
     <string name="delete">Ștergere</string>
     <string name="rename_attachment">Redenumire atașament</string>
     <string name="name">Nume</string>
-    <string name="add_file">Adăugați din fișiere</string>
+    <string name="choose_from_files">Adăugați din fișiere</string>
     <string name="attachment_error">Eroare la adăugarea fișierului atașat</string>
     <string name="no_app_found">Nu s-a găsit nicio aplicație pentru a deschide acest tip de fișier.</string>
     <string name="attachment_too_large">Fișierul este prea mare. Adăugați un fișier de mai puțin de 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-ru/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-ru/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Сделать фотографию</string>
-    <string name="add_from_gallery">Добавить из галереи</string>
+    <string name="choose_from_gallery">Добавить из галереи</string>
     <string name="rename">Переименовать</string>
     <string name="delete">Удалить</string>
     <string name="rename_attachment">Переименовать вложение</string>
     <string name="name">Имя</string>
-    <string name="add_file">Добавить из файлов</string>
+    <string name="choose_from_files">Добавить из файлов</string>
     <string name="attachment_error">Ошибка добавления вложения</string>
     <string name="no_app_found">Не найдено приложение для открытия этого типа файлов.</string>
     <string name="attachment_too_large">Этот файл слишком большой. Добавьте файл размером меньше 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-sk/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-sk/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">Popoludní</string>
 
     <string name="take_photo">Odfotiť</string>
-    <string name="add_from_gallery">Pridať z Galérie</string>
+    <string name="choose_from_gallery">Pridať z Galérie</string>
     <string name="rename">Premenovať</string>
     <string name="delete">Zmazať</string>
     <string name="rename_attachment">Premenovať prílohu</string>
     <string name="name">Názov</string>
-    <string name="add_file">Pridať zo súborov</string>
+    <string name="choose_from_files">Pridať zo súborov</string>
     <string name="attachment_error">Chyba pri pridávaní prílohy</string>
     <string name="no_app_found">Na otvorenie tohto typu súboru nie je k dispozícii žiadna aplikácia.</string>
     <string name="attachment_too_large">Súbor je príliš veľký. Pridajte súbor menší ako 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-sl/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-sl/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">popoldne</string>
 
     <string name="take_photo">Fotografirajte</string>
-    <string name="add_from_gallery">Dodaj iz galerije</string>
+    <string name="choose_from_gallery">Dodaj iz galerije</string>
     <string name="rename">Preimenuj</string>
     <string name="delete">Izbriši</string>
     <string name="rename_attachment">Preimenuj prilogo</string>
     <string name="name">Ime</string>
-    <string name="add_file">Dodaj iz datotek</string>
+    <string name="choose_from_files">Dodaj iz datotek</string>
     <string name="attachment_error">Napaka pri dodajanju priloge</string>
     <string name="no_app_found">Ni najdene aplikacije za odpiranje te vrste datoteke.</string>
     <string name="attachment_too_large">Datoteka je prevelika. Dodajte datoteko manjšo od 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-sr/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-sr/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">Popodne</string>
 
     <string name="take_photo">Fotografišite</string>
-    <string name="add_from_gallery">Dodaj iz galerije</string>
+    <string name="choose_from_gallery">Dodaj iz galerije</string>
     <string name="rename">Preimenuj</string>
     <string name="delete">Izbriši</string>
     <string name="rename_attachment">Preimenuj prilog</string>
     <string name="name">Naziv</string>
-    <string name="add_file">Dodaj iz datoteka</string>
+    <string name="choose_from_files">Dodaj iz datoteka</string>
     <string name="attachment_error">Greška prilikom dodavanja priloga</string>
     <string name="no_app_found">Nije pronađena nijedna aplikacija za otvaranje ove vrste datoteke.</string>
     <string name="attachment_too_large">Datoteka je prevelika. Dodajte datoteku koja je manja od 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-sv/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-sv/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Ta ett foto</string>
-    <string name="add_from_gallery">Lägg till från galleriet</string>
+    <string name="choose_from_gallery">Lägg till från galleriet</string>
     <string name="rename">Byt namn</string>
     <string name="delete">Ta bort</string>
     <string name="rename_attachment">Byt namn på bilaga</string>
     <string name="name">Namn</string>
-    <string name="add_file">Lägg till från filer</string>
+    <string name="choose_from_files">Lägg till från filer</string>
     <string name="attachment_error">Det uppstod ett fel när bilagan skulle läggas till</string>
     <string name="no_app_found">Ingen applikation hittades som kan öppna den här filtypen.</string>
     <string name="attachment_too_large">Filen är för stor. Lägg till en fil som är mindre än 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-th/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-th/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">ถ่ายภาพ</string>
-    <string name="add_from_gallery">เพิ่มจากแกลเลอรี</string>
+    <string name="choose_from_gallery">เพิ่มจากแกลเลอรี</string>
     <string name="rename">เปลี่ยนชื่อ</string>
     <string name="delete">ลบ</string>
     <string name="rename_attachment">เปลี่ยนชื่อไฟล์แนบ</string>
     <string name="name">ชื่อ</string>
-    <string name="add_file">เพิ่มจากไฟล์</string>
+    <string name="choose_from_files">เพิ่มจากไฟล์</string>
     <string name="attachment_error">ข้อผิดพลาดในการเพิ่มไฟล์แนบ</string>
     <string name="no_app_found">ไม่พบแอปพลิเคชันที่จะใช้เปิดไฟล์ประเภทนี้</string>
     <string name="attachment_too_large">ไฟล์ใหญ่เกินไป โปรดเพิ่มไฟล์ที่มีขนาดไม่เกิน 50 MB</string>

--- a/toolkit/featureforms/src/main/res/values-tr/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-tr/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Fotoğraf Çek</string>
-    <string name="add_from_gallery">Galeriden Ekle</string>
+    <string name="choose_from_gallery">Galeriden Ekle</string>
     <string name="rename">Yeniden Adlandır</string>
     <string name="delete">Sil</string>
     <string name="rename_attachment">Eki Yeniden Adlandır</string>
     <string name="name">Adı</string>
-    <string name="add_file">Dosyalardan Ekle</string>
+    <string name="choose_from_files">Dosyalardan Ekle</string>
     <string name="attachment_error">Ek Ekleme Hatası</string>
     <string name="no_app_found">Bu dosya türünü açmak için herhangi bir uygulama bulunamadı.</string>
     <string name="attachment_too_large">Dosya fazla büyük. Lütfen 50 MB\'den küçük bir dosya ekleyin.</string>

--- a/toolkit/featureforms/src/main/res/values-uk/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-uk/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Зробити фото</string>
-    <string name="add_from_gallery">Додати з галереї</string>
+    <string name="choose_from_gallery">Додати з галереї</string>
     <string name="rename">Змінити назву</string>
     <string name="delete">Видалити</string>
     <string name="rename_attachment">Перейменувати прикріплення</string>
     <string name="name">Назва</string>
-    <string name="add_file">Додати з файлів</string>
+    <string name="choose_from_files">Додати з файлів</string>
     <string name="attachment_error">Помилка при додаванні прикріплення</string>
     <string name="no_app_found">Не знайдено додатку, щоб відкрити файл цього типу.</string>
     <string name="attachment_too_large">Занадто великий розмір файлу. Додайте файл розміром до 50 МБ.</string>

--- a/toolkit/featureforms/src/main/res/values-vi/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-vi/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">CH</string>
 
     <string name="take_photo">Chụp Ảnh</string>
-    <string name="add_from_gallery">Thêm Từ Thư viện</string>
+    <string name="choose_from_gallery">Thêm Từ Thư viện</string>
     <string name="rename">Đổi tên</string>
     <string name="delete">Xóa</string>
     <string name="rename_attachment">Đổi tên Tệp đính kèm</string>
     <string name="name">Tên</string>
-    <string name="add_file">Thêm Từ Tệp</string>
+    <string name="choose_from_files">Thêm Từ Tệp</string>
     <string name="attachment_error">Lỗi khi Thêm Tệp đính kèm</string>
     <string name="no_app_found">Không tìm thấy ứng dụng để mở loại tệp này.</string>
     <string name="attachment_too_large">Tệp quá lớn. Vui lòng thêm tệp dưới 50 MB.</string>

--- a/toolkit/featureforms/src/main/res/values-zh-rHK/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-zh-rHK/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">下午</string>
 
     <string name="take_photo">拍照</string>
-    <string name="add_from_gallery">從圖庫新增</string>
+    <string name="choose_from_gallery">從圖庫新增</string>
     <string name="rename">重新命名</string>
     <string name="delete">刪除</string>
     <string name="rename_attachment">重新命名附件</string>
     <string name="name">名稱</string>
-    <string name="add_file">從檔案新增</string>
+    <string name="choose_from_files">從檔案新增</string>
     <string name="attachment_error">新增附件時出錯</string>
     <string name="no_app_found">找不到開啟此檔案類型的應用程式。</string>
     <string name="attachment_too_large">檔案太大。 請新增小於 50 MB 的檔案。</string>

--- a/toolkit/featureforms/src/main/res/values-zh-rTW/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-zh-rTW/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">下午</string>
 
     <string name="take_photo">拍照</string>
-    <string name="add_from_gallery">從圖庫新增</string>
+    <string name="choose_from_gallery">從圖庫新增</string>
     <string name="rename">重新命名</string>
     <string name="delete">刪除</string>
     <string name="rename_attachment">重新命名附件</string>
     <string name="name">名稱</string>
-    <string name="add_file">從檔案新增</string>
+    <string name="choose_from_files">從檔案新增</string>
     <string name="attachment_error">新增附件時出錯</string>
     <string name="no_app_found">找不到開啟此檔案類型的應用程式。</string>
     <string name="attachment_too_large">檔案太大。 請新增小於 50 MB 的檔案。</string>

--- a/toolkit/featureforms/src/main/res/values-zh/strings.xml
+++ b/toolkit/featureforms/src/main/res/values-zh/strings.xml
@@ -91,12 +91,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">拍照</string>
-    <string name="add_from_gallery">从图库添加</string>
+    <string name="choose_from_gallery">从图库添加</string>
     <string name="rename">重命名</string>
     <string name="delete">删除</string>
     <string name="rename_attachment">重命名附件</string>
     <string name="name">名称</string>
-    <string name="add_file">从文件添加</string>
+    <string name="choose_from_files">从文件添加</string>
     <string name="attachment_error">添加附件时出错</string>
     <string name="no_app_found">未找到可以打开此文件类型的应用程序。</string>
     <string name="attachment_too_large">文件过大。 请添加小于 50 MB 的文件。</string>

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -185,6 +185,7 @@
     <string name="media_too_long">This media is too long. Maximum allowed duration is %1$d seconds.</string>
     <string name="this_file_is_too_large">This file is too large. Maximum allowed size is %1$d MB.</string>
     <string name="attachment_with_name">Attachment: %1$s</string>
+    <string name="add_attachment">Add Attachment</string>
     <plurals name="min_attachments_required">
         <item quantity="zero">At least %1$d attachments are required</item>
         <item quantity="one">At least %1$d attachment is required</item>

--- a/toolkit/featureforms/src/main/res/values/strings.xml
+++ b/toolkit/featureforms/src/main/res/values/strings.xml
@@ -94,12 +94,12 @@
     <string name="ff_time_picker_pm">PM</string>
 
     <string name="take_photo">Take Photo</string>
-    <string name="add_from_gallery">Choose From Gallery</string>
+    <string name="choose_from_gallery">Choose From Gallery</string>
     <string name="rename">Rename</string>
     <string name="delete">Delete</string>
     <string name="rename_attachment">Rename Attachment</string>
     <string name="name">Name</string>
-    <string name="add_file">Choose From Files</string>
+    <string name="choose_from_files">Choose From Files</string>
     <string name="attachment_error">Error Adding Attachment</string>
     <string name="no_app_found">No application found to open this file type.</string>
     <string name="attachment_too_large">The File is too large. Please add a file less than 50 MB.</string>
@@ -180,13 +180,14 @@
     <string name="filters_not_applied">Filters have not been applied</string>
     <string name="discard_changes_confirmation">Are you sure you want to discard the changes?</string>
     <string name="record_audio">Record Audio</string>
-    <string name="record_video">Record Video</string>
+    <string name="take_video">Take Video</string>
     <string name="max_attachments_limit_reached">The maximum number of attachments allowed is %1$d</string>
     <string name="media_too_long">This media is too long. Maximum allowed duration is %1$d seconds.</string>
     <string name="this_file_is_too_large">This file is too large. Maximum allowed size is %1$d MB.</string>
+    <string name="attachment_with_name">Attachment: %1$s</string>
     <plurals name="min_attachments_required">
         <item quantity="zero">At least %1$d attachments are required</item>
-        <item quantity="one">At least %1$d attachment is required></item>
+        <item quantity="one">At least %1$d attachment is required</item>
         <item quantity="two">At least %1$d attachments are required</item>
         <item quantity="few">At least %1$d attachments are required</item>
         <item quantity="many">At least %1$d attachments are required</item>


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/1781](https://devtopia.esri.com/runtime/apollo/issues/1781)

<!-- link to design, if applicable -->

### Description:

This PR adds the toolkit tests for the recently introduced enhancements to the `AttachmentsFormElement`. The common toolkit test design is given [here](https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/FormsTestDesign.md#attachments-form-element).

### Summary of changes:

- Added toolkit tests 14.1, 14.2, 14.3, 14.4 and 14.5 from the common test design.
- Updated semantic tags and content descriptions.
- Removed "Record Audio" from the list of options displayed, since this feature isn't yet available in the toolkit.
- Updated strings accordingly. 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1300/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  