### PR TITLE
`FeatureForm`: Update the usage of `addAttachment` methods.

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentFileOperationTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentFileOperationTests.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms
+
+import android.net.Uri
+import androidx.test.platform.app.InstrumentationRegistry
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.cacheFile
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.deleteIfExists
+import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.io.File
+import com.google.common.truth.Truth.assertThat
+
+/**
+ * Test class for various file operations and their internal utilities related to attachments in the
+ * Feature Forms toolkit.
+ *
+ * @since 300.1.0
+ */
+class AttachmentFileOperationTests {
+
+    /**
+     * The context of the application under test.
+     */
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    /**
+     * Given a source file with content,
+     * When the file is cached using the [cacheFile] extension function,
+     * Then the cached file is created successfully and has the expected properties and content.
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun testCachedFileCreation() = runTest {
+        val source = AttachmentsFileProvider.createTempFileWithUri(
+            prefix = "source",
+            suffix = ".txt",
+            context = context
+        )
+        source.file.writeText("Attachment content")
+
+        var cachedFile : File? = null
+        try {
+            cachedFile = context.cacheFile(
+                uri = source.uri,
+                extension = "txt"
+            ).getOrThrow()
+            assertThat(cachedFile.exists()).isTrue()
+            assertThat(cachedFile.readText()).isEqualTo("Attachment content")
+            assertThat(source.file.absolutePath).isNotEqualTo(cachedFile.absolutePath)
+            assertThat(cachedFile.name).endsWith(".txt")
+        } finally {
+            // Clean up the temporary files
+            source.file.deleteIfExists()
+            cachedFile?.deleteIfExists()
+        }
+
+        assertThat(source.file.exists()).isFalse()
+        assertThat(cachedFile.exists()).isFalse()
+    }
+
+    /**
+     * Given a non-existing source,
+     * When the [cacheFile] extension function is called with the non-existing source,
+     * Then the function returns a failure result and leaves no temp files.
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun testCachedFileCreationWithNonExistingSource() = runTest {
+        // Track the files in the cache directory before the operation
+        val filesBefore = context.cacheDir
+            .listFiles()
+            .orEmpty()
+            .map(File::getAbsolutePath)
+            .toSet()
+        val invalidUri = Uri.parse(
+            "content://${context.packageName}.invalid/missing.txt"
+        )
+        val result = context.cacheFile(
+            uri = invalidUri,
+            extension = "txt"
+        )
+        // Track the files in the cache directory after the operation
+        val filesAfter = context.cacheDir
+            .listFiles()
+            .orEmpty()
+            .map(File::getAbsolutePath)
+            .toSet()
+        assertThat(result.isFailure).isTrue()
+        // No new files should be created
+        assertThat(filesAfter).isEqualTo(filesBefore)
+    }
+}

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
@@ -44,7 +44,16 @@ import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.rule.IntentsRule
 import androidx.test.platform.app.InstrumentationRegistry
+import com.arcgismaps.exceptions.FeatureFormValidationException
 import com.arcgismaps.mapping.featureforms.AttachmentsFormElement
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentElementState
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentSizeLimitExceededException
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentSource
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.EmptyAttachmentException
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.addAttachmentFromFile
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.addAttachmentFromUri
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.deleteIfExists
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.maxAttachmentUploadSize
 import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
@@ -53,6 +62,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.io.File
 import java.io.FileWriter
+import java.io.RandomAccessFile
 
 /**
  * Test class for the authored AttachmentsFormElement in the FeatureForm.
@@ -666,6 +676,151 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
     }
 
     /**
+     * Given valid and invalid captured files
+     * When they are added as attachments
+     * Then each temporary file is deleted after the attempt
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun testCapturedFileIsDeleted() = runTest {
+        val featureFormState = FeatureFormState(
+            featureForm = featureForm,
+            coroutineScope = scope
+        )
+        val attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "General - All Inputs"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        val elementState =
+            featureFormState.getActiveFormStateData().stateCollection[attachmentsFormElement!!] as? AttachmentElementState
+        assertThat(elementState).isNotNull()
+
+        // Create a temporary file to simulate a captured image
+        val validFile = File.createTempFile(
+            "source",
+            ".txt",
+            context.cacheDir
+        )
+        validFile.writeText("Attachment content")
+
+        try {
+            // Add the valid file and assert it was a success
+            val result = elementState!!.addAttachmentFromFile(
+                file = validFile,
+                source = AttachmentSource.Camera
+            )
+            assertThat(result.isSuccess).isTrue()
+            // Assert that the temporary file was deleted after the attempt
+            assertThat(validFile.exists()).isFalse()
+        } finally {
+            // Test fallback cleanup
+            validFile.deleteIfExists()
+        }
+
+        // Create empty file to simulate a captured image that will fail validation
+        val invalidFile = File.createTempFile(
+            "invalid_source",
+            ".txt",
+            context.cacheDir
+        )
+        try {
+            // Add the invalid file and assert it was a failure
+            val result = elementState.addAttachmentFromFile(
+                file = invalidFile,
+                source = AttachmentSource.Camera
+            )
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isInstanceOf(
+                EmptyAttachmentException::class.java
+            )
+            // Assert that the temporary file was deleted after the attempt
+            assertThat(invalidFile.exists()).isFalse()
+        } finally {
+            // Test fallback cleanup
+            invalidFile.deleteIfExists()
+        }
+
+        // Create a temporary file to simulate a captured image that exceeds the maximum attachment
+        // upload size
+        val overSizedFile = File.createTempFile(
+            "oversized_source",
+            ".txt",
+            context.cacheDir
+        )
+        try {
+            // Set the file length to exceed the maximum attachment upload size
+            RandomAccessFile(overSizedFile, "rw").use {
+                // Set the file length to exceed the maximum attachment upload size
+                it.setLength(maxAttachmentUploadSize + 1L)
+            }
+            // Add the oversized file and assert it was a failure due to exceeding the size limit
+            val result = elementState.addAttachmentFromFile(
+                file = overSizedFile,
+                source = AttachmentSource.Camera
+            )
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isInstanceOf(
+                AttachmentSizeLimitExceededException::class.java
+            )
+            // Assert that the temporary file was deleted after the attempt
+            assertThat(overSizedFile.exists()).isFalse()
+        } finally {
+            // Test fallback cleanup
+            overSizedFile.deleteIfExists()
+        }
+    }
+
+    /**
+     * Given a URI for an unsupported attachment type
+     * When it is added to an attachments element
+     * Then the validation failure is propagated
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun testAddAttachmentFromUriPropagatesFailures() = runTest {
+        val featureFormState = FeatureFormState(
+            featureForm = featureForm,
+            coroutineScope = scope
+        )
+        val attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Media - Audio - Any"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        val elementState =
+            featureFormState.getActiveFormStateData().stateCollection[attachmentsFormElement!!] as? AttachmentElementState
+        assertThat(elementState).isNotNull()
+
+        // Create a temporary file to simulate a selected document
+        val source = AttachmentsFileProvider.createTempFileWithUri(
+            prefix = "source",
+            suffix = ".txt",
+            context = context
+        )
+        source.file.writeText("Attachment content")
+
+        try {
+            val result = elementState!!.addAttachmentFromUri(
+                uri = source.uri,
+                context = context
+            )
+            // Since the file is not a valid attachment type for the "Media - Audio - Any" input,
+            // it should fail
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isInstanceOf(
+                FeatureFormValidationException.IncorrectAttachmentTypeException::class.java
+            )
+        } finally {
+            // Clean up the temporary file
+            source.file.deleteIfExists()
+        }
+        assertThat(source.file.exists()).isFalse()
+    }
+
+    /**
      * Mocks the result of a file picker intent to simulate selecting a file from the device's
      * storage. This method supports mocking files with the following content types: "image/png" and
      * "text/plain". If an unsupported content type is provided, an [UnsupportedOperationException]
@@ -683,7 +838,7 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
         contentType: String
     ) {
         val file = File(
-            // parent nested dir must match the path in the file provider xml
+            // parent nested dir must match the path in the file provider XML
             File(context.cacheDir, "feature_forms_attachments"),
             // the test file
             fileName //"test_document.txt"

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AddAttachment.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -57,15 +58,18 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.core.net.toUri
 import com.arcgismaps.mapping.featureforms.AttachmentInputMethod
-import com.arcgismaps.toolkit.featureforms.R
-import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
-import com.arcgismaps.toolkit.featureforms.internal.utils.DialogType
-import com.arcgismaps.toolkit.featureforms.internal.utils.LocalDialogRequester
 import com.arcgismaps.mapping.featureforms.AttachmentsFormInput
 import com.arcgismaps.mapping.featureforms.AudioFormInput
 import com.arcgismaps.mapping.featureforms.DocumentFormInput
 import com.arcgismaps.mapping.featureforms.ImageFormInput
 import com.arcgismaps.mapping.featureforms.VideoFormInput
+import com.arcgismaps.toolkit.featureforms.R
+import com.arcgismaps.toolkit.featureforms.internal.utils.AttachmentsFileProvider
+import com.arcgismaps.toolkit.featureforms.internal.utils.DialogType
+import com.arcgismaps.toolkit.featureforms.internal.utils.FileUriReference
+import com.arcgismaps.toolkit.featureforms.internal.utils.LocalDialogRequester
+import kotlinx.coroutines.launch
+import java.io.File
 import java.time.Instant
 
 /**
@@ -205,7 +209,7 @@ internal fun AddAttachment(
 
 /**
  * Launches the camera to capture an image. When an image is captured, the [onImageCaptured] callback
- * is invoked with the URI of the captured image. In case of a dismissal or if no image is captured,
+ * is invoked with the [File] of the captured image. In case of a dismissal or if no image is captured,
  * the [onDismissRequest] callback is invoked.
  *
  * @param onDismissRequest A request to dismiss the camera picker.
@@ -214,17 +218,15 @@ internal fun AddAttachment(
 @Composable
 internal fun ImageCapture(
     onDismissRequest: () -> Unit,
-    onImageCaptured: (Uri) -> Unit
+    onImageCaptured: (File) -> Unit
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var hasLaunched by rememberSaveable {
         mutableStateOf(false)
     }
-    val capturedImageUri = rememberSaveable(
-        saver = listSaver(
-            save = { listOf(it.toString()) },
-            restore = { it.first().toUri() }
-        )
+    val capturedImageTarget = rememberSaveable(
+        saver = fileUriReferenceSaver
     ) {
         val timeStamp = Instant.now().toEpochMilli()
         AttachmentsFileProvider.createTempFileWithUri("IMAGE_$timeStamp", ".jpg", context)
@@ -233,23 +235,27 @@ internal fun ImageCapture(
         contract = ActivityResultContracts.TakePicture(),
         onResult = { success ->
             if (success) {
-                onImageCaptured(capturedImageUri)
+                onImageCaptured(capturedImageTarget.file)
             } else {
-                onDismissRequest()
+                scope.launch {
+                    // delete the temp file if the capture was not successful
+                    capturedImageTarget.file.deleteIfExists()
+                    onDismissRequest()
+                }
             }
         }
     )
     LaunchedEffect(Unit) {
         if (!hasLaunched) {
             hasLaunched = true
-            cameraLauncher.launch(capturedImageUri)
+            cameraLauncher.launch(capturedImageTarget.uri)
         }
     }
 }
 
 /**
  * Launches the camera to capture a video. When a video is captured, the [onVideoCaptured] callback
- * is invoked with the URI of the captured video.
+ * is invoked with the [File] of the captured video.
  *
  * @param onDismissRequest A request to dismiss the camera picker.
  * @param onVideoCaptured A callback to invoke when a video is captured.
@@ -258,17 +264,15 @@ internal fun ImageCapture(
 internal fun VideoCapture(
     maxDuration: Long?,
     onDismissRequest: () -> Unit,
-    onVideoCaptured: (Uri) -> Unit
+    onVideoCaptured: (File) -> Unit
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var hasLaunched by rememberSaveable {
         mutableStateOf(false)
     }
-    val capturedVideoUri = rememberSaveable(
-        saver = listSaver(
-            save = { listOf(it.toString()) },
-            restore = { it.first().toUri() }
-        )
+    val capturedVideoTarget = rememberSaveable(
+        saver = fileUriReferenceSaver
     ) {
         val timeStamp = Instant.now().toEpochMilli()
         AttachmentsFileProvider.createTempFileWithUri("VIDEO_$timeStamp", ".mp4", context)
@@ -290,16 +294,20 @@ internal fun VideoCapture(
         contract = captureVideoContract,
         onResult = { success ->
             if (success) {
-                onVideoCaptured(capturedVideoUri)
+                onVideoCaptured(capturedVideoTarget.file)
             } else {
-                onDismissRequest()
+                // delete the temp file if the video capture was not successful
+                scope.launch {
+                    capturedVideoTarget.file.deleteIfExists()
+                    onDismissRequest()
+                }
             }
         }
     )
     LaunchedEffect(Unit) {
         if (!hasLaunched) {
             hasLaunched = true
-            cameraLauncher.launch(capturedVideoUri)
+            cameraLauncher.launch(capturedVideoTarget.uri)
         }
     }
 }
@@ -498,6 +506,24 @@ private fun List<VisualMediaType>.toPickerMediaType(): VisualMediaType = when {
     contains(ActivityResultContracts.PickVisualMedia.ImageOnly) && contains(ActivityResultContracts.PickVisualMedia.VideoOnly) -> ActivityResultContracts.PickVisualMedia.ImageAndVideo
     else -> throw IllegalArgumentException("Unsupported combination of media types")
 }
+
+/**
+ * A saver for [FileUriReference] that saves and restores the object.
+ */
+private val fileUriReferenceSaver = listSaver<FileUriReference, String>(
+    save = { reference ->
+        listOf(
+            reference.file.absolutePath,
+            reference.uri.toString()
+        )
+    },
+    restore = { values ->
+        FileUriReference(
+            file = File(values[0]),
+            uri = values[1].toUri()
+        )
+    }
+)
 
 /**
  * Clamps a Long value to the range of Int values.

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentElementState.kt
@@ -55,9 +55,11 @@ import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.base.FormElementState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.ValidationErrorState
 import com.arcgismaps.toolkit.featureforms.internal.components.base.mapValidationErrors
+import com.arcgismaps.toolkit.featureforms.internal.utils.runCatchingCancellable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -65,7 +67,9 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.FileNotFoundException
 import java.util.Objects
+import java.util.UUID
 
 /**
  * The maximum attachment size in bytes that can be added.
@@ -243,17 +247,30 @@ internal class AttachmentElementState(
     }
 
     /**
-     * Adds an attachment with the given [name], [contentType], and [filePath].
+     * Adds an attachment with the given [name], [contentType], and [filePath]. If the [source] is
+     * [AttachmentSource.FileSystem], the attachment will be added with the given [name]. If the
+     * [source] is [AttachmentSource.Camera], the attachment is added with the API generated name.
+     *
+     * @param name The name of the attachment.
+     * @param contentType The content type of the attachment.
+     * @param filePath The file path of the attachment.
+     * @param source The source of the attachment.
      */
-    suspend fun addAttachment(name: String, contentType: String, filePath: String): Result<Unit> {
-        return if (useOriginalFilename) {
-            formElement.addAttachment(
-                name,
-                contentType,
-                filePath
+    suspend fun addAttachment(
+        name: String,
+        contentType: String,
+        filePath: String,
+        source: AttachmentSource
+    ): Result<Unit> {
+        return when (source) {
+            // If the attachment is from the camera, use the API generated name.
+            AttachmentSource.Camera -> formElement.addAttachment(
+                contentType = contentType,
+                filePath = filePath
             )
-        } else {
-            formElement.addAttachment(
+            // If the attachment is from the file system, use the provided name.
+            AttachmentSource.FileSystem -> formElement.addAttachment(
+                name = name,
                 contentType = contentType,
                 filePath = filePath
             )
@@ -530,102 +547,124 @@ internal fun FormAttachmentType.getIcon(): ImageVector = when (this) {
 }
 
 /**
- * Returns a new attachment name based on the [contentType] and [extension].
+ * Returns a random temporary attachment name.
  *
- * @param contentType The content type of the attachment.
  * @param extension The file extension of the attachment.
  * @return A new attachment name including the file extension specified by [extension].
  */
-internal fun AttachmentElementState.getNewAttachmentNameForContentType(
-    contentType: String,
+internal fun generateTemporaryAttachmentName(
     extension: String
-): String {
-    // use the content type prefix to generate a new attachment name
-    val prefix = contentType.split("/").firstOrNull()?.replaceFirstChar(Char::titlecase)
-        ?: "Attachment"
-    var count = attachments.count { entry ->
-        // count the number of attachments with the same content type
-        entry.contentType == contentType
-    } + 1
-    // create a set of attachment names to check for duplicates
-    val names = attachments.mapTo(hashSetOf()) { it.name }
-    while (names.contains("${prefix}$count.$extension")) {
-        count++
+): String = "Attachment-${UUID.randomUUID()}.$extension"
+
+/**
+ * Adds an attachment to the [AttachmentElementState] from the specified [File]. The file will be
+ * deleted after the attempt to add the attachment. Hence, ensure the file is not needed or is a
+ * temporary file before calling this method.
+ *
+ * @param file The file to add as an attachment.
+ * @param source The source of the attachment.
+ * @return A [Result] indicating success or failure.
+ */
+internal suspend fun AttachmentElementState.addAttachmentFromFile(
+    file: File,
+    source: AttachmentSource
+): Result<Unit> = withContext(Dispatchers.IO) {
+    try {
+        if (file.exists().not()) {
+            return@withContext Result.failure(
+                FileNotFoundException("File not found: ${file.absolutePath}")
+            )
+        }
+        // get the name and content type of the file
+        val name = file.name
+        val contentType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
+            file.extension.lowercase()
+        ) ?: "application/octet-stream"
+        // validate the file size before adding the attachment
+        return@withContext when {
+            file.length() == 0L -> Result.failure(EmptyAttachmentException())
+            file.length() > maxAttachmentUploadSize -> Result.failure(
+                AttachmentSizeLimitExceededException(maxAttachmentUploadSize)
+            )
+
+            else -> addAttachment(name, contentType, file.absolutePath, source)
+        }
+    } finally {
+        file.deleteIfExists()
     }
-    return "${prefix}$count.$extension"
 }
 
 /**
- * Adds an attachment to the [AttachmentElementState] from the specified [uri].
+ * Adds an attachment to the [AttachmentElementState] from the specified [uri]. The source of the
+ * provided [uri] must always be [AttachmentSource.FileSystem]. This is typically used when the
+ * uri is obtained from external or scoped storage sources.
  *
  * @param uri The uri of the attachment.
  * @param context The context.
- * @param useDefaultName Whether to use the default name from the uri. If false, a new name will be generated
- * based on the content type of the attachment.
+ * @return A [Result] indicating success or failure.
  */
 internal suspend fun AttachmentElementState.addAttachmentFromUri(
     uri: Uri,
-    context: Context,
-    useDefaultName: Boolean
-): Result<Unit> = withContext(Dispatchers.IO) {
-    // get the content type of the uri
-    val contentType = context.contentResolver.getType(uri) ?: run {
-        return@withContext Result.failure(Exception(context.getString(R.string.attachment_error)))
-    }
-    // get the file extension from the content type
-    val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(contentType) ?: run {
-        return@withContext Result.failure(Exception(context.getString(R.string.attachment_error)))
-    }
-    // generate a name for the attachment
-    var name = getNewAttachmentNameForContentType(contentType, extension)
-    // size of the attachment
-    var size = 0L
-    // get the name and size of the attachment
-    context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-        cursor.moveToFirst()
-        val nameIndex =
-            cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-        val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
-        // use the default file name from the uri if available
-        if (useDefaultName) {
-            cursor.getStringOrNull(nameIndex)?.let {
-                name = it
+    context: Context
+): Result<Unit> = runCatchingCancellable {
+    withContext(Dispatchers.IO) {
+        // get the content type of the uri
+        val contentType = context.contentResolver.getType(uri)
+            ?: "application/octet-stream"
+
+        // get the file extension from the content type
+        val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(contentType)
+            ?: throw Exception(context.getString(R.string.attachment_error))
+
+        // generate an initial name for the attachment
+        var name = generateTemporaryAttachmentName(extension)
+        // size of the attachment
+        var size = 0L
+        // get the name and size of the attachment
+        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+                // use the default file name from the uri if available
+                cursor.getStringOrNull(nameIndex)?.let {
+                    name = it
+                }
+                // update the size
+                cursor.getLongOrNull(sizeIndex)?.let {
+                    size = it
+                }
             }
         }
-        // update the size
-        cursor.getLongOrNull(sizeIndex)?.let {
-            size = it
-        }
-    }
 
-    // Add the attachment if it passes all the checks
-    return@withContext when {
-        size == 0L -> Result.failure(EmptyAttachmentException())
-        size > maxAttachmentUploadSize -> Result.failure(
-            exception = AttachmentSizeLimitExceededException(maxAttachmentUploadSize)
-        )
-
-        else -> {
-            // Cache the file from the URI and get the cached file reference. This is required to get a file
-            // path that can be accessed by the toolkit/app.
-            context.cacheFile(uri, name).fold(
-                onSuccess = { cachedFile ->
-                    addAttachment(name, contentType, cachedFile.absolutePath).also {
-                        // delete the cached file after attempting to add the attachment since it's
-                        // no longer needed
-                        try {
-                            cachedFile.delete()
-                        } catch (ex: Exception) {
-                            Log.w(
-                                "FeatureFormToolkit",
-                                "Unable to clear cached attachment data",
-                                ex
-                            )
-                        }
-                    }
-                },
-                onFailure = { ex -> Result.failure(ex) }
+        // Add the attachment if it passes all the checks
+        return@withContext when {
+            size == 0L -> throw EmptyAttachmentException()
+            size > maxAttachmentUploadSize -> throw AttachmentSizeLimitExceededException(
+                maxAttachmentUploadSize
             )
+
+            else -> {
+                // Cache the file from the URI and get the cached file reference. This is required to get a file
+                // path that can be accessed by the toolkit/app.
+                context.cacheFile(uri, extension).fold(
+                    onSuccess = { cachedFile ->
+                        try {
+                            // Note here the name is from the original uri.
+                            addAttachment(
+                                name = name,
+                                contentType = contentType,
+                                filePath = cachedFile.absolutePath,
+                                source = AttachmentSource.FileSystem
+                            ).getOrThrow()
+                        } finally {
+                            // delete the cached file after attempting to add the attachment since it's
+                            // no longer needed
+                            cachedFile.deleteIfExists()
+                        }
+                    },
+                    onFailure = { ex -> throw ex }
+                )
+            }
         }
     }
 }
@@ -633,30 +672,58 @@ internal suspend fun AttachmentElementState.addAttachmentFromUri(
 
 /**
  * Copies the content from the specified [uri] to a file in the cache directory given by
- * [Context.getCacheDir].
+ * [Context.getCacheDir]. A unique file name is generated for the cached file to avoid conflicts
+ * with other files in the directory.
  *
  * @param uri The uri of the file to copy.
- * @param fileName The name of the file to create in the cache directory.
  * @return The file in the cache directory that contains the copied content.
  */
 internal suspend fun Context.cacheFile(
     uri: Uri,
-    fileName: String
-): Result<File> = runCatching {
-    withContext(Dispatchers.IO) {
-        val outFile = cacheDir.resolve(fileName)
-        // Delete the file if it already exists
-        if (outFile.exists()) {
-            outFile.delete()
-        }
-        // Copy the content from the uri to a file in the cache directory that the toolkit/app
-        // controls, so that it can be accessed.
-        contentResolver.openInputStream(uri)?.use { inputStream ->
-            outFile.outputStream().use { outputStream ->
-                inputStream.copyTo(outputStream)
+    extension: String
+): Result<File> = runCatchingCancellable {
+    require(extension.isNotEmpty()) { "File extension cannot be empty" }
+    val fileName = generateTemporaryAttachmentName(extension)
+    val outFile = cacheDir.resolve(fileName)
+    return@runCatchingCancellable try {
+        withContext(Dispatchers.IO) {
+            // Copy the content from the uri to a file in the cache directory that the toolkit/app
+            // controls, so that it can be accessed.
+            val inputStream = contentResolver.openInputStream(uri)
+                ?: throw Exception("Unable to open input stream for URI: $uri")
+            inputStream.use { inputStream ->
+                outFile.outputStream().use { outputStream ->
+                    inputStream.copyTo(outputStream)
+                }
             }
+            outFile
         }
-        return@withContext outFile
+    } catch (ex: Exception) {
+        // If an exception occurs during the copy process, delete the output file if it was created
+        outFile.deleteIfExists()
+        throw ex
+    }
+}
+
+/**
+ * Deletes the file if it exists. If the file cannot be deleted, a warning is logged. This function
+ * is executed in a non-cancellable context to ensure that the file deletion is attempted even if the
+ * calling coroutine is canceled.
+ */
+internal suspend fun File.deleteIfExists() = withContext(NonCancellable + Dispatchers.IO) {
+    try {
+        if (exists() && delete().not()) {
+            Log.w(
+                "FeatureFormToolkit",
+                "Unable to delete temporary file: $absolutePath"
+            )
+        }
+    } catch (ex: Exception) {
+        Log.w(
+            "FeatureFormToolkit",
+            "Exception occurred while trying to delete temporary file: $absolutePath",
+            ex
+        )
     }
 }
 
@@ -673,3 +740,11 @@ internal class AttachmentSizeLimitExceededException(val limit: Long) : Exception
  * Exception indicating that the attachment size is 0.
  */
 internal class EmptyAttachmentException : Exception("Attachment size is 0")
+
+/**
+ * Enum representing the source of an attachment.
+ */
+internal enum class AttachmentSource {
+    Camera,
+    FileSystem
+}

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/AttachmentsFileProvider.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/AttachmentsFileProvider.kt
@@ -28,20 +28,33 @@ internal class AttachmentsFileProvider :
 
         private const val AUTHORITY_BASE = "com.arcgismaps.toolkit.featureforms.attachmentsfileprovider"
 
-        fun createTempFileWithUri(prefix: String, suffix: String, context: Context): Uri {
+        /**
+         * Creates a temporary file with the specified prefix and suffix in the cache directory of
+         * the app. The responsibility of deleting the file is on the caller.
+         *
+         * @param prefix The prefix string to be used in generating the file's name
+         * @param suffix The suffix string to be used in generating the file's name
+         * @param context The context of the application
+         * @return A [FileUriReference] containing the created file and its corresponding URI
+         */
+        fun createTempFileWithUri(prefix: String, suffix: String, context: Context): FileUriReference {
             // authority is unique, which uses the package name + base authority name
             // to avoid conflicts with other apps using the same library
             val authority = "${context.packageName}.$AUTHORITY_BASE"
             val directory = File(context.cacheDir.absolutePath)
             directory.mkdirs()
             val file =  File.createTempFile(prefix, suffix, directory)
-            // delete the temp file when no process is using it
-            file.deleteOnExit()
-            return getUriForFile(
-                context,
-                authority,
-                file,
-            )
+            return try {
+                val uri = getUriForFile(
+                    context,
+                    authority,
+                    file,
+                )
+                FileUriReference(file, uri)
+            } catch (ex: Exception) {
+                file.delete()
+                throw ex
+            }
         }
 
         fun getUriForFile(file: File, context: Context): Uri {
@@ -52,3 +65,14 @@ internal class AttachmentsFileProvider :
         }
     }
 }
+
+/**
+ * A data class that holds a reference to a file and its corresponding URI.
+ *
+ * @property file The file reference.
+ * @property uri The URI reference for the file.
+ */
+internal data class FileUriReference(
+    val file: File,
+    val uri: Uri,
+)

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Dialog.kt
@@ -52,12 +52,14 @@ import com.arcgismaps.mapping.featureforms.VideoFormInput
 import com.arcgismaps.toolkit.featureforms.R
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentElementState
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentErrorDialog
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.AttachmentSource
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.DeleteAttachmentDialog
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.FilePicker
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.GalleryPicker
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.ImageCapture
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.RenameAttachmentDialog
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.VideoCapture
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.addAttachmentFromFile
 import com.arcgismaps.toolkit.featureforms.internal.components.attachment.addAttachmentFromUri
 import com.arcgismaps.toolkit.featureforms.internal.components.barcode.BarcodeScanner
 import com.arcgismaps.toolkit.featureforms.internal.components.barcode.BarcodeTextFieldState
@@ -288,9 +290,12 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
             }
             ImageCapture(
                 onDismissRequest = dialogRequester::dismissDialog
-            ) { uri ->
+            ) { file ->
                 scope.launch {
-                    state.addAttachmentFromUri(uri, context, false).onFailure {
+                    state.addAttachmentFromFile(
+                        file = file,
+                        source = AttachmentSource.Camera
+                    ).onFailure {
                         errorMessage = it.message ?: attachmentError
                     }
                     dialogRequester.dismissDialog()
@@ -309,9 +314,12 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
             VideoCapture(
                 maxDuration = maxDuration,
                 onDismissRequest = dialogRequester::dismissDialog
-            ) { uri ->
+            ) { file ->
                 scope.launch {
-                    state.addAttachmentFromUri(uri, context, false).onFailure {
+                    state.addAttachmentFromFile(
+                        file = file,
+                        source = AttachmentSource.Camera
+                    ).onFailure {
                         errorMessage = it.message ?: attachmentError
                     }
                     dialogRequester.dismissDialog()
@@ -337,7 +345,7 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
                 onDismissRequest = dialogRequester::dismissDialog
             ) { uri ->
                 scope.launch {
-                    state.addAttachmentFromUri(uri, context, false).onFailure {
+                    state.addAttachmentFromUri(uri, context).onFailure {
                         errorMessage = when (it) {
                             is MaxAttachmentDurationConstraintException -> {
                                 resources.getString(
@@ -382,7 +390,7 @@ internal fun FeatureFormDialog(states: FormStateCollection) {
                 onDismissRequest = dialogRequester::dismissDialog
             ) { uri ->
                 scope.launch {
-                    state.addAttachmentFromUri(uri, context, true).onFailure {
+                    state.addAttachmentFromUri(uri, context).onFailure {
                         errorMessage = when (it) {
                             is MaxAttachmentDurationConstraintException -> {
                                 resources.getString(

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Utils.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/utils/Utils.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import com.arcgismaps.data.CodedValue
+import kotlinx.coroutines.CancellationException
 
 /**
  * Changes the visual output of the placeholder and label properties of a TextField. Using this
@@ -92,3 +93,13 @@ internal fun Number?.format(digits: Int = 2): String =
 internal fun List<CodedValue>.toMap(): Map<Any?, String> {
     return associateBy(CodedValue::code, CodedValue::name)
 }
+
+/**
+ * Runs the specified [block] and catches any exceptions, returning a `Result` with the result of
+ * the block or the exception. If the exception is a [CancellationException], the exception will not
+ * be encapsulated in the failure but will be rethrown.
+
+ */
+internal inline fun <V> runCatchingCancellable(block: () -> V): Result<V> =
+    runCatching(block)
+        .onFailure { if (it is CancellationException) throw it }

--- a/toolkit/featureforms/src/test/java/com/arcgismaps/toolkit/featureforms/AttachmentFileUtilityTests.kt
+++ b/toolkit/featureforms/src/test/java/com/arcgismaps/toolkit/featureforms/AttachmentFileUtilityTests.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arcgismaps.toolkit.featureforms
+
+import com.arcgismaps.toolkit.featureforms.internal.components.attachment.deleteIfExists
+import com.arcgismaps.toolkit.featureforms.internal.utils.runCatchingCancellable
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.io.File
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import org.junit.Assert.assertThrows
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Tests for the various utility functions related to attachment files in the Feature Forms toolkit.
+ *
+ * @since 300.1.0
+ */
+class AttachmentFileUtilityTests {
+
+    /**
+     * Given a coroutine that throws a [CancellationException],
+     * When the [runCatchingCancellable] function is invoked,
+     * Then the [CancellationException] should be rethrown and not caught by the function
+     */
+    @Test
+    fun `runCatchingCancellable rethrows cancellation`() {
+        assertThrows(CancellationException::class.java) {
+            runCatchingCancellable<Unit> {
+                throw CancellationException("Cancelled")
+            }
+        }
+    }
+
+    /**
+     * Given an existing temporary file,
+     * When the file is deleted using the [deleteIfExists] extension function,
+     * Then the file should be deleted successfully and no exception should be thrown.
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun `deletes existing file`() = runTest {
+        val file = File.createTempFile("attachment-test", ".tmp")
+        file.deleteIfExists()
+        assertThat(file.exists()).isFalse()
+    }
+
+    /**
+     * Given a non-existing temporary file,
+     * When the [deleteIfExists] extension function is called on it,
+     * Then no exception should be thrown and the function should complete successfully.
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun `does not throw when deleting non-existing file`() = runTest {
+        val file = File.createTempFile("attachment-test", ".tmp")
+        assertThat(file.delete()).isTrue() // Ensure the file is deleted
+        file.deleteIfExists() // Should not throw
+        assertThat(file.exists()).isFalse()
+    }
+
+    /**
+     * Given a coroutine that is performing some operation on a temporary file,
+     * When the coroutine is canceled,
+     * Then the temporary file is deleted during cancellation cleanup.
+     *
+     * @since 300.1.0
+     */
+    @Test
+    fun `deletes file when calling coroutine is cancelled`() = runTest {
+        val file = File.createTempFile("attachment-test", ".tmp")
+        val deferred = CompletableDeferred<Unit>()
+
+        val job = launch {
+            try {
+                deferred.complete(Unit)
+                awaitCancellation()
+            } finally {
+                file.deleteIfExists()
+            }
+        }
+
+        // Wait until the coroutine has started and is awaiting cancellation
+        deferred.await()
+        // Cancel the coroutine
+        job.cancelAndJoin()
+
+        assertThat(job.isCancelled).isTrue()
+        // Check that the file has been deleted
+        assertThat(file.exists()).isFalse()
+    }
+}


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/1810](https://devtopia.esri.com/runtime/apollo/issues/1810)

<!-- link to design, if applicable -->

### Description:

This PR provides a refactor of how attachments are created and added to the element.

### Summary of changes:

- The correct overload of `addAttachment` is called based on if the source of the attachment is a camera/file system.
- Refactored and improved the implementation details of the attachment files are created and added. This refactoring provides a more correct, clean and optimized approach while considering all edge cases.
    - Ensured cached/temp files are deleted appropriately.
    - Adding attachments are now provided by two distinct helper methods. This distinction is an optimization, because previously, a `Uri` was cached to a `File`. This isn't needed if the component is creating the file, like in the case of capturing from a camera.
        - addAttachmentFromFile
        - addAttachmentFromUri. 
- Since this can be a bit hard to test and verify, I've added some automated unit and integration tests that cover a wide range of use-cases for correctness.  

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/job/vtest/job/toolkit/1304/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  