### PR TITLE
drop support for android 9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ ksp = "2.3.7"
 materialIcons = "1.7.7"
 media3Exoplayer = "1.10.0"
 #noinspection UnusedVersionCatalogEntry
-minSdk = "28"
+minSdk = "29"
 mlkitBarcodeScanning = "17.3.0"
 mockingjay = "2.0.1"
 kotlinxCoroutinesTest = "1.10.2"


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #8068

<!-- link to design, if applicable -->

### Description:

bump minSdk to 29 (android 10)

### Summary of changes:

- 

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [ ] link: pending, should be rerun after merged into bigger update of dependencies.
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [ ] Yes
  - [ ] No
  