### PR TITLE
`FeatureForm`: Fix crash while renaming attachment

### DIFF
--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
@@ -943,31 +943,32 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
             // parent nested dir must match the path in the file provider XML
             File(context.cacheDir, "feature_forms_attachments"),
             // the test file
-            fileName //"test_document.txt"
+            fileName
         )
         // Create the mock document file with some content
         file.parentFile?.mkdirs()
         // If the file already exists, we don't need to create it again
-        if (file.exists()) return
-        when (contentType) {
-            "image/png" -> {
-                val bitmap = Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
-                file.outputStream().use { outputStream ->
-                    bitmap.compress(Bitmap.CompressFormat.PNG, 0, outputStream)
+        if (file.exists().not()) {
+            when (contentType) {
+                "image/png" -> {
+                    val bitmap = Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
+                    file.outputStream().use { outputStream ->
+                        bitmap.compress(Bitmap.CompressFormat.PNG, 0, outputStream)
+                    }
+                    bitmap.recycle()
                 }
-                bitmap.recycle()
-            }
 
-            "text/plain" -> {
-                FileWriter(file).use { writer ->
-                    writer.write("Mock file content for testing.")
-                    writer.flush()
+                "text/plain" -> {
+                    FileWriter(file).use { writer ->
+                        writer.write("Mock file content for testing.")
+                        writer.flush()
+                    }
                 }
-            }
 
-            else -> {
-                // If the content type is not supported, throw an exception
-                throw UnsupportedOperationException("Unsupported content type: $contentType")
+                else -> {
+                    // If the content type is not supported, throw an exception
+                    throw UnsupportedOperationException("Unsupported content type: $contentType")
+                }
             }
         }
         // Set up the intent response with the file URI

--- a/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
+++ b/toolkit/featureforms/src/androidTest/java/com/arcgismaps/toolkit/featureforms/AttachmentsFormElementTests.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.isDisplayed
@@ -38,7 +39,9 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.printToLog
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
@@ -818,6 +821,105 @@ class AttachmentsFormElementTests : FeatureFormTestRunner(
             source.file.deleteIfExists()
         }
         assertThat(source.file.exists()).isFalse()
+    }
+
+    /**
+     * Given a `FeatureForm` with an authored `AttachmentsFormElement`
+     * When the `FeatureForm` is displayed
+     * Then the attachments can be renamed successfully
+     *
+     * @since 300.2.0
+     */
+    @Test
+    fun testRenamingAttachments() = runTest {
+        // Create a FeatureFormState and set the compose content
+        val featureFormState = FeatureFormState(
+            featureForm = featureForm,
+            coroutineScope = scope
+        )
+        composeTestRule.setContent {
+            FeatureForm(featureFormState = featureFormState, showFormActions = false)
+        }
+
+        // Find the lazy column node the FeatureForm is displayed in
+        val lazyColumnNode = composeTestRule.onNodeWithContentDescription("lazy column")
+
+        val attachmentsFormElement = featureForm.elements.firstOrNull {
+            it.label == "Any"
+        } as? AttachmentsFormElement
+        assertThat(attachmentsFormElement).isNotNull()
+
+        // Scroll to the attachments form element to ensure it is visible
+        lazyColumnNode.performScrollToNode(hasText(attachmentsFormElement!!.label))
+
+        // Assert that the attachments element is displayed
+        val attachmentsNode = composeTestRule.onNodeWithText(attachmentsFormElement.label)
+        attachmentsNode.assertIsDisplayed()
+
+        // Get the add attachment button and assert that it is displayed
+        val addAttachmentButton = attachmentsNode.onChildWithContentDescription(
+            context.getString(R.string.add_attachment)
+        )
+        addAttachmentButton.assertIsDisplayed()
+        addAttachmentButton.performClick()
+
+        // Add an attachment
+        val menu = composeTestRule.onNode(isPopup())
+        menu.assertIsDisplayed()
+        val chooseFromFiles = menu.onChildWithText(
+            value = context.getString(R.string.choose_from_files),
+            recurse = true
+        ).assertIsDisplayed()
+
+        // Create a temporary file to simulate the selected document
+        mockFilePickerIntentResult(context, "test_document.txt", "text/plain")
+        // Perform the click on the "Choose From Files" option
+        chooseFromFiles.performClick()
+        composeTestRule.waitForIdle()
+        // Assert that the intent was sent and received correctly by the component and the new
+        // attachment is displayed in the attachments list
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            try {
+                // Check for the content description since `displayFileName` is false
+                attachmentsNode.onChildWithContentDescription(
+                    "Attachment: test_document.txt"
+                ).assertExists()
+                true
+            } catch (_: AssertionError) {
+                false
+            }
+        }
+        lazyColumnNode.performScrollToNode(
+            hasContentDescription("Attachment: test_document.txt")
+        ).assertIsDisplayed()
+        composeTestRule.waitForIdle()
+        val attachmentNode = attachmentsNode.onChildWithContentDescription(
+            "Attachment: test_document.txt"
+        )
+        attachmentNode.performTouchInput { longClick() }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(context.getString(R.string.rename)).performClick()
+        composeTestRule.waitForIdle()
+
+        // Assert that the rename dialog is displayed
+        val dialog = composeTestRule.onNode(isDialog())
+        dialog.assertIsDisplayed()
+        dialog.printToLog("XYZ")
+        dialog.onChildWithText("test_document", recurse = true).performTextReplacement("renamed_document")
+        dialog.onChildWithText(context.getString(R.string.rename), recurse = true).performClick()
+
+        // Assert that the attachment has been renamed successfully
+        composeTestRule.waitUntil {
+            try {
+                // Check for the content description since `displayFileName` is false
+                attachmentsNode.onChildWithContentDescription(
+                    "Attachment: renamed_document.txt"
+                ).assertExists()
+                true
+            } catch (_: AssertionError) {
+                false
+            }
+        }
     }
 
     /**

--- a/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
+++ b/toolkit/featureforms/src/main/java/com/arcgismaps/toolkit/featureforms/internal/components/attachment/AttachmentTile.kt
@@ -16,7 +16,6 @@
 
 package com.arcgismaps.toolkit.featureforms.internal.components.attachment
 
-import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.graphics.Bitmap
@@ -69,6 +68,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -90,7 +90,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import java.io.File
 
-@SuppressLint("LocalContextGetResourceValueCall")
 @Composable
 internal fun AttachmentTile(
     onFocused: () -> Unit,
@@ -99,12 +98,16 @@ internal fun AttachmentTile(
     displayFilename: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val resources = LocalResources.current
     val name = remember(state.name) {
         if (displayFilename) {
             state.name
         } else {
             ""
         }
+    }
+    val contentDescriptionString = remember(state.name) {
+        resources.getString(R.string.attachment_with_name, state.name)
     }
     val isRenameEnabled = remember(state) {
         allowUserRename && state.size <= maxAttachmentUploadSize
@@ -126,8 +129,7 @@ internal fun AttachmentTile(
             .semantics(mergeDescendants = displayFilename) {
                 // set the content description, when displayFilename is false
                 if (name.isEmpty()) {
-                    contentDescription =
-                        context.getString(R.string.attachment_with_name, state.name)
+                    contentDescription = contentDescriptionString
                 }
             },
         colors = CardDefaults.cardColors(
@@ -260,22 +262,22 @@ internal fun AttachmentTile(
                     val limit = error.limit
                     val limitFormatted = Formatter.formatFileSize(context, limit)
                     Pair(
-                        context.getString(R.string.file_size_exceeds_limit),
-                        context.getString(R.string.attachment_size_limit_exceeded, limitFormatted)
+                        resources.getString(R.string.file_size_exceeds_limit),
+                        resources.getString(R.string.attachment_size_limit_exceeded, limitFormatted)
                     )
                 }
 
                 is EmptyAttachmentException -> {
                     Pair(
-                        context.getString(R.string.unsupported_file_type),
-                        context.getString(R.string.download_empty_file)
+                        resources.getString(R.string.unsupported_file_type),
+                        resources.getString(R.string.download_empty_file)
                     )
                 }
 
                 else -> {
                     Pair(
                         "",
-                        error.localizedMessage ?: context.getString(R.string.download_failed)
+                        error.localizedMessage ?: resources.getString(R.string.download_failed)
                     )
                 }
             }


### PR DESCRIPTION
<!-- PRs should provide sufficient context on the changes, either by linking to the associated issue and/or by providing a summary. Also provide a link to the design if it's appropriate. -->

Related to issue: #[apollo/1831](https://devtopia.esri.com/runtime/apollo/issues/1831)

<!-- link to design, if applicable -->

### Description:

This PR fixes a crash while renaming an attachment.

### Summary of changes:

- When an attachment is renamed and the element itself is configured to not show the file names, we inject the file name into the content description of the attachment node. Hence, the reason for the crash is a race condition within the compose library with the reference to `LocalContext.current.getString()` in the `semantics { }` block. Although, I think this is a very common pattern, a work around is introduced to fix this. Please check the linked issue for the repro.
- Added test.

### Pre-merge Checklist

<!-- Tick one box for each section -->
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/toolkit/1337/
- Unit and/or integration tests have been added to exercise this PR's logic, and the tests are passing:
  - [x] Yes
  - [ ] No
  